### PR TITLE
fix: use character wrapping for toast body text

### DIFF
--- a/src-tauri/src/native_toast.rs
+++ b/src-tauri/src/native_toast.rs
@@ -619,7 +619,7 @@ fn build_toast_view(
             &body_font,
         );
         body_label.setMaximumNumberOfLines(2);
-        body_label.setLineBreakMode(NSLineBreakMode::ByTruncatingTail);
+        body_label.setLineBreakMode(NSLineBreakMode::ByCharWrapping);
         effect_view.addSubview(&body_label);
     }
 


### PR DESCRIPTION
## Summary

- Fix toast body text not wrapping to the second line when the text contains long words without spaces
- Change `NSLineBreakMode` from `ByTruncatingTail` (single-line truncation) to `ByCharWrapping` (character-level wrapping) so the body utilizes the 2-line maximum set by `setMaximumNumberOfLines(2)`

## Changes

- `src-tauri/src/native_toast.rs`: Replace `ByTruncatingTail` with `ByCharWrapping` for the body label's line break mode

