### PR TITLE
feat: suppress notifications when originating tmux pane is active

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Editor resolution priority is `config.toml` `editor` field → `$EDITOR` → `vi
 # group_limit = 3
 ```
 
+When a terminal is focused and the notification's originating tmux pane is the active pane, notifications are automatically suppressed — since you're already looking at it.
+
 ### Tips
 
 Set up a shell alias for command completion notifications.

--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -144,6 +144,7 @@ fn default_config_template() -> &'static str {
 # Format: modifier+key (modifiers: ctrl, shift, alt/option, super/cmd)
 # Set to "" to disable
 # toggle_panel = "ctrl+alt+n"
+
 "#
 }
 


### PR DESCRIPTION
## Summary

- Suppress notifications when the user is already looking at the originating tmux pane (terminal focused + pane active)
- Suppressed notifications are deleted from DB — no toast, no panel event, no tray badge update
- Detection: `NSWorkspace.isActive()` for terminal focus, `tmux display-message` for pane visibility (`pane_active`, `window_active`, `session_attached`)
- Short-circuit: tmux check is skipped if the terminal isn't focused (zero overhead in the common case)

## Changed files

- `src-tauri/src/terminal.rs` — Add `is_terminal_focused()`, `is_tmux_pane_active()`, `is_pane_visible_to_user()`
- `src-tauri/src/watcher.rs` — Insert suppression filter before mute check in `check_new_notifications()`
- `crates/agentoast-shared/src/config.rs` — Whitespace cleanup in config template
- `README.md` — Document the suppression behavior


