### PR TITLE
feat: replace agent type text label with tooltip on green dot

### DIFF
--- a/src/components/pane-card.tsx
+++ b/src/components/pane-card.tsx
@@ -72,11 +72,8 @@ export function PaneCard({
           {/* Line 1: Running status + notification badge + session info + time */}
           <div className="flex items-center gap-1.5">
             {pane.agentType && (
-              <span className="flex items-center gap-1 flex-shrink-0">
+              <span className="flex-shrink-0" title={pane.agentType}>
                 <Circle size={5} className="text-green-500 fill-green-500" />
-                <span className="text-[10px] text-[var(--text-secondary)] font-medium">
-                  {pane.agentType}
-                </span>
               </span>
             )}
             {notification?.badge && badgeClass && (


### PR DESCRIPTION
## Summary

- Remove the `agentType` text label ("claude-code", etc.) from PaneCard Line 1 to reclaim horizontal space in the 380px panel
- Add a native tooltip (`title` attribute) to the green running indicator dot, showing the agent name on hover
- The `IconPreset` icon already conveys the agent type, so the text label was redundant

## Changes

- `src/components/pane-card.tsx`: Replace `<span>` with text label to a simple `<span>` with `title={pane.agentType}` on the green dot

