### PR TITLE
fix: add missing spinner char (U+2733) to SPINNER_CHARS

### DIFF
--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -436,7 +436,7 @@ fn detect_claude_status(
 }
 
 /// Claude Code spinner characters that appear at the start of running lines.
-const SPINNER_CHARS: &[char] = &['✢', '✽', '✶', '✻', '·'];
+const SPINNER_CHARS: &[char] = &['✢', '✽', '✶', '✳', '✻', '·'];
 
 /// Check pane content for running indicators, prompt patterns, and mode indicators.
 /// Running: spinner+"…" / spinner+"esc to interrupt" / status bar "(running)".


### PR DESCRIPTION
## Summary
- Add missing spinner character ✳ (U+2733) to `SPINNER_CHARS` constant in `sessions.rs`
- This character appears in Claude Code's TUI spinner animation but was not included in the detection set, causing running status to be missed

