### PR TITLE
feat: replace text labels with SVG icons for pane and branch metadata

### DIFF
--- a/src/components/notification-card.tsx
+++ b/src/components/notification-card.tsx
@@ -1,8 +1,8 @@
-import { X } from "lucide-react";
+import { X, GitBranch } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { cn, formatRelativeTime } from "@/lib/utils";
 import type { Notification } from "@/lib/types";
-import { IconPreset } from "@/components/icons/source-icon";
+import { IconPreset, TmuxIcon } from "@/components/icons/source-icon";
 
 interface NotificationCardProps {
   notification: Notification;
@@ -87,14 +87,18 @@ export function NotificationCard({
           {(metaEntries.length > 0 || notification.tmuxPane) && (
             <div className="flex items-center gap-1 mt-1 text-[10px] text-[var(--text-muted)] truncate">
               {metaEntries.map(([key, value], i) => (
-                <span key={key} className={i > 0 ? "ml-1" : ""}>
-                  <span>{key}:</span>{" "}
-                  {value}
+                <span key={key} className={cn("flex items-center gap-0.5", i > 0 ? "ml-1" : "")}>
+                  {key === "branch" ? (
+                    <GitBranch size={10} className="flex-shrink-0" />
+                  ) : (
+                    <span>{key}:</span>
+                  )}
+                  {" "}{value}
                 </span>
               ))}
               {notification.tmuxPane && (
-                <span className={metaEntries.length > 0 ? "ml-1" : ""}>
-                  <span>pane:</span> {notification.tmuxPane}
+                <span className={cn("flex items-center gap-0.5", metaEntries.length > 0 ? "ml-1" : "")}>
+                  <TmuxIcon size={10} className="flex-shrink-0" /> {notification.tmuxPane}
                 </span>
               )}
             </div>

--- a/src/components/pane-card.tsx
+++ b/src/components/pane-card.tsx
@@ -1,8 +1,8 @@
-import { X, Circle } from "lucide-react";
+import { X, Circle, GitBranch } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { cn, formatRelativeTime } from "@/lib/utils";
 import type { PaneItem } from "@/lib/types";
-import { IconPreset } from "@/components/icons/source-icon";
+import { IconPreset, TmuxIcon } from "@/components/icons/source-icon";
 
 interface PaneCardProps {
   paneItem: PaneItem;
@@ -107,13 +107,18 @@ export function PaneCard({
           {(metaEntries.length > 0 || pane.paneId) && (
             <div className="flex items-center gap-1 mt-0.5 text-[10px] text-[var(--text-muted)] truncate">
               {metaEntries.map(([key, value], i) => (
-                <span key={key} className={i > 0 ? "ml-1" : ""}>
-                  <span>{key}:</span> {value}
+                <span key={key} className={cn("flex items-center gap-0.5", i > 0 ? "ml-1" : "")}>
+                  {key === "branch" ? (
+                    <GitBranch size={10} className="flex-shrink-0" />
+                  ) : (
+                    <span>{key}:</span>
+                  )}
+                  {" "}{value}
                 </span>
               ))}
               {pane.paneId && (
-                <span className={metaEntries.length > 0 ? "ml-1" : ""}>
-                  <span>pane:</span> {pane.paneId}
+                <span className={cn("flex items-center gap-0.5", metaEntries.length > 0 ? "ml-1" : "")}>
+                  <TmuxIcon size={10} className="flex-shrink-0" /> {pane.paneId}
                 </span>
               )}
             </div>


### PR DESCRIPTION
## Summary

- Replace `pane:` text label with `TmuxIcon` SVG in pane-card and notification-card
- Replace `branch:` text label with `GitBranch` SVG icon (matching repo-group header style)
- Add `flex items-center gap-0.5` layout for proper icon-text alignment

## Changed Files

| File | Change |
|---|---|
| `src/components/pane-card.tsx` | Import `TmuxIcon` + `GitBranch`, replace text labels with SVG icons |
| `src/components/notification-card.tsx` | Import `TmuxIcon` + `GitBranch`, replace text labels with SVG icons |

