### PR TITLE
fix: remove notification count badge from panel header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ import type { Notification } from "@/lib/types";
 export function App() {
   const {
     groups,
-    unreadCount,
     loading,
     deleteNotification,
     deleteGroup,
@@ -130,7 +129,6 @@ export function App() {
       <div className="tray-arrow" />
       <div className="w-full flex-1 min-h-0 flex flex-col bg-[var(--panel-bg)] backdrop-blur-xl rounded-xl border border-[var(--border-primary)] shadow-2xl overflow-hidden">
         <PanelHeader
-          unreadCount={unreadCount}
           globalMuted={globalMuted}
           onDeleteAll={() => void deleteAll()}
           onToggleGlobalMute={() => void toggleGlobalMute()}

--- a/src/components/panel-header.tsx
+++ b/src/components/panel-header.tsx
@@ -1,27 +1,18 @@
 import { Bell, BellOff, Trash2 } from "lucide-react";
 
 interface PanelHeaderProps {
-  unreadCount: number;
   globalMuted: boolean;
   onDeleteAll: () => void;
   onToggleGlobalMute: () => void;
 }
 
 export function PanelHeader({
-  unreadCount,
   globalMuted,
   onDeleteAll,
   onToggleGlobalMute,
 }: PanelHeaderProps) {
   return (
-    <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border-primary)]">
-      <div className="flex items-center gap-2">
-        {unreadCount > 0 && (
-          <span className="px-1.5 py-0.5 text-[10px] font-medium bg-[var(--badge-count-bg)] text-[var(--badge-count-text)] rounded-full">
-            {unreadCount}
-          </span>
-        )}
-      </div>
+    <div className="flex items-center justify-end px-4 py-3 border-b border-[var(--border-primary)]">
       <div className="flex items-center gap-1">
         <button
           tabIndex={-1}

--- a/src/index.css
+++ b/src/index.css
@@ -21,9 +21,6 @@
   --badge-stop-text: #16a34a;
   --badge-notif-bg: rgba(59, 130, 246, 0.15);
   --badge-notif-text: #2563eb;
-  --badge-count-bg: #3b82f6;
-  --badge-count-text: #ffffff;
-
   --tray-arrow-fill: rgba(244, 244, 245, 0.95);
   --scrollbar-thumb: rgba(0, 0, 0, 0.15);
   --scrollbar-thumb-hover: rgba(0, 0, 0, 0.25);
@@ -62,9 +59,6 @@
     --badge-stop-text: #4ade80;
     --badge-notif-bg: rgba(59, 130, 246, 0.20);
     --badge-notif-text: #60a5fa;
-    --badge-count-bg: #3b82f6;
-    --badge-count-text: #ffffff;
-
     --tray-arrow-fill: rgba(28, 28, 30, 0.95);
     --scrollbar-thumb: rgba(255, 255, 255, 0.15);
     --scrollbar-thumb-hover: rgba(255, 255, 255, 0.25);


### PR DESCRIPTION
## Summary

- Remove the notification count badge (blue circle + white number) from the panel header for a cleaner UI
- Remove unused `unreadCount` prop from `PanelHeader` component
- Clean up `--badge-count-bg` and `--badge-count-text` CSS variables (light + dark mode)

## Changed files

- `src/components/panel-header.tsx`: Remove `unreadCount` prop and badge JSX, change layout to `justify-end`
- `src/App.tsx`: Remove `unreadCount` destructuring and prop passing
- `src/index.css`: Remove `--badge-count-bg` / `--badge-count-text` CSS variables
