### PR TITLE
feat: add dismiss buttons to toast notifications

### DIFF
--- a/src/ToastApp.tsx
+++ b/src/ToastApp.tsx
@@ -263,20 +263,20 @@ export function ToastApp() {
           </div>
         </div>
         {/* Dismiss buttons (bottom-left) */}
-        <div className="absolute bottom-1.5 left-2.5 flex items-center gap-0.5">
+        <div className="absolute bottom-1.5 left-2.5 flex items-center gap-1">
           <button
             onClick={handleDismissKeep}
-            className="p-1 rounded text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--hover-bg-strong)] transition-colors"
+            className="p-1.5 rounded text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--hover-bg-strong)] transition-colors"
             title="Dismiss (keep in history)"
           >
-            <X size={12} />
+            <X size={14} />
           </button>
           <button
             onClick={handleDismissDelete}
-            className="p-1 rounded text-[var(--text-muted)] hover:text-[var(--delete-hover-text)] hover:bg-[var(--hover-bg-strong)] transition-colors"
+            className="p-1.5 rounded text-[var(--text-muted)] hover:text-[var(--delete-hover-text)] hover:bg-[var(--hover-bg-strong)] transition-colors"
             title="Delete from history"
           >
-            <Trash2 size={12} />
+            <Trash2 size={14} />
           </button>
         </div>
         {/* Queue counter badge */}

--- a/src/ToastApp.tsx
+++ b/src/ToastApp.tsx
@@ -4,6 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { cn } from "@/lib/utils";
 import type { Notification } from "@/lib/types";
 import { IconPreset, TmuxIcon } from "@/components/icons/source-icon";
+import { X, Trash2 } from "lucide-react";
 
 const DEFAULT_TOAST_DURATION = 4000;
 const FADE_DURATION = 300;
@@ -159,6 +160,28 @@ export function ToastApp() {
     }
   };
 
+  const handleDismissKeep = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+    advanceOrHide();
+  };
+
+  const handleDismissDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+    const current = queueRef.current[currentIndexRef.current];
+    if (current) {
+      void invoke("delete_notification", { id: current.id });
+    }
+    advanceOrHide();
+  };
+
   const current = queue[currentIndex];
 
   if (!isVisible || !current) {
@@ -238,6 +261,23 @@ export function ToastApp() {
             )}
 
           </div>
+        </div>
+        {/* Dismiss buttons (bottom-left) */}
+        <div className="absolute bottom-1.5 left-2.5 flex items-center gap-0.5">
+          <button
+            onClick={handleDismissKeep}
+            className="p-1 rounded text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--hover-bg-strong)] transition-colors"
+            title="Dismiss (keep in history)"
+          >
+            <X size={12} />
+          </button>
+          <button
+            onClick={handleDismissDelete}
+            className="p-1 rounded text-[var(--text-muted)] hover:text-[var(--delete-hover-text)] hover:bg-[var(--hover-bg-strong)] transition-colors"
+            title="Delete from history"
+          >
+            <Trash2 size={12} />
+          </button>
         </div>
         {/* Queue counter badge */}
         {queue.length > 1 && (


### PR DESCRIPTION
## Summary

- Add two dismiss icon buttons (X and Trash2) to the bottom-left of toast notifications
- **X button**: Dismisses the toast but keeps the notification in DB (viewable later in main panel history)
- **Trash2 button**: Dismisses the toast and deletes the notification from DB (no history)
- Card click behavior remains unchanged (delete + terminal focus)

## Changes

- `src/ToastApp.tsx`:
  - Added `handleDismissKeep` handler — closes toast without deleting from DB or focusing terminal
  - Added `handleDismissDelete` handler — closes toast and deletes from DB, without focusing terminal
  - Added dismiss button group (absolute bottom-left) with X and Trash2 icons from lucide-react


