### PR TITLE
fix: change filter_notified_only default to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,8 @@ Editor resolution priority is `config.toml` `editor` field → `$EDITOR` → `vi
 # Mute all notifications (default: false)
 # muted = false
 
-# Show only groups with notifications (default: true)
-# filter_notified_only = true
+# Show only groups with notifications (default: false)
+# filter_notified_only = false
 
 # Global keyboard shortcut
 [shortcut]

--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -81,7 +81,7 @@ impl Default for PanelConfig {
 }
 
 fn default_filter_notified_only() -> bool {
-    true
+    false
 }
 
 fn default_toast_duration() -> u64 {
@@ -194,8 +194,8 @@ fn default_config_template() -> &'static str {
 # Mute all notifications (default: false)
 # muted = false
 
-# Show only groups with notifications (default: true)
-# filter_notified_only = true
+# Show only groups with notifications (default: false)
+# filter_notified_only = false
 
 # Global keyboard shortcut
 [shortcut]


### PR DESCRIPTION
## Summary

- Change `filter_notified_only` default from `true` to `false` so the panel shows all groups/panes by default
- Update config template comment and README to reflect the new default

## Changes

| File | Change |
|---|---|
| `crates/agentoast-shared/src/config.rs` | `default_filter_notified_only()` returns `false`; config template comment updated |
| `README.md` | Config example comment updated |

