### PR TITLE
feat: add toast notification queue, configurable duration, and new notification highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ agentoast send \
 | `--focus` | No | `false` | Focus terminal automatically when notification is sent. A toast is shown with "Focused: no history" label, but the notification does not appear in the notification history |
 | `--meta` | No | - | Display metadata as key=value pairs (can be specified multiple times). Shown on notification cards |
 
-Clicking a notification dismisses it and brings you back to the terminal. With `--tmux-pane`, all notifications sharing the same `--group` + `--tmux-pane` are dismissed at once.
+Clicking a notification dismisses it and brings you back to the terminal. With `--tmux-pane`, all notifications sharing the same `--group` + `--tmux-pane` are dismissed at once. Sending a new notification with the same `--group` + `--tmux-pane` replaces the previous one, so only the latest notification per pane is kept.
 
 For a quick test, you can fire off notifications straight from the CLI.
 
@@ -187,8 +187,17 @@ Editor resolution priority is `config.toml` `editor` field → `$EDITOR` → `vi
 # Falls back to $EDITOR environment variable, then vim
 # editor = "vim"
 
-[display]
-# Maximum number of notifications per group in the main panel (default: 3, 0 = unlimited)
+# Toast popup notification
+[toast]
+# Display duration in milliseconds (default: 4000)
+# duration_ms = 4000
+
+# Keep toast visible until clicked (default: false)
+# persistent = false
+
+# Menu bar notification panel
+[panel]
+# Maximum number of notifications per group (default: 3, 0 = unlimited)
 # group_limit = 3
 ```
 

--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -36,25 +36,48 @@ pub fn config_dir() -> PathBuf {
 pub struct AppConfig {
     pub editor: Option<String>,
     #[serde(default)]
-    pub display: DisplayConfig,
+    pub toast: ToastConfig,
+    #[serde(default)]
+    pub panel: PanelConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct DisplayConfig {
+pub struct ToastConfig {
+    #[serde(default = "default_toast_duration")]
+    pub duration_ms: u64,
+    #[serde(default)]
+    pub persistent: bool,
+}
+
+impl Default for ToastConfig {
+    fn default() -> Self {
+        Self {
+            duration_ms: default_toast_duration(),
+            persistent: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PanelConfig {
     #[serde(default = "default_group_limit")]
     pub group_limit: usize,
+}
+
+impl Default for PanelConfig {
+    fn default() -> Self {
+        Self {
+            group_limit: default_group_limit(),
+        }
+    }
 }
 
 fn default_group_limit() -> usize {
     3
 }
 
-impl Default for DisplayConfig {
-    fn default() -> Self {
-        Self {
-            group_limit: default_group_limit(),
-        }
-    }
+fn default_toast_duration() -> u64 {
+    4000
 }
 
 /// config.toml のパスを返す。
@@ -82,8 +105,17 @@ fn default_config_template() -> &'static str {
 # Falls back to $EDITOR environment variable, then vim
 # editor = "vim"
 
-[display]
-# Maximum number of notifications per group in the main panel
+# Toast popup notification
+[toast]
+# Display duration in milliseconds (default: 4000)
+# duration_ms = 4000
+
+# Keep toast visible until clicked (default: false)
+# persistent = false
+
+# Menu bar notification panel
+[panel]
+# Maximum number of notifications per group (default: 3, 0 = unlimited)
 # group_limit = 3
 "#
 }

--- a/crates/agentoast-shared/src/db.rs
+++ b/crates/agentoast-shared/src/db.rs
@@ -43,6 +43,14 @@ pub fn insert_notification(
 ) -> rusqlite::Result<i64> {
     let metadata_json = serde_json::to_string(metadata).unwrap_or_else(|_| "{}".to_string());
 
+    // Overwrite: remove existing notifications from the same tmux session
+    if !tmux_pane.is_empty() {
+        conn.execute(
+            "DELETE FROM notifications WHERE group_name = ?1 AND tmux_pane = ?2",
+            params![group_name, tmux_pane],
+        )?;
+    }
+
     conn.execute(
         "INSERT INTO notifications (title, body, color, icon, group_name, metadata, tmux_pane, force_focus)
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -76,7 +76,7 @@ fn hide_toast(app_handle: tauri::AppHandle) {
 }
 
 #[tauri::command]
-fn show_main_panel(app_handle: tauri::AppHandle) {
+fn show_panel(app_handle: tauri::AppHandle) {
     panel::init(&app_handle).ok();
     use tauri_nspanel::ManagerExt;
     if let Ok(panel) = app_handle.get_webview_panel("main") {
@@ -115,12 +115,8 @@ fn get_notifications_grouped(
 ) -> Result<Vec<NotificationGroup>, String> {
     let state = state.lock().map_err(|e| e.to_string())?;
     let conn = db::open_reader(&state.db_path).map_err(|e| e.to_string())?;
-    db::get_notifications_grouped(
-        &conn,
-        limit.unwrap_or(100),
-        state.config.display.group_limit,
-    )
-    .map_err(|e| e.to_string())
+    db::get_notifications_grouped(&conn, limit.unwrap_or(100), state.config.panel.group_limit)
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -209,6 +205,18 @@ fn toggle_group_mute(
 }
 
 #[tauri::command]
+fn get_toast_duration(state: tauri::State<'_, Mutex<AppState>>) -> Result<u64, String> {
+    let state = state.lock().map_err(|e| e.to_string())?;
+    Ok(state.config.toast.duration_ms)
+}
+
+#[tauri::command]
+fn get_toast_persistent(state: tauri::State<'_, Mutex<AppState>>) -> Result<bool, String> {
+    let state = state.lock().map_err(|e| e.to_string())?;
+    Ok(state.config.toast.persistent)
+}
+
+#[tauri::command]
 fn delete_all_notifications(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, Mutex<AppState>>,
@@ -231,7 +239,7 @@ pub fn run() {
             init_panel,
             hide_panel,
             hide_toast,
-            show_main_panel,
+            show_panel,
             focus_terminal,
             get_notifications,
             get_notifications_grouped,
@@ -240,6 +248,8 @@ pub fn run() {
             delete_notifications_by_group_tmux,
             delete_notifications_by_group,
             delete_all_notifications,
+            get_toast_duration,
+            get_toast_persistent,
             get_mute_state,
             toggle_global_mute,
             toggle_group_mute,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ export function App() {
     deleteNotification,
     deleteGroup,
     deleteAll,
+    newIds,
   } = useNotifications();
 
   const {
@@ -51,6 +52,7 @@ export function App() {
               key={group.groupName}
               group={group}
               isMuted={isGroupMuted(group.groupName)}
+              newIds={newIds}
               onDelete={(id) => void deleteNotification(id)}
               onDeleteGroup={(name) => void deleteGroup(name)}
               onToggleGroupMute={(name) => void toggleGroupMute(name)}

--- a/src/components/notification-card.tsx
+++ b/src/components/notification-card.tsx
@@ -6,6 +6,7 @@ import { IconPreset, TmuxIcon } from "@/components/icons/source-icon";
 
 interface NotificationCardProps {
   notification: Notification;
+  isNew?: boolean;
   onDelete: (id: number) => void;
 }
 
@@ -18,6 +19,7 @@ const badgeColorClasses: Record<string, string> = {
 
 export function NotificationCard({
   notification,
+  isNew,
   onDelete,
 }: NotificationCardProps) {
   const metaEntries = Object.entries(notification.metadata).filter(
@@ -28,6 +30,7 @@ export function NotificationCard({
     <div
       className={cn(
         "group relative px-3 py-2.5 hover:bg-[var(--hover-bg)] transition-colors cursor-pointer",
+        isNew && "animate-new-highlight",
       )}
       onClick={() => {
         if (notification.tmuxPane) {

--- a/src/components/repo-group.tsx
+++ b/src/components/repo-group.tsx
@@ -6,6 +6,7 @@ import { NotificationCard } from "./notification-card";
 interface RepoGroupProps {
   group: NotificationGroup;
   isMuted: boolean;
+  newIds: Set<number>;
   onDelete: (id: number) => void;
   onDeleteGroup: (groupName: string) => void;
   onToggleGroupMute: (groupName: string) => void;
@@ -14,6 +15,7 @@ interface RepoGroupProps {
 export function RepoGroup({
   group,
   isMuted,
+  newIds,
   onDelete,
   onDeleteGroup,
   onToggleGroupMute,
@@ -65,6 +67,7 @@ export function RepoGroup({
             <NotificationCard
               key={n.id}
               notification={n}
+              isNew={newIds.has(n.id)}
               onDelete={onDelete}
             />
           ))}

--- a/src/index.css
+++ b/src/index.css
@@ -36,6 +36,8 @@
   --border-focus: rgba(139, 92, 246, 0.35);
   --badge-focus-bg: rgba(139, 92, 246, 0.15);
   --badge-focus-text: #7c3aed;
+
+  --new-highlight-bg: rgba(59, 130, 246, 0.08);
 }
 
 /* Dark mode */
@@ -75,6 +77,8 @@
     --border-focus: rgba(139, 92, 246, 0.40);
     --badge-focus-bg: rgba(139, 92, 246, 0.25);
     --badge-focus-text: #a78bfa;
+
+    --new-highlight-bg: rgba(59, 130, 246, 0.12);
   }
 }
 
@@ -142,4 +146,18 @@ body,
 
 .animate-toast-out {
   animation: toast-out 0.3s ease-in forwards;
+}
+
+/* New notification highlight animation */
+@keyframes new-highlight {
+  0% {
+    background-color: var(--new-highlight-bg);
+  }
+  100% {
+    background-color: transparent;
+  }
+}
+
+.animate-new-highlight {
+  animation: new-highlight 3s ease-out forwards;
 }


### PR DESCRIPTION
## Summary

- Restructure config from `[display]` into separate `[toast]` and `[panel]` sections with new configurable toast duration and persistent mode
- Implement toast notification queue system with counter badge, auto-advance, and deduplication by group+tmuxPane
- Auto-delete existing notifications with same group+tmux_pane on DB insert (overwrite semantics)
- Add new notification highlight animation (3s blue fade) in main panel

## Changes

### Config (`config.rs`, `README.md`)
- Split `[display]` section into `[toast]` and `[panel]`
- Add `toast.duration_ms` (default: 4000) and `toast.persistent` (default: false)
- Rename `display.group_limit` → `panel.group_limit`
- Update default config template and README documentation

### Toast Queue (`ToastApp.tsx`)
- Rewrite toast component to support notification queue with counter badge (e.g., "1/3")
- Auto-advance through queued notifications on timer expiry or click
- Deduplicate incoming notifications by group+tmuxPane when merging into existing queue
- Load toast duration and persistent settings from config via new Tauri commands
- On click: delete current notification and advance to next (or hide if last)

### DB Overwrite (`db.rs`)
- Auto-delete existing notifications with same `group_name` + `tmux_pane` before inserting new one
- Only applies when `tmux_pane` is non-empty

### New Notification Highlight (`notification-card.tsx`, `repo-group.tsx`, `use-notifications.ts`, `index.css`)
- Track new notification IDs for 3 seconds after arrival
- Apply `animate-new-highlight` CSS animation (blue fade) to new cards
- Pass `newIds` set through component hierarchy

### Tauri Commands (`lib.rs`)
- Add `get_toast_duration` and `get_toast_persistent` commands
- Rename `show_main_panel` → `show_panel`

