### PR TITLE
feat: use __CFBundleIdentifier for terminal focus instead of hardcoded list

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ agentoast send \
 | `--icon` | No | `agentoast` | Icon preset (`agentoast` / `claude-code` / `codex` / `opencode`) |
 | `--group` | No | `""` | Group name (e.g. repository name, project name) |
 | `--tmux-pane` | No | `""` | tmux pane ID. Used for focus-on-click and batch dismiss (e.g. `%0`) |
+| `--bundle-id` | No | auto | Terminal bundle ID for focus-on-click (e.g. `com.github.wez.wezterm`). Auto-detected from `__CFBundleIdentifier` env var if not specified |
 | `--focus` | No | `false` | Focus terminal automatically when notification is sent. A toast is shown with "Focused: no history" label, but the notification does not appear in the notification history |
 | `--meta` | No | - | Display metadata as key=value pairs (can be specified multiple times). Shown on notification cards |
 

--- a/crates/agentoast-cli/src/main.rs
+++ b/crates/agentoast-cli/src/main.rs
@@ -115,8 +115,16 @@ fn main() {
             });
 
             match db::insert_notification(
-                &conn, &title, &body, &color, &icon_type, &group, &metadata, &tmux_pane,
-                &terminal_bundle_id, focus,
+                &conn,
+                &title,
+                &body,
+                &color,
+                &icon_type,
+                &group,
+                &metadata,
+                &tmux_pane,
+                &terminal_bundle_id,
+                focus,
             ) {
                 Ok(id) => println!("Notification saved (id={})", id),
                 Err(e) => {

--- a/crates/agentoast-shared/src/db.rs
+++ b/crates/agentoast-shared/src/db.rs
@@ -39,6 +39,7 @@ pub fn insert_notification(
     group_name: &str,
     metadata: &HashMap<String, String>,
     tmux_pane: &str,
+    terminal_bundle_id: &str,
     force_focus: bool,
 ) -> rusqlite::Result<i64> {
     let metadata_json = serde_json::to_string(metadata).unwrap_or_else(|_| "{}".to_string());
@@ -52,9 +53,9 @@ pub fn insert_notification(
     }
 
     conn.execute(
-        "INSERT INTO notifications (title, body, color, icon, group_name, metadata, tmux_pane, force_focus)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-        params![title, body, color, icon.as_str(), group_name, metadata_json, tmux_pane, force_focus as i32],
+        "INSERT INTO notifications (title, body, color, icon, group_name, metadata, tmux_pane, terminal_bundle_id, force_focus)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        params![title, body, color, icon.as_str(), group_name, metadata_json, tmux_pane, terminal_bundle_id, force_focus as i32],
     )?;
     Ok(conn.last_insert_rowid())
 }
@@ -72,15 +73,16 @@ fn row_to_notification(row: &rusqlite::Row) -> rusqlite::Result<Notification> {
         group_name: row.get(6)?,
         metadata,
         tmux_pane: row.get(7)?,
-        force_focus: row.get::<_, i32>(8)? != 0,
-        is_read: row.get::<_, i32>(9)? != 0,
-        created_at: row.get(10)?,
+        terminal_bundle_id: row.get(8)?,
+        force_focus: row.get::<_, i32>(9)? != 0,
+        is_read: row.get::<_, i32>(10)? != 0,
+        created_at: row.get(11)?,
     })
 }
 
 pub fn get_notifications(conn: &Connection, limit: i64) -> rusqlite::Result<Vec<Notification>> {
     let mut stmt = conn.prepare(
-        "SELECT id, title, body, color, icon, metadata, group_name, tmux_pane, force_focus, is_read, created_at
+        "SELECT id, title, body, color, icon, metadata, group_name, tmux_pane, terminal_bundle_id, force_focus, is_read, created_at
          FROM notifications ORDER BY created_at DESC LIMIT ?1",
     )?;
     let rows = stmt.query_map(params![limit], row_to_notification)?;
@@ -178,7 +180,7 @@ pub fn get_notifications_after_id(
     after_id: i64,
 ) -> rusqlite::Result<Vec<Notification>> {
     let mut stmt = conn.prepare(
-        "SELECT id, title, body, color, icon, metadata, group_name, tmux_pane, force_focus, is_read, created_at
+        "SELECT id, title, body, color, icon, metadata, group_name, tmux_pane, terminal_bundle_id, force_focus, is_read, created_at
          FROM notifications WHERE id > ?1 ORDER BY id ASC",
     )?;
     let rows = stmt.query_map(params![after_id], row_to_notification)?;

--- a/crates/agentoast-shared/src/models.rs
+++ b/crates/agentoast-shared/src/models.rs
@@ -53,6 +53,7 @@ pub struct Notification {
     pub group_name: String,
     pub metadata: HashMap<String, String>,
     pub tmux_pane: String,
+    pub terminal_bundle_id: String,
     pub force_focus: bool,
     pub is_read: bool,
     pub created_at: String,

--- a/crates/agentoast-shared/src/schema.rs
+++ b/crates/agentoast-shared/src/schema.rs
@@ -14,6 +14,7 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             group_name    TEXT NOT NULL DEFAULT '',
             metadata      TEXT NOT NULL DEFAULT '{}',
             tmux_pane     TEXT NOT NULL DEFAULT '',
+            terminal_bundle_id TEXT NOT NULL DEFAULT '',
             force_focus   INTEGER NOT NULL DEFAULT 0,
             is_read       INTEGER NOT NULL DEFAULT 0,
             created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,14 +86,14 @@ fn show_panel(app_handle: tauri::AppHandle) {
 }
 
 #[tauri::command]
-fn focus_terminal(tmux_pane: String) -> Result<(), String> {
+fn focus_terminal(tmux_pane: String, terminal_bundle_id: String) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
-        terminal::focus_terminal(&tmux_pane)
+        terminal::focus_terminal(&tmux_pane, &terminal_bundle_id)
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = tmux_pane;
+        let _ = (tmux_pane, terminal_bundle_id);
         Err("focus_terminal is only supported on macOS".to_string())
     }
 }

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -56,10 +56,7 @@ fn activate_terminal(bundle_id: &str) -> Result<(), String> {
         }
     }
 
-    Err(format!(
-        "Terminal application not found: {}",
-        bundle_id
-    ))
+    Err(format!("Terminal application not found: {}", bundle_id))
 }
 
 pub fn focus_terminal(tmux_pane: &str, terminal_bundle_id: &str) -> Result<(), String> {

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -10,19 +10,10 @@ fn find_tmux() -> Option<PathBuf> {
     candidates.iter().map(PathBuf::from).find(|p| p.exists())
 }
 
-const KNOWN_TERMINAL_BUNDLE_IDS: &[&str] = &[
-    "com.github.wez.wezterm",
-    "com.mitchellh.ghostty",
-    "com.googlecode.iterm2",
-    "com.apple.Terminal",
-    "org.alacritty",
-    "net.kovidgoyal.kitty",
-];
-
 fn switch_tmux_pane(tmux_pane: &str) -> Result<(), String> {
     let tmux_path = find_tmux().ok_or_else(|| "tmux not found".to_string())?;
 
-    // 画面に映すセッションをペインが属するセッションに切替
+    // Switch the attached session to the one containing the target pane
     Command::new(&tmux_path)
         .args(["switch-client", "-t", tmux_pane])
         .output()
@@ -41,35 +32,37 @@ fn switch_tmux_pane(tmux_pane: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn activate_terminal() -> Result<(), String> {
+fn activate_terminal(bundle_id: &str) -> Result<(), String> {
+    if bundle_id.is_empty() {
+        return Err("No terminal bundle ID specified".to_string());
+    }
+
     use objc2_app_kit::{NSApplicationActivationOptions, NSWorkspace};
     use objc2_foundation::NSString;
 
-    {
-        let workspace = NSWorkspace::sharedWorkspace();
-        let apps = workspace.runningApplications();
+    let workspace = NSWorkspace::sharedWorkspace();
+    let apps = workspace.runningApplications();
+    let target_ns = NSString::from_str(bundle_id);
 
-        for target_id in KNOWN_TERMINAL_BUNDLE_IDS {
-            let target_ns = NSString::from_str(target_id);
-            for app in &apps {
-                if let Some(bundle_id) = app.bundleIdentifier() {
-                    if bundle_id.isEqualToString(&target_ns) {
-                        let activated = app.activateWithOptions(
-                            NSApplicationActivationOptions::ActivateAllWindows,
-                        );
-                        if activated {
-                            return Ok(());
-                        }
-                    }
+    for app in &apps {
+        if let Some(bid) = app.bundleIdentifier() {
+            if bid.isEqualToString(&target_ns) {
+                let activated =
+                    app.activateWithOptions(NSApplicationActivationOptions::ActivateAllWindows);
+                if activated {
+                    return Ok(());
                 }
             }
         }
     }
 
-    Err("No matching terminal application found".to_string())
+    Err(format!(
+        "Terminal application not found: {}",
+        bundle_id
+    ))
 }
 
-pub fn focus_terminal(tmux_pane: &str) -> Result<(), String> {
+pub fn focus_terminal(tmux_pane: &str, terminal_bundle_id: &str) -> Result<(), String> {
     // 1. Switch tmux pane if specified (failure is non-fatal)
     if !tmux_pane.is_empty() {
         if let Err(e) = switch_tmux_pane(tmux_pane) {
@@ -78,5 +71,5 @@ pub fn focus_terminal(tmux_pane: &str) -> Result<(), String> {
     }
 
     // 2. Activate terminal app
-    activate_terminal()
+    activate_terminal(terminal_bundle_id)
 }

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -192,9 +192,7 @@ fn check_new_notifications(app_handle: &AppHandle, conn: &Connection) {
             let terminal_bundle_id = focus_notification.terminal_bundle_id.clone();
             let handle_for_focus = app_handle.clone();
             let _ = handle_for_focus.run_on_main_thread(move || {
-                if let Err(e) =
-                    crate::terminal::focus_terminal(&tmux_pane, &terminal_bundle_id)
-                {
+                if let Err(e) = crate::terminal::focus_terminal(&tmux_pane, &terminal_bundle_id) {
                     log::debug!("force_focus: terminal focus failed (non-fatal): {}", e);
                 }
             });

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -189,9 +189,12 @@ fn check_new_notifications(app_handle: &AppHandle, conn: &Connection) {
     {
         if let Some(focus_notification) = active_focus.last() {
             let tmux_pane = focus_notification.tmux_pane.clone();
+            let terminal_bundle_id = focus_notification.terminal_bundle_id.clone();
             let handle_for_focus = app_handle.clone();
             let _ = handle_for_focus.run_on_main_thread(move || {
-                if let Err(e) = crate::terminal::focus_terminal(&tmux_pane) {
+                if let Err(e) =
+                    crate::terminal::focus_terminal(&tmux_pane, &terminal_bundle_id)
+                {
                     log::debug!("force_focus: terminal focus failed (non-fatal): {}", e);
                 }
             });

--- a/src/ToastApp.tsx
+++ b/src/ToastApp.tsx
@@ -144,6 +144,7 @@ export function ToastApp() {
       }
       void invoke("focus_terminal", {
         tmuxPane: current.tmuxPane,
+        terminalBundleId: current.terminalBundleId,
       });
     }
 

--- a/src/components/notification-card.tsx
+++ b/src/components/notification-card.tsx
@@ -43,6 +43,7 @@ export function NotificationCard({
         }
         void invoke("focus_terminal", {
           tmuxPane: notification.tmuxPane,
+          terminalBundleId: notification.terminalBundleId,
         });
       }}
     >

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,6 +9,7 @@ export interface Notification {
   groupName: string;
   metadata: Record<string, string>;
   tmuxPane: string;
+  terminalBundleId: string;
   forceFocus: boolean;
   isRead: boolean;
   createdAt: string;


### PR DESCRIPTION
## Summary

- Replace hardcoded `KNOWN_TERMINAL_BUNDLE_IDS` list with automatic detection via `__CFBundleIdentifier` environment variable (set by macOS for .app bundles)
- Add `terminal_bundle_id` column to DB schema and pass it through the full data flow (CLI → DB → watcher/frontend → terminal focus)
- Add `--bundle-id` CLI option for manual override when auto-detection is insufficient

## Changes

### Backend (Rust)
- `schema.rs`: Add `terminal_bundle_id TEXT NOT NULL DEFAULT ''` column
- `models.rs`: Add `terminal_bundle_id` field to `Notification` struct
- `db.rs`: Add `terminal_bundle_id` parameter to `insert_notification()`, update SELECT queries and row mapping
- `terminal.rs`: Remove `KNOWN_TERMINAL_BUNDLE_IDS`, change `activate_terminal()` / `focus_terminal()` to accept bundle ID parameter
- `lib.rs`: Add `terminal_bundle_id` parameter to `focus_terminal` Tauri command
- `watcher.rs`: Pass `terminal_bundle_id` from notification to `focus_terminal()`

### CLI
- `main.rs`: Add `--bundle-id` option, auto-detect from `__CFBundleIdentifier` env var if not specified

### Frontend (TypeScript)
- `types.ts`: Add `terminalBundleId` to `Notification` type
- `notification-card.tsx`: Pass `terminalBundleId` to `focus_terminal` invoke
- `ToastApp.tsx`: Pass `terminalBundleId` to `focus_terminal` invoke

### Docs
- `README.md`: Add `--bundle-id` option to CLI reference table
