### PR TITLE
chore: rename Homebrew Formula to agentoast-cli

### DIFF
--- a/.github/actions/release-cli/action.yaml
+++ b/.github/actions/release-cli/action.yaml
@@ -43,7 +43,7 @@ runs:
       ARCHIVE_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/${ARCHIVE_NAME}"
 
       FORMULA_CONTENT=$(cat <<FORMULA_EOF
-      class Agentoast < Formula
+      class AgentoastCli < Formula
         desc "CLI notification tool for AI coding agents"
         homepage "https://github.com/${{ github.repository }}"
         url "${ARCHIVE_URL}"
@@ -63,18 +63,18 @@ runs:
       )
 
       ENCODED=$(echo "${FORMULA_CONTENT}" | base64)
-      EXISTING_SHA=$(GH_TOKEN="${GH_PAT}" gh api repos/shuntaka9576/homebrew-tap/contents/Formula/agentoast.rb --jq '.sha' 2>/dev/null || echo "")
+      EXISTING_SHA=$(GH_TOKEN="${GH_PAT}" gh api repos/shuntaka9576/homebrew-tap/contents/Formula/agentoast-cli.rb --jq '.sha' 2>/dev/null || echo "")
 
       if [ -n "${EXISTING_SHA}" ]; then
-        GH_TOKEN="${GH_PAT}" gh api repos/shuntaka9576/homebrew-tap/contents/Formula/agentoast.rb \
+        GH_TOKEN="${GH_PAT}" gh api repos/shuntaka9576/homebrew-tap/contents/Formula/agentoast-cli.rb \
           --method PUT \
-          -f message="Update agentoast formula to ${TAG}" \
+          -f message="Update agentoast-cli formula to ${TAG}" \
           -f content="${ENCODED}" \
           -f sha="${EXISTING_SHA}"
       else
-        GH_TOKEN="${GH_PAT}" gh api repos/shuntaka9576/homebrew-tap/contents/Formula/agentoast.rb \
+        GH_TOKEN="${GH_PAT}" gh api repos/shuntaka9576/homebrew-tap/contents/Formula/agentoast-cli.rb \
           --method PUT \
-          -f message="Add agentoast formula ${TAG}" \
+          -f message="Add agentoast-cli formula ${TAG}" \
           -f content="${ENCODED}"
       fi
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,10 @@ All notifications are grouped by repository in the menu bar. Clicking one takes 
 
 ## Installation
 
-> **Install the CLI before the App.** Both share the same Homebrew tap name, so installing the Cask first causes Homebrew to skip linking the CLI binary. If you installed the App first, run `brew link --overwrite agentoast` to fix it.
-
 ### CLI
 
 ```bash
-brew install --formula shuntaka9576/tap/agentoast
+brew install shuntaka9576/tap/agentoast-cli
 ```
 
 ### App
@@ -49,7 +47,7 @@ xattr -cr /Applications/Agentoast.app
 
 ```bash
 brew uninstall --cask shuntaka9576/tap/agentoast
-brew uninstall --formula shuntaka9576/tap/agentoast
+brew uninstall shuntaka9576/tap/agentoast-cli
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

- Rename Homebrew Formula from `agentoast` to `agentoast-cli` to resolve Cask/Formula naming conflict
- The CLI command name remains `agentoast` (only the Homebrew package name changes)
- Remove installation order warning from README (no longer needed since names no longer collide)

## Changes

### `.github/actions/release-cli/action.yaml`
- Formula class: `Agentoast` → `AgentoastCli`
- Formula path in homebrew-tap: `Formula/agentoast.rb` → `Formula/agentoast-cli.rb`
- Commit messages updated accordingly

### `README.md`
- CLI install: `brew install shuntaka9576/tap/agentoast-cli` (`--formula` flag no longer needed)
- CLI uninstall: `brew uninstall shuntaka9576/tap/agentoast-cli`
- Removed installation order caveat (naming conflict resolved)


