### PR TITLE
fix: add explicit version field to Homebrew Formula template

### DIFF
--- a/.github/actions/release-cli/action.yaml
+++ b/.github/actions/release-cli/action.yaml
@@ -48,6 +48,7 @@ runs:
         homepage "https://github.com/${{ github.repository }}"
         url "${ARCHIVE_URL}"
         sha256 "${SHA256}"
+        version "${VERSION}"
         license "MIT"
 
         def install


### PR DESCRIPTION
## Summary

- Add explicit `version` field to Homebrew Formula template in release-cli action
- Fixes `brew install shuntaka9576/tap/agentoast` showing version `64` instead of the correct semantic version (e.g. `0.5.0`)

## Root Cause

The Formula lacked a `version` declaration, causing Homebrew to infer the version from the archive URL. It incorrectly extracted `64` from `arm64` in the filename `agentoast_X.Y.Z_darwin_arm64.tar.gz`.

