### PR TITLE
feat: add agent status detection with Running/Idle/Waiting states

### DIFF
--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -133,7 +133,6 @@ fn default_claude_events() -> Vec<String> {
     vec![
         "Stop".to_string(),
         "permission_prompt".to_string(),
-        "idle_prompt".to_string(),
         "auth_success".to_string(),
         "elicitation_dialog".to_string(),
     ]
@@ -207,9 +206,10 @@ fn default_config_template() -> &'static str {
 
 # Claude Code hook settings
 [hook.claude]
-# Events that trigger notifications (default: all)
+# Events that trigger notifications
 # Available: Stop, permission_prompt, idle_prompt, auth_success, elicitation_dialog
-# events = ["Stop", "permission_prompt", "idle_prompt", "auth_success", "elicitation_dialog"]
+# idle_prompt is excluded by default (noisy); add it back if you want idle notifications
+# events = ["Stop", "permission_prompt", "auth_success", "elicitation_dialog"]
 
 # Events that auto-focus the terminal (default: none)
 # These events set force_focus=true, causing silent terminal focus without toast (when not muted)
@@ -242,7 +242,6 @@ mod tests {
             vec![
                 "Stop",
                 "permission_prompt",
-                "idle_prompt",
                 "auth_success",
                 "elicitation_dialog",
             ]
@@ -272,8 +271,8 @@ focus_events = ["Stop", "permission_prompt"]
             config.hook.claude.focus_events,
             vec!["Stop", "permission_prompt"]
         );
-        // Events should still have defaults
-        assert_eq!(config.hook.claude.events.len(), 5);
+        // Events should still have defaults (4 without idle_prompt)
+        assert_eq!(config.hook.claude.events.len(), 4);
     }
 
     #[test]
@@ -283,8 +282,8 @@ focus_events = ["Stop", "permission_prompt"]
 duration_ms = 5000
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
-        // Hook.claude should use defaults
-        assert_eq!(config.hook.claude.events.len(), 5);
+        // Hook.claude should use defaults (4 without idle_prompt)
+        assert_eq!(config.hook.claude.events.len(), 4);
         assert!(config.hook.claude.focus_events.is_empty());
     }
 }

--- a/crates/agentoast-shared/src/models.rs
+++ b/crates/agentoast-shared/src/models.rs
@@ -42,6 +42,14 @@ impl std::fmt::Display for IconType {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentStatus {
+    Running,
+    Idle,
+    Waiting,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Notification {
@@ -68,6 +76,8 @@ pub struct TmuxPane {
     pub window_name: String,
     pub current_path: String,
     pub agent_type: Option<String>,
+    pub agent_status: Option<AgentStatus>,
+    pub agent_modes: Vec<String>,
     pub git_repo_root: Option<String>,
     pub git_branch: Option<String>,
 }

--- a/crates/agentoast-shared/src/models.rs
+++ b/crates/agentoast-shared/src/models.rs
@@ -75,6 +75,7 @@ pub struct TmuxPane {
     pub session_name: String,
     pub window_name: String,
     pub current_path: String,
+    pub is_active: bool,
     pub agent_type: Option<String>,
     pub agent_status: Option<AgentStatus>,
     pub agent_modes: Vec<String>,

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -379,6 +379,15 @@ fn detect_agent_status(
 ) -> (AgentStatus, Vec<String>) {
     let info = check_pane_content(pane_id);
 
+    log::debug!(
+        "detect_agent_status({}): spinner={} status_running={} elicitation={} prompt={}",
+        pane_id,
+        info.has_spinner,
+        info.has_status_running,
+        info.has_elicitation,
+        info.at_prompt
+    );
+
     // Spinners are real-time signals and take highest priority.
     // Status bar "(running)" may be stale (e.g., plan mode waiting with old
     // status bar text), so it does NOT override at_prompt.
@@ -399,9 +408,8 @@ fn detect_agent_status(
         } else {
             AgentStatus::Idle
         }
-    } else if info.has_status_running {
-        AgentStatus::Running
     } else {
+        // has_status_running or no signal — default to Running
         AgentStatus::Running
     };
 
@@ -663,7 +671,7 @@ fn is_numbered_option(line: &str) -> bool {
 /// Check if a line shows file changes (e.g., "4 files +42 -0").
 fn is_file_changes_line(line: &str) -> bool {
     let trimmed = line.trim();
-    trimmed.chars().next().map_or(false, |c| c.is_ascii_digit())
+    trimmed.chars().next().is_some_and(|c| c.is_ascii_digit())
         && trimmed.contains("file")
         && (trimmed.contains('+') || trimmed.contains('-'))
 }

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -205,8 +205,7 @@ pub fn list_tmux_panes_grouped() -> Result<Vec<TmuxPaneGroup>, String> {
 
         let pane_pid: u32 = parts[1].parse().unwrap_or(0);
         let agent_type = detect_agent(&process_tree, pane_pid);
-        let is_active =
-            parts[5] == "1" && parts[6] == "1" && parts[7] == "1";
+        let is_active = parts[5] == "1" && parts[6] == "1" && parts[7] == "1";
         log::debug!(
             "sessions: pane {} pid={} agent={:?} is_active={}",
             parts[0],
@@ -367,10 +366,10 @@ fn build_process_tree() -> ProcessTree {
 }
 
 struct PaneContentInfo {
-    has_spinner: bool,       // Spinner chars + "…" / "esc to interrupt" (real-time, reliable)
+    has_spinner: bool, // Spinner chars + "…" / "esc to interrupt" (real-time, reliable)
     has_status_running: bool, // Status bar "(running)" suffix (may be stale)
     at_prompt: bool,
-    has_elicitation: bool,   // "Enter to select" navigation hint (selection dialog)
+    has_elicitation: bool, // "Enter to select" navigation hint (selection dialog)
     agent_modes: Vec<String>,
 }
 
@@ -446,10 +445,7 @@ fn check_pane_content(pane_id: &str) -> PaneContentInfo {
         .ok();
 
     let Some(output) = output else {
-        log::debug!(
-            "check_pane_content({}): capture-pane exec failed",
-            pane_id
-        );
+        log::debug!("check_pane_content({}): capture-pane exec failed", pane_id);
         return default;
     };
     if !output.status.success() {
@@ -667,10 +663,7 @@ fn is_numbered_option(line: &str) -> bool {
 /// Check if a line shows file changes (e.g., "4 files +42 -0").
 fn is_file_changes_line(line: &str) -> bool {
     let trimmed = line.trim();
-    trimmed
-        .chars()
-        .next()
-        .map_or(false, |c| c.is_ascii_digit())
+    trimmed.chars().next().map_or(false, |c| c.is_ascii_digit())
         && trimmed.contains("file")
         && (trimmed.contains('+') || trimmed.contains('-'))
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -268,14 +268,28 @@ export function App() {
         }
         needFetchVersionRef.current = -1;
 
+        // If notifications exist, focus the pane with the most recent notification
+        let latestNotifIdx = -1;
+        let latestCreatedAt = "";
+        for (let i = 0; i < flatItems.length; i++) {
+          const f = flatItems[i];
+          if (f.type === "pane-item" && f.paneItem.notification) {
+            if (f.paneItem.notification.createdAt > latestCreatedAt) {
+              latestCreatedAt = f.paneItem.notification.createdAt;
+              latestNotifIdx = i;
+            }
+          }
+        }
+        if (latestNotifIdx >= 0) return latestNotifIdx;
+
         if (!filterNotifiedOnly) {
-          // Not filtering: always focus the active tmux pane
+          // No notifications: focus the active tmux pane
           const activeIdx = flatItems.findIndex(
             (f) => f.type === "pane-item" && f.paneItem.pane.isActive,
           );
           if (activeIdx >= 0) return activeIdx;
         }
-        // Filtering or no active pane: focus first non-header item
+        // No notifications and no active pane: focus first non-header item
         const idx = flatItems.findIndex((f) => f.type !== "group-header");
         return idx >= 0 ? idx : 0;
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,6 +137,8 @@ export function App() {
           windowName: "",
           currentPath: "",
           agentType: null,
+          agentStatus: null,
+          agentModes: [],
           gitRepoRoot: null,
           gitBranch: null,
         },

--- a/src/components/keybind-help.tsx
+++ b/src/components/keybind-help.tsx
@@ -10,7 +10,7 @@ const KEYBINDS = [
   { key: "D", action: "Delete all notifs" },
   { key: "C", action: "Collapse all" },
   { key: "E", action: "Expand all" },
-  { key: "F", action: "Filter notified" },
+  { key: "F", action: "Filter action needed" },
   { key: "Esc", action: "Close" },
   { key: "?", action: "Help" },
 ] as const;

--- a/src/components/pane-card.tsx
+++ b/src/components/pane-card.tsx
@@ -1,7 +1,7 @@
 import { X, Circle, GitBranch } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { cn, formatRelativeTime } from "@/lib/utils";
-import type { PaneItem } from "@/lib/types";
+import type { PaneItem, AgentStatus, TmuxPane } from "@/lib/types";
 import { IconPreset, TmuxIcon } from "@/components/icons/source-icon";
 
 interface PaneCardProps {
@@ -10,6 +10,46 @@ interface PaneCardProps {
   isSelected?: boolean;
   navIndex?: number;
   onDeleteNotification: (id: number) => void;
+}
+
+function statusDotClass(status: AgentStatus | null): string {
+  switch (status) {
+    case "running":
+      return "text-green-500 fill-green-500";
+    case "idle":
+    case "waiting":
+      return "text-[var(--text-muted)] fill-[var(--text-muted)]";
+    default:
+      return "text-green-500 fill-green-500";
+  }
+}
+
+function statusTooltip(pane: TmuxPane): string {
+  const agent = pane.agentType ?? "agent";
+  const modeStr = pane.agentModes.length > 0 ? ` (${pane.agentModes.join(", ")})` : "";
+  switch (pane.agentStatus) {
+    case "running":
+      return `${agent}: running${modeStr}`;
+    case "idle":
+      return `${agent}: idle${modeStr}`;
+    case "waiting":
+      return `${agent}: waiting for input${modeStr}`;
+    default:
+      return agent;
+  }
+}
+
+function badgeGlowStyle(badgeColor: string): React.CSSProperties | undefined {
+  switch (badgeColor) {
+    case "green":
+      return { boxShadow: "0 0 6px rgba(34, 197, 94, 0.3)" };
+    case "blue":
+      return { boxShadow: "0 0 6px rgba(59, 130, 246, 0.3)" };
+    case "red":
+      return { boxShadow: "0 0 6px rgba(239, 68, 68, 0.3)" };
+    default:
+      return undefined;
+  }
 }
 
 const badgeColorClasses: Record<string, string> = {
@@ -53,7 +93,7 @@ export function PaneCard({
     <div
       data-nav-index={navIndex}
       className={cn(
-        "group relative mx-2 my-0.5 px-2.5 py-2 rounded-lg hover:bg-[var(--hover-bg)] cursor-pointer",
+        "group relative ml-6 mr-2 my-0.5 px-2.5 py-2 min-h-[52px] rounded-lg hover:bg-[var(--hover-bg)] cursor-pointer pane-separator",
         isNew && "animate-new-highlight",
         isSelected && "bg-[var(--hover-bg)]",
       )}
@@ -72,16 +112,22 @@ export function PaneCard({
           {/* Line 1: Running status + notification badge + session info + time */}
           <div className="flex items-center gap-1.5">
             {pane.agentType && (
-              <span className="flex-shrink-0" title={pane.agentType}>
-                <Circle size={5} className="text-green-500 fill-green-500" />
+              <span className="flex-shrink-0" title={statusTooltip(pane)}>
+                <Circle size={7} className={statusDotClass(pane.agentStatus)} />
               </span>
             )}
+            {pane.agentModes.map((mode) => (
+              <span key={mode} className="text-[10px] text-[var(--text-muted)] font-medium flex-shrink-0">
+                {mode}
+              </span>
+            ))}
             {notification?.badge && badgeClass && (
               <span
                 className={cn(
                   "px-1.5 py-0.5 text-[10px] font-medium rounded flex-shrink-0",
                   badgeClass,
                 )}
+                style={badgeGlowStyle(notification.badgeColor)}
               >
                 {notification.badge}
               </span>

--- a/src/components/pane-card.tsx
+++ b/src/components/pane-card.tsx
@@ -17,8 +17,9 @@ function statusDotClass(status: AgentStatus | null): string {
     case "running":
       return "text-green-500 fill-green-500";
     case "idle":
-    case "waiting":
       return "text-[var(--text-muted)] fill-[var(--text-muted)]";
+    case "waiting":
+      return "text-amber-500 fill-amber-500";
     default:
       return "text-green-500 fill-green-500";
   }

--- a/src/components/repo-group.tsx
+++ b/src/components/repo-group.tsx
@@ -44,7 +44,11 @@ export function RepoGroup({
   const totalNotifications =
     paneItems.filter((pi) => pi.notification !== null).length;
 
-  const activeSessions = paneItems.filter((pi) => pi.pane.agentType !== null).length;
+  const runningCount = paneItems.filter((pi) => pi.pane.agentStatus === "running").length;
+  const inactiveCount = paneItems.filter(
+    (pi) => pi.pane.agentStatus === "idle" || pi.pane.agentStatus === "waiting"
+  ).length;
+  const modeCount = paneItems.filter((pi) => pi.pane.agentModes.length > 0).length;
 
   return (
     <div className="border-b border-[var(--border-subtle)] last:border-b-0">
@@ -106,19 +110,22 @@ export function RepoGroup({
             </span>
           </div>
         )}
-        {/* Line 3: notification count + agent count */}
-        {(totalNotifications > 0 || activeSessions > 0) && (
+        {/* Line 3: agent status counts */}
+        {(runningCount > 0 || inactiveCount > 0) && (
           <div className="flex items-center gap-3 pl-[33px] mt-0.5">
-            {totalNotifications > 0 && (
-              <span className="flex items-center gap-1 text-[10px] text-[#FF9500] font-medium">
-                <span className="w-1.5 h-1.5 rounded-full bg-[#FF9500]" />
-                {totalNotifications}
-              </span>
-            )}
-            {activeSessions > 0 && (
+            {runningCount > 0 && (
               <span className="flex items-center gap-1 text-[10px] text-green-500 font-medium">
                 <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
-                {activeSessions}
+                {runningCount}
+              </span>
+            )}
+            {inactiveCount > 0 && (
+              <span className="flex items-center gap-1 text-[10px] text-[var(--text-muted)] font-medium">
+                <span className="w-1.5 h-1.5 rounded-full bg-[var(--text-muted)]" />
+                {inactiveCount}
+                {modeCount > 0 && (
+                  <span className="ml-0.5">({modeCount} mode)</span>
+                )}
               </span>
             )}
           </div>

--- a/src/components/repo-group.tsx
+++ b/src/components/repo-group.tsx
@@ -45,10 +45,8 @@ export function RepoGroup({
     paneItems.filter((pi) => pi.notification !== null).length;
 
   const runningCount = paneItems.filter((pi) => pi.pane.agentStatus === "running").length;
-  const inactiveCount = paneItems.filter(
-    (pi) => pi.pane.agentStatus === "idle" || pi.pane.agentStatus === "waiting"
-  ).length;
-  const modeCount = paneItems.filter((pi) => pi.pane.agentModes.length > 0).length;
+  const idleCount = paneItems.filter((pi) => pi.pane.agentStatus === "idle").length;
+  const waitingCount = paneItems.filter((pi) => pi.pane.agentStatus === "waiting").length;
 
   return (
     <div className="border-b border-[var(--border-subtle)] last:border-b-0">
@@ -111,7 +109,7 @@ export function RepoGroup({
           </div>
         )}
         {/* Line 3: agent status counts */}
-        {(runningCount > 0 || inactiveCount > 0) && (
+        {(runningCount > 0 || idleCount > 0 || waitingCount > 0) && (
           <div className="flex items-center gap-3 pl-[33px] mt-0.5">
             {runningCount > 0 && (
               <span className="flex items-center gap-1 text-[10px] text-green-500 font-medium">
@@ -119,13 +117,16 @@ export function RepoGroup({
                 {runningCount}
               </span>
             )}
-            {inactiveCount > 0 && (
+            {idleCount > 0 && (
               <span className="flex items-center gap-1 text-[10px] text-[var(--text-muted)] font-medium">
                 <span className="w-1.5 h-1.5 rounded-full bg-[var(--text-muted)]" />
-                {inactiveCount}
-                {modeCount > 0 && (
-                  <span className="ml-0.5">({modeCount} mode)</span>
-                )}
+                {idleCount}
+              </span>
+            )}
+            {waitingCount > 0 && (
+              <span className="flex items-center gap-1 text-[10px] text-amber-500 font-medium">
+                <span className="w-1.5 h-1.5 rounded-full bg-amber-500" />
+                {waitingCount}
               </span>
             )}
           </div>

--- a/src/hooks/use-sessions.ts
+++ b/src/hooks/use-sessions.ts
@@ -7,6 +7,7 @@ export function useSessions() {
   const [groups, setGroups] = useState<TmuxPaneGroup[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [fetchVersion, setFetchVersion] = useState(0);
   const mountedRef = useRef(true);
 
   const refresh = useCallback(async () => {
@@ -17,6 +18,7 @@ export function useSessions() {
           if (JSON.stringify(prev) === JSON.stringify(result)) return prev;
           return result;
         });
+        setFetchVersion((v) => v + 1);
         setError(null);
       }
     } catch (e) {
@@ -58,5 +60,5 @@ export function useSessions() {
     };
   }, [refresh]);
 
-  return { groups, loading, error, refresh };
+  return { groups, loading, error, refresh, fetchVersion };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -142,3 +142,17 @@ body,
 .animate-new-highlight {
   animation: new-highlight 3s ease-out forwards;
 }
+
+/* Gradient fade separator between PaneCards */
+.pane-separator::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 10%;
+  right: 10%;
+  height: 1px;
+  background: linear-gradient(to right, transparent, var(--border-primary), transparent);
+}
+.pane-separator:last-child::after {
+  display: none;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
 export type Icon = "agentoast" | "claude-code" | "codex" | "opencode";
+export type AgentStatus = "running" | "idle" | "waiting";
 
 export interface Notification {
   id: number;
@@ -27,6 +28,8 @@ export interface TmuxPane {
   windowName: string;
   currentPath: string;
   agentType: Icon | null;
+  agentStatus: AgentStatus | null;
+  agentModes: string[];
   gitRepoRoot: string | null;
   gitBranch: string | null;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -27,6 +27,7 @@ export interface TmuxPane {
   sessionName: string;
   windowName: string;
   currentPath: string;
+  isActive: boolean;
   agentType: Icon | null;
   agentStatus: AgentStatus | null;
   agentModes: string[];


### PR DESCRIPTION
## Summary

- Display agent status with 3-color dots per tmux pane (Running=green, Idle=gray, Waiting=amber)
- Detect spinners, prompts, and elicitation dialogs via capture-pane to determine status
- Detect and display mode badges (plan/bypass/accept)
- Show per-status counters in RepoGroup headers
- Improve active pane selection on panel open

### Statusline-independent prompt detection in is_prompt_line

Previously, `is_prompt_line()` skipped lines containing specific emoji (🟢🟡🔴) as Claude Code statusline via `is_token_count_line`. However, the statusline content is user-configurable, making this approach fragile.

**Change**: Removed `is_token_count_line` and introduced a multi-line scan tolerance. Lines that match neither known footer elements nor prompt patterns are counted as "unknown lines" and tolerated up to `MAX_UNKNOWN_LINES` (3) before concluding the agent is not at a prompt. This removes any dependency on statusline content.

```
Scan direction (bottom → top)
│ >                      │  ← prompt → Idle ✓
╰────────────────────────╯  ← separator (unconditional skip)
🟢 114.5K (57%)             ← unknown line 1/3 (continue scanning)
⏵⏵ bypass permissions ...   ← mode (unconditional skip)
ctrl+r for shortcuts        ← help text (unconditional skip)
```

