### PR TITLE
feat: add global shortcut and keyboard navigation for notification panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-nspanel",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-opener",
 ]
 
@@ -822,7 +823,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1005,7 +1006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1353,6 +1354,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1470,6 +1481,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -3306,7 +3335,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3999,6 +4028,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424af23c7e88d05e4a1a6fc2c7be077912f8c76bd7900fd50aa2b7cbf5a2c405"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4131,7 +4175,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4870,7 +4914,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5378,6 +5422,29 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -39,6 +39,8 @@ pub struct AppConfig {
     pub toast: ToastConfig,
     #[serde(default)]
     pub panel: PanelConfig,
+    #[serde(default)]
+    pub shortcut: ShortcutConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -80,6 +82,24 @@ fn default_toast_duration() -> u64 {
     4000
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct ShortcutConfig {
+    #[serde(default = "default_toggle_panel")]
+    pub toggle_panel: String,
+}
+
+impl Default for ShortcutConfig {
+    fn default() -> Self {
+        Self {
+            toggle_panel: default_toggle_panel(),
+        }
+    }
+}
+
+fn default_toggle_panel() -> String {
+    "ctrl+shift+n".to_string()
+}
+
 /// config.toml のパスを返す。
 pub fn config_path() -> PathBuf {
     config_dir().join("config.toml")
@@ -117,6 +137,13 @@ fn default_config_template() -> &'static str {
 [panel]
 # Maximum number of notifications per group (default: 3, 0 = unlimited)
 # group_limit = 3
+
+# Global keyboard shortcut
+[shortcut]
+# Shortcut to toggle the notification panel (default: ctrl+shift+n)
+# Format: modifier+key (modifiers: ctrl, shift, alt, super)
+# Set to "" to disable
+# toggle_panel = "ctrl+shift+n"
 "#
 }
 

--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -97,7 +97,7 @@ impl Default for ShortcutConfig {
 }
 
 fn default_toggle_panel() -> String {
-    "ctrl+shift+n".to_string()
+    "ctrl+alt+n".to_string()
 }
 
 /// config.toml のパスを返す。
@@ -140,10 +140,10 @@ fn default_config_template() -> &'static str {
 
 # Global keyboard shortcut
 [shortcut]
-# Shortcut to toggle the notification panel (default: ctrl+shift+n)
-# Format: modifier+key (modifiers: ctrl, shift, alt, super)
+# Shortcut to toggle the notification panel (default: ctrl+alt+n)
+# Format: modifier+key (modifiers: ctrl, shift, alt/option, super/cmd)
 # Set to "" to disable
-# toggle_panel = "ctrl+shift+n"
+# toggle_panel = "ctrl+alt+n"
 "#
 }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 agentoast-shared = { path = "../crates/agentoast-shared" }
 tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
+tauri-plugin-global-shortcut = "2"
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
 log = "0.4"
 env_logger = "0.11"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:window:allow-outer-size",
     "core:window:allow-inner-size",
     "core:window:allow-scale-factor",
-    "opener:default"
+    "opener:default",
+    "global-shortcut:default"
   ]
 }

--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -110,7 +110,7 @@ pub fn position_panel_at_tray_icon(
 
     let icon_center_x_phys = icon_phys_x + (icon_width_phys / 2);
     let panel_x_phys = icon_center_x_phys - (window_width_phys / 2);
-    let nudge_up_points: f64 = 0.0;
+    let nudge_up_points: f64 = 8.0;
     let nudge_up_phys = (nudge_up_points * scale_factor).round() as i32;
     let panel_y_phys = icon_phys_y + icon_height_phys - nudge_up_phys;
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 use tauri::image::Image;
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
 use tauri::path::BaseDirectory;
-use tauri::tray::{MouseButtonState, TrayIconBuilder, TrayIconEvent};
+use tauri::tray::{MouseButtonState, TrayIconBuilder, TrayIconEvent, TrayIconId};
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_nspanel::ManagerExt;
 
@@ -49,6 +49,11 @@ pub fn toggle_panel(app_handle: &AppHandle) {
     } else {
         let _ = app_handle.emit("notifications:refresh", ());
         panel.show_and_make_key();
+        if let Some(tray) = app_handle.tray_by_id(&TrayIconId::new("tray")) {
+            if let Ok(Some(rect)) = tray.rect() {
+                position_panel_at_tray_icon(app_handle, rect.position, rect.size);
+            }
+        }
     }
 }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -40,6 +40,18 @@ fn show_panel(app_handle: &AppHandle) {
     }
 }
 
+pub fn toggle_panel(app_handle: &AppHandle) {
+    let Some(panel) = get_or_init_panel!(app_handle) else {
+        return;
+    };
+    if panel.is_visible() {
+        panel.hide();
+    } else {
+        let _ = app_handle.emit("notifications:refresh", ());
+        panel.show_and_make_key();
+    }
+}
+
 pub fn create(app_handle: &AppHandle) -> tauri::Result<()> {
     let tray_icon_path = app_handle
         .path()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,8 +14,8 @@
       {
         "label": "main",
         "title": "Agentoast",
-        "width": 380,
-        "height": 520,
+        "width": 412,
+        "height": 554,
         "resizable": false,
         "decorations": false,
         "transparent": true,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,7 +126,7 @@ export function App() {
   const selectedId = flatNotifications[selectedIndex]?.id ?? null;
 
   return (
-    <div className="h-screen flex flex-col items-center px-4 pb-4 pt-1.5 bg-transparent">
+    <div className="h-screen flex flex-col items-center px-4 pb-4 pt-0.5 bg-transparent">
       <div className="tray-arrow" />
       <div className="w-full flex-1 min-h-0 flex flex-col bg-[var(--panel-bg)] backdrop-blur-xl rounded-xl border border-[var(--border-primary)] shadow-2xl overflow-hidden">
         <PanelHeader

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,44 +126,42 @@ export function App() {
   const selectedId = flatNotifications[selectedIndex]?.id ?? null;
 
   return (
-    <div className="h-screen flex flex-col bg-[var(--panel-bg)] backdrop-blur-xl rounded-xl border border-[var(--border-primary)] shadow-2xl overflow-hidden">
-      {/* Tray arrow */}
-      <div className="flex justify-center -mt-[7px]">
-        <div className="tray-arrow" />
-      </div>
+    <div className="h-screen flex flex-col items-center px-4 pb-4 pt-1.5 bg-transparent">
+      <div className="tray-arrow" />
+      <div className="w-full flex-1 min-h-0 flex flex-col bg-[var(--panel-bg)] backdrop-blur-xl rounded-xl border border-[var(--border-primary)] shadow-2xl overflow-hidden">
+        <PanelHeader
+          unreadCount={unreadCount}
+          globalMuted={globalMuted}
+          onDeleteAll={() => void deleteAll()}
+          onToggleGlobalMute={() => void toggleGlobalMute()}
+        />
 
-      <PanelHeader
-        unreadCount={unreadCount}
-        globalMuted={globalMuted}
-        onDeleteAll={() => void deleteAll()}
-        onToggleGlobalMute={() => void toggleGlobalMute()}
-      />
-
-      <div className="flex-1 overflow-y-auto" ref={scrollContainerRef}>
-        {loading ? (
-          <div className="flex items-center justify-center h-full">
-            <div className="text-xs text-[var(--text-muted)]">Loading...</div>
-          </div>
-        ) : groups.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full gap-3">
-            <Bell size={32} className="text-[var(--text-faint)]" />
-            <p className="text-xs text-[var(--text-muted)]">No notifications yet</p>
-          </div>
-        ) : (
-          groups.map((group) => (
-            <RepoGroup
-              key={group.groupName}
-              group={group}
-              isMuted={isGroupMuted(group.groupName)}
-              newIds={newIds}
-              selectedId={selectedId}
-              flatNotifications={flatNotifications}
-              onDelete={(id) => void deleteNotification(id)}
-              onDeleteGroup={(name) => void deleteGroup(name)}
-              onToggleGroupMute={(name) => void toggleGroupMute(name)}
-            />
-          ))
-        )}
+        <div className="flex-1 overflow-y-auto" ref={scrollContainerRef}>
+          {loading ? (
+            <div className="flex items-center justify-center h-full">
+              <div className="text-xs text-[var(--text-muted)]">Loading...</div>
+            </div>
+          ) : groups.length === 0 ? (
+            <div className="flex flex-col items-center justify-center h-full gap-3">
+              <Bell size={32} className="text-[var(--text-faint)]" />
+              <p className="text-xs text-[var(--text-muted)]">No notifications yet</p>
+            </div>
+          ) : (
+            groups.map((group) => (
+              <RepoGroup
+                key={group.groupName}
+                group={group}
+                isMuted={isGroupMuted(group.groupName)}
+                newIds={newIds}
+                selectedId={selectedId}
+                flatNotifications={flatNotifications}
+                onDelete={(id) => void deleteNotification(id)}
+                onDeleteGroup={(name) => void deleteGroup(name)}
+                onToggleGroupMute={(name) => void toggleGroupMute(name)}
+              />
+            ))
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,12 @@
+import { useEffect, useState, useCallback, useRef, useMemo } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
 import { useNotifications } from "@/hooks/use-notifications";
 import { useMute } from "@/hooks/use-mute";
 import { PanelHeader } from "@/components/panel-header";
 import { RepoGroup } from "@/components/repo-group";
 import { Bell } from "lucide-react";
+import type { Notification } from "@/lib/types";
 
 export function App() {
   const {
@@ -22,6 +26,105 @@ export function App() {
     toggleGroupMute,
   } = useMute();
 
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // Flatten all visible notifications into a single list for keyboard navigation
+  const flatNotifications = useMemo(() => {
+    const result: Notification[] = [];
+    for (const group of groups) {
+      for (const n of group.notifications) {
+        result.push(n);
+      }
+    }
+    return result;
+  }, [groups]);
+
+  // Reset selection when panel is shown (notifications:refresh is emitted on panel show)
+  useEffect(() => {
+    const unlisten = listen("notifications:refresh", () => {
+      setSelectedIndex(0);
+    });
+    return () => {
+      unlisten.then((f) => f()).catch(() => {});
+    };
+  }, []);
+
+  // Clamp selectedIndex when notifications change
+  useEffect(() => {
+    setSelectedIndex((prev) =>
+      flatNotifications.length === 0 ? 0 : Math.min(prev, flatNotifications.length - 1)
+    );
+  }, [flatNotifications]);
+
+  // Scroll selected card into view
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const el = container.querySelector(`[data-nav-index="${selectedIndex}"]`);
+    if (el) {
+      el.scrollIntoView({ block: "nearest" });
+    }
+  }, [selectedIndex]);
+
+  const activateNotification = useCallback(
+    (notification: Notification) => {
+      if (notification.tmuxPane) {
+        void invoke("delete_notifications_by_group_tmux", {
+          groupName: notification.groupName,
+          tmuxPane: notification.tmuxPane,
+        });
+      } else {
+        void deleteNotification(notification.id);
+      }
+      void invoke("focus_terminal", {
+        tmuxPane: notification.tmuxPane,
+        terminalBundleId: notification.terminalBundleId,
+      });
+    },
+    [deleteNotification],
+  );
+
+  // Keyboard navigation
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case "Escape":
+          e.preventDefault();
+          void invoke("hide_panel");
+          break;
+        case "j":
+          e.preventDefault();
+          if (flatNotifications.length > 0) {
+            setSelectedIndex((prev) => Math.min(prev + 1, flatNotifications.length - 1));
+          }
+          break;
+        case "k":
+          e.preventDefault();
+          if (flatNotifications.length > 0) {
+            setSelectedIndex((prev) => Math.max(prev - 1, 0));
+          }
+          break;
+        case "Enter": {
+          e.preventDefault();
+          const n = flatNotifications[selectedIndex];
+          if (n) {
+            activateNotification(n);
+          } else {
+            void invoke("hide_panel");
+          }
+          break;
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [flatNotifications, selectedIndex, activateNotification]);
+
+  // Build a set of selected notification IDs for highlighting
+  const selectedId = flatNotifications[selectedIndex]?.id ?? null;
+
   return (
     <div className="h-screen flex flex-col bg-[var(--panel-bg)] backdrop-blur-xl rounded-xl border border-[var(--border-primary)] shadow-2xl overflow-hidden">
       {/* Tray arrow */}
@@ -36,7 +139,7 @@ export function App() {
         onToggleGlobalMute={() => void toggleGlobalMute()}
       />
 
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto" ref={scrollContainerRef}>
         {loading ? (
           <div className="flex items-center justify-center h-full">
             <div className="text-xs text-[var(--text-muted)]">Loading...</div>
@@ -53,6 +156,8 @@ export function App() {
               group={group}
               isMuted={isGroupMuted(group.groupName)}
               newIds={newIds}
+              selectedId={selectedId}
+              flatNotifications={flatNotifications}
               onDelete={(id) => void deleteNotification(id)}
               onDeleteGroup={(name) => void deleteGroup(name)}
               onToggleGroupMute={(name) => void toggleGroupMute(name)}

--- a/src/components/notification-card.tsx
+++ b/src/components/notification-card.tsx
@@ -7,6 +7,8 @@ import { IconPreset, TmuxIcon } from "@/components/icons/source-icon";
 interface NotificationCardProps {
   notification: Notification;
   isNew?: boolean;
+  isSelected?: boolean;
+  navIndex?: number;
   onDelete: (id: number) => void;
 }
 
@@ -20,6 +22,8 @@ const badgeColorClasses: Record<string, string> = {
 export function NotificationCard({
   notification,
   isNew,
+  isSelected,
+  navIndex,
   onDelete,
 }: NotificationCardProps) {
   const metaEntries = Object.entries(notification.metadata).filter(
@@ -28,9 +32,11 @@ export function NotificationCard({
   const badgeClass = badgeColorClasses[notification.color] || badgeColorClasses.gray;
   return (
     <div
+      data-nav-index={navIndex}
       className={cn(
         "group relative px-3 py-2.5 hover:bg-[var(--hover-bg)] transition-colors cursor-pointer",
         isNew && "animate-new-highlight",
+        isSelected && "bg-[var(--hover-bg)]",
       )}
       onClick={() => {
         if (notification.tmuxPane) {
@@ -108,6 +114,7 @@ export function NotificationCard({
 
         {/* Delete button */}
         <button
+          tabIndex={-1}
           onClick={(e) => {
             e.stopPropagation();
             onDelete(notification.id);

--- a/src/components/panel-header.tsx
+++ b/src/components/panel-header.tsx
@@ -16,7 +16,6 @@ export function PanelHeader({
   return (
     <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border-primary)]">
       <div className="flex items-center gap-2">
-        <h1 className="text-sm font-semibold text-[var(--text-primary)]">Notifications</h1>
         {unreadCount > 0 && (
           <span className="px-1.5 py-0.5 text-[10px] font-medium bg-[var(--badge-count-bg)] text-[var(--badge-count-text)] rounded-full">
             {unreadCount}

--- a/src/components/panel-header.tsx
+++ b/src/components/panel-header.tsx
@@ -25,6 +25,7 @@ export function PanelHeader({
       </div>
       <div className="flex items-center gap-1">
         <button
+          tabIndex={-1}
           onClick={onToggleGlobalMute}
           className="p-1.5 rounded-md text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--hover-bg-strong)] transition-colors"
           title={globalMuted ? "Unmute notifications" : "Mute notifications"}
@@ -32,6 +33,7 @@ export function PanelHeader({
           {globalMuted ? <BellOff size={14} /> : <Bell size={14} />}
         </button>
         <button
+          tabIndex={-1}
           onClick={onDeleteAll}
           className="p-1.5 rounded-md text-[var(--text-tertiary)] hover:text-[var(--delete-hover-text)] hover:bg-[var(--hover-bg-strong)] transition-colors"
           title="Delete all"

--- a/src/components/repo-group.tsx
+++ b/src/components/repo-group.tsx
@@ -1,12 +1,14 @@
 import { useState } from "react";
 import { Bell, BellOff, ChevronDown, ChevronRight, Folder, Trash2 } from "lucide-react";
-import type { NotificationGroup } from "@/lib/types";
+import type { Notification, NotificationGroup } from "@/lib/types";
 import { NotificationCard } from "./notification-card";
 
 interface RepoGroupProps {
   group: NotificationGroup;
   isMuted: boolean;
   newIds: Set<number>;
+  selectedId: number | null;
+  flatNotifications: Notification[];
   onDelete: (id: number) => void;
   onDeleteGroup: (groupName: string) => void;
   onToggleGroupMute: (groupName: string) => void;
@@ -16,6 +18,8 @@ export function RepoGroup({
   group,
   isMuted,
   newIds,
+  selectedId,
+  flatNotifications,
   onDelete,
   onDeleteGroup,
   onToggleGroupMute,
@@ -41,6 +45,7 @@ export function RepoGroup({
           {group.notifications.length}
         </span>
         <button
+          tabIndex={-1}
           onClick={(e) => {
             e.stopPropagation();
             onToggleGroupMute(group.groupName);
@@ -51,6 +56,7 @@ export function RepoGroup({
           {isMuted ? <BellOff size={11} /> : <Bell size={11} />}
         </button>
         <button
+          tabIndex={-1}
           onClick={(e) => {
             e.stopPropagation();
             onDeleteGroup(group.groupName);
@@ -63,14 +69,19 @@ export function RepoGroup({
 
       {expanded && (
         <div>
-          {group.notifications.map((n) => (
-            <NotificationCard
-              key={n.id}
-              notification={n}
-              isNew={newIds.has(n.id)}
-              onDelete={onDelete}
-            />
-          ))}
+          {group.notifications.map((n) => {
+            const navIndex = flatNotifications.findIndex((f) => f.id === n.id);
+            return (
+              <NotificationCard
+                key={n.id}
+                notification={n}
+                isNew={newIds.has(n.id)}
+                isSelected={n.id === selectedId}
+                navIndex={navIndex}
+                onDelete={onDelete}
+              />
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -24,7 +24,7 @@
   --badge-count-bg: #3b82f6;
   --badge-count-text: #ffffff;
 
-  --tray-arrow-color: rgba(0, 0, 0, 0.10);
+  --tray-arrow-fill: rgba(244, 244, 245, 0.95);
   --scrollbar-thumb: rgba(0, 0, 0, 0.15);
   --scrollbar-thumb-hover: rgba(0, 0, 0, 0.25);
 
@@ -65,7 +65,7 @@
     --badge-count-bg: #3b82f6;
     --badge-count-text: #ffffff;
 
-    --tray-arrow-color: rgba(255, 255, 255, 0.10);
+    --tray-arrow-fill: rgba(28, 28, 30, 0.95);
     --scrollbar-thumb: rgba(255, 255, 255, 0.15);
     --scrollbar-thumb-hover: rgba(255, 255, 255, 0.25);
 
@@ -96,7 +96,20 @@ body,
   height: 0;
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
-  border-bottom: 7px solid var(--tray-arrow-color);
+  border-bottom: 7px solid var(--border-primary);
+  position: relative;
+  flex-shrink: 0;
+}
+.tray-arrow::after {
+  content: "";
+  position: absolute;
+  left: -6px;
+  top: 1.5px;
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-bottom: 6px solid var(--tray-arrow-fill);
 }
 
 /* Scrollbar styling */


### PR DESCRIPTION
## Summary

- Add global keyboard shortcut (`Ctrl+Alt+N`) to toggle the notification panel, using `tauri-plugin-global-shortcut` v2
- Add vim-style keyboard navigation (`j`/`k`/`Enter`/`Escape`) within the main panel for navigating and activating notifications
- Redesign the main panel as a floating popover with transparent padding, tray arrow with filled interior, and refined layout

## Changes

### Global Shortcut (`Ctrl+Alt+N`)
- **`crates/agentoast-shared/src/config.rs`**: Add `ShortcutConfig` struct with `toggle_panel` field (default: `ctrl+alt+n`), configurable via `config.toml`
- **`src-tauri/src/lib.rs`**: Register `tauri-plugin-global-shortcut` in `.setup()`, parse shortcut from config, handle `ShortcutState::Pressed` to call `tray::toggle_panel()`
- **`src-tauri/src/tray.rs`**: Add `toggle_panel()` public function that uses `tray.rect()` to position the panel at the tray icon
- **`src-tauri/Cargo.toml`**: Add `tauri-plugin-global-shortcut = "2"` dependency
- **`src-tauri/capabilities/default.json`**: Add `global-shortcut:default` permission

### Keyboard Navigation (Main Panel)
- **`src/App.tsx`**: Add `selectedIndex` state, `flatNotifications` memo, `j`/`k`/`Enter`/`Escape` key handlers, `data-nav-index` scroll tracking
- **`src/components/notification-card.tsx`**: Add `isSelected`/`navIndex` props for highlight and scroll-into-view
- **`src/components/repo-group.tsx`**: Pass `selectedId`/`flatNotifications` to child cards
- **`src/components/panel-header.tsx`**: Add `tabIndex={-1}` to buttons to prevent keyboard focus

### Floating Popover Redesign
- **`src/App.tsx`**: Wrap panel content in transparent outer container with padding, inner container has the actual panel styling
- **`src/index.css`**: Tray arrow now uses `::after` pseudo-element for filled interior matching panel background
- **`src-tauri/tauri.conf.json`**: Increase main window size to 412x554 to account for transparent padding
- **`src-tauri/src/panel.rs`**: Add 8pt nudge-up offset for tray arrow alignment

## Test plan

- [ ] Verify `Ctrl+Alt+N` (Control+Option+N on macOS) toggles the notification panel
- [ ] Verify panel positions correctly at the tray icon when opened via shortcut
- [ ] Verify `j`/`k` navigates notifications, `Enter` activates (deletes + focuses terminal), `Escape` closes panel
- [ ] Verify selected notification highlights and scrolls into view
- [ ] Verify panel appears as floating popover with tray arrow pointing to the tray icon
- [ ] Verify setting `toggle_panel = ""` in config.toml disables the shortcut
- [ ] Verify dark/light mode tray arrow styling
