### PR TITLE
feat: add keybind help overlay toggled by ? key

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -20,6 +20,8 @@
     "ghostty",
     "googlecode",
     "iterm",
+    "keybind",
+    "keybinds",
     "kovidgoyal",
     "lefthook",
     "mitchellh",

--- a/src/components/keybind-help.tsx
+++ b/src/components/keybind-help.tsx
@@ -1,0 +1,45 @@
+interface KeybindHelpProps {
+  onClose: () => void;
+}
+
+const KEYBINDS = [
+  { key: "j", action: "Next" },
+  { key: "k", action: "Previous" },
+  { key: "Enter", action: "Open" },
+  { key: "Esc", action: "Close" },
+  { key: "?", action: "Help" },
+] as const;
+
+export function KeybindHelp({ onClose }: KeybindHelpProps) {
+  return (
+    <div
+      className="absolute inset-0 z-10 flex items-center justify-center"
+      style={{ backgroundColor: "var(--panel-bg)" }}
+      onClick={onClose}
+      tabIndex={-1}
+    >
+      <div className="flex flex-col gap-2" onClick={(e) => e.stopPropagation()}>
+        {KEYBINDS.map(({ key, action }) => (
+          <div key={key} className="flex items-center gap-3">
+            <span
+              className="w-12 text-center text-[11px] font-mono py-0.5 px-1.5 rounded"
+              style={{
+                backgroundColor: "var(--hover-bg-strong)",
+                color: "var(--text-primary)",
+                border: "1px solid var(--border-subtle)",
+              }}
+            >
+              {key}
+            </span>
+            <span
+              className="text-[11px]"
+              style={{ color: "var(--text-secondary)" }}
+            >
+              {action}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a keybind help overlay to the notification panel, toggled by pressing `?`
- Show a small circled `?` indicator in the bottom-right corner of the panel for discoverability
- Disable navigation keys (j/k/Enter) while help is shown; Escape dismisses the overlay

## Changes

- **`src/components/keybind-help.tsx`** (new): Overlay component displaying keybinding reference (j/k/Enter/Esc/?)
- **`src/App.tsx`**: Add `showHelp` state, `?` key handler, help overlay + indicator rendering
- **`cspell.json`**: Add `keybind`/`keybinds` to dictionary


