### PR TITLE
fix: change filter_notified_only default to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.14.1](https://github.com/shuntaka9576/agentoast/compare/v0.14.0...v0.14.1) - 2026-02-19
+- fix: resolve toast layout overlap in release builds by @shuntaka9576 in https://github.com/shuntaka9576/agentoast/pull/37
+
 ## [v0.14.0](https://github.com/shuntaka9576/agentoast/compare/v0.13.0...v0.14.0) - 2026-02-19
 - feat: add agent status detection with Running/Idle/Waiting states by @shuntaka9576 in https://github.com/shuntaka9576/agentoast/pull/34
 - fix: use character wrapping for toast body text by @shuntaka9576 in https://github.com/shuntaka9576/agentoast/pull/36

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentoast-app"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "agentoast-shared",
  "block2",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "agentoast-cli"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "agentoast-shared",
  "clap",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentoast-shared"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "log",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/agentoast-shared", "crates/agentoast-cli", "src-tauri"]
 resolver = "2"
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/README.md
+++ b/README.md
@@ -218,8 +218,8 @@ Editor resolution priority is `config.toml` `editor` field → `$EDITOR` → `vi
 # Mute all notifications (default: false)
 # muted = false
 
-# Show only groups with notifications (default: true)
-# filter_notified_only = true
+# Show only groups with notifications (default: false)
+# filter_notified_only = false
 
 # Global keyboard shortcut
 [shortcut]

--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -81,7 +81,7 @@ impl Default for PanelConfig {
 }
 
 fn default_filter_notified_only() -> bool {
-    true
+    false
 }
 
 fn default_toast_duration() -> u64 {
@@ -194,8 +194,8 @@ fn default_config_template() -> &'static str {
 # Mute all notifications (default: false)
 # muted = false
 
-# Show only groups with notifications (default: true)
-# filter_notified_only = true
+# Show only groups with notifications (default: false)
+# filter_notified_only = false
 
 # Global keyboard shortcut
 [shortcut]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentoast",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.14.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Agentoast",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "identifier": "com.shuntaka.agentoast",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

- Change `filter_notified_only` default from `true` to `false` so the panel shows all groups/panes by default
- Update config template comment and README to reflect the new default

## Changes

| File | Change |
|---|---|
| `crates/agentoast-shared/src/config.rs` | `default_filter_notified_only()` returns `false`; config template comment updated |
| `README.md` | Config example comment updated |

## Test plan

- [ ] `cargo make dev` — panel shows all groups/panes by default
- [ ] Press `F` to toggle filter — only notified groups shown