### PR TITLE
fix: explicitly hide panel when activating a notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ agentoast send \
 
 Clicking a notification dismisses it and brings you back to the terminal. With `--tmux-pane`, all notifications sharing the same `--group` + `--tmux-pane` are dismissed at once. Sending a new notification with the same `--group` + `--tmux-pane` replaces the previous one, so only the latest notification per pane is kept.
 
+When a terminal is focused and the notification's originating tmux pane is the active pane, notifications are automatically suppressed — since you're already looking at it.
+
 For a quick test, you can fire off notifications straight from the CLI.
 
 Claude Code
@@ -208,8 +210,6 @@ Editor resolution priority is `config.toml` `editor` field → `$EDITOR` → `vi
 # Maximum number of notifications per group (default: 3, 0 = unlimited)
 # group_limit = 3
 ```
-
-When a terminal is focused and the notification's originating tmux pane is the active pane, notifications are automatically suppressed — since you're already looking at it.
 
 ### Tips
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,6 +122,7 @@ export function App() {
           const n = flatNotifications[selectedIndex];
           if (n) {
             activateNotification(n);
+            void invoke("hide_panel");
           } else {
             void invoke("hide_panel");
           }

--- a/src/components/notification-card.tsx
+++ b/src/components/notification-card.tsx
@@ -51,6 +51,7 @@ export function NotificationCard({
           tmuxPane: notification.tmuxPane,
           terminalBundleId: notification.terminalBundleId,
         });
+        void invoke("hide_panel");
       }}
     >
       <div className="flex items-start gap-2.5">


### PR DESCRIPTION
## Summary

- Explicitly call `hide_panel` after activating a notification via Enter key or card click
- The panel was not closing because `nonactivating_panel` style mask prevents `window_did_resign_key` from firing reliably when another app gains focus

## Changes

- `src/App.tsx`: Add `void invoke("hide_panel")` after `activateNotification(n)` in Enter key handler
- `src/components/notification-card.tsx`: Add `void invoke("hide_panel")` after `focus_terminal` in card click handler

