### PR TITLE
feat: add built-in `agentoast hook codex` CLI subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ brew uninstall shuntaka9576/tap/agentoast-cli
 
 ## Usage
 
-Integration samples for each agent are in [`examples/notify/`](examples/notify/). Claude Code uses the built-in CLI subcommand (`agentoast hook claude`). Codex uses a [Deno](https://deno.land/) hook script. opencode uses its plugin system.
+Integration samples for each agent are in [`examples/notify/`](examples/notify/). Claude Code and Codex use built-in CLI subcommands (`agentoast hook claude` / `agentoast hook codex`). opencode uses its plugin system.
 
 ### Claude Code
 
@@ -91,17 +91,15 @@ No Deno dependency required. The CLI reads hook data from stdin and writes direc
 
 ### Codex
 
-Script [`examples/notify/codex.ts`](examples/notify/codex.ts)
-
 `~/.codex/config.toml`
 
 ```toml
 notify = [
-  "/path/to/notify/codex.ts",
+  "agentoast hook codex",
 ]
 ```
 
-Update the path to match where you saved the script.
+No Deno dependency required. The CLI reads hook data from the last command-line argument and writes directly to the notification database. See [`examples/notify/codex.ts`](examples/notify/codex.ts) for a Deno-based alternative.
 
 ### opencode
 
@@ -238,6 +236,18 @@ Editor resolution priority is `config.toml` `editor` field → `$EDITOR` → `vi
 # Events that auto-focus the terminal (default: none)
 # These events set force_focus=true, causing silent terminal focus without toast (when not muted)
 # focus_events = []
+
+# Codex hook settings
+[hook.codex]
+# Events that trigger notifications
+# Available: agent-turn-complete
+# events = ["agent-turn-complete"]
+
+# Events that auto-focus the terminal (default: none)
+# focus_events = []
+
+# Include last-assistant-message as notification body (default: true, truncated to 200 chars)
+# include_body = true
 ```
 
 ### Keyboard Shortcuts

--- a/crates/agentoast-cli/tests/hook_codex.rs
+++ b/crates/agentoast-cli/tests/hook_codex.rs
@@ -1,0 +1,302 @@
+use std::process::{Command, Output, Stdio};
+
+use agentoast_shared::db;
+
+fn run_hook_codex(json: &str, data_dir: &std::path::Path, config_dir: &std::path::Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_agentoast"))
+        .args(["hook", "codex", json])
+        .env("XDG_DATA_HOME", data_dir)
+        .env("XDG_CONFIG_HOME", config_dir)
+        .env_remove("TMUX_PANE")
+        .env_remove("__CFBundleIdentifier")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn agentoast")
+        .wait_with_output()
+        .expect("Failed to wait for output")
+}
+
+fn setup_db(data_dir: &std::path::Path) {
+    let db_path = data_dir.join("agentoast").join("notifications.db");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+    let _conn = db::open(&db_path).unwrap();
+}
+
+fn get_notifications(data_dir: &std::path::Path) -> Vec<agentoast_shared::models::Notification> {
+    let db_path = data_dir.join("agentoast").join("notifications.db");
+    let conn = db::open_reader(&db_path).unwrap();
+    db::get_notifications(&conn, 100).unwrap()
+}
+
+fn write_config(config_dir: &std::path::Path, content: &str) {
+    let config_path = config_dir.join("agentoast").join("config.toml");
+    std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    std::fs::write(config_path, content).unwrap();
+}
+
+#[test]
+fn agent_turn_complete_event() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    let json = serde_json::json!({
+        "type": "agent-turn-complete",
+        "thread-id": "test-thread",
+        "turn-id": "test-turn",
+        "cwd": env!("CARGO_MANIFEST_DIR"),
+        "input-messages": ["test message"],
+        "last-assistant-message": "Task completed successfully"
+    })
+    .to_string();
+
+    let output = run_hook_codex(&json, data_dir.path(), config_dir.path());
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let result: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(result["success"], true);
+
+    let notifications = get_notifications(data_dir.path());
+    assert_eq!(notifications.len(), 1);
+    assert_eq!(notifications[0].badge, "Stop");
+    assert_eq!(notifications[0].badge_color, "green");
+    assert_eq!(notifications[0].icon, "codex");
+    assert_eq!(notifications[0].body, "Task completed successfully");
+    assert!(!notifications[0].force_focus);
+}
+
+#[test]
+fn invalid_json() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    let output = run_hook_codex("not valid json{", data_dir.path(), config_dir.path());
+    assert!(
+        output.status.success(),
+        "should exit 0 even on invalid JSON"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let result: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(result["success"], false);
+    assert!(result["error"]
+        .as_str()
+        .unwrap()
+        .contains("Failed to parse JSON"));
+
+    let notifications = get_notifications(data_dir.path());
+    assert!(notifications.is_empty());
+}
+
+#[test]
+fn event_filtered_by_config() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    write_config(
+        config_dir.path(),
+        r#"
+[hook.codex]
+events = []
+"#,
+    );
+
+    let json = serde_json::json!({
+        "type": "agent-turn-complete",
+        "cwd": env!("CARGO_MANIFEST_DIR")
+    })
+    .to_string();
+
+    let output = run_hook_codex(&json, data_dir.path(), config_dir.path());
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let result: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(result["success"], true);
+
+    let notifications = get_notifications(data_dir.path());
+    assert!(
+        notifications.is_empty(),
+        "agent-turn-complete should be filtered out when events is empty"
+    );
+}
+
+#[test]
+fn focus_events_config() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    write_config(
+        config_dir.path(),
+        r#"
+[hook.codex]
+focus_events = ["agent-turn-complete"]
+"#,
+    );
+
+    let json = serde_json::json!({
+        "type": "agent-turn-complete",
+        "cwd": env!("CARGO_MANIFEST_DIR")
+    })
+    .to_string();
+
+    let output = run_hook_codex(&json, data_dir.path(), config_dir.path());
+    assert!(output.status.success());
+
+    let notifications = get_notifications(data_dir.path());
+    assert_eq!(notifications.len(), 1);
+    assert!(
+        notifications[0].force_focus,
+        "agent-turn-complete should have force_focus=true"
+    );
+}
+
+#[test]
+fn git_info_from_cwd() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    let json = serde_json::json!({
+        "type": "agent-turn-complete",
+        "cwd": workspace_root.to_str().unwrap()
+    })
+    .to_string();
+
+    let output = run_hook_codex(&json, data_dir.path(), config_dir.path());
+    assert!(output.status.success());
+
+    let notifications = get_notifications(data_dir.path());
+    assert_eq!(notifications.len(), 1);
+    assert!(
+        notifications[0].metadata.contains_key("branch"),
+        "metadata should contain branch info when cwd is a git repo"
+    );
+}
+
+#[test]
+fn missing_cwd() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    let json = serde_json::json!({
+        "type": "agent-turn-complete"
+    })
+    .to_string();
+
+    let output = run_hook_codex(&json, data_dir.path(), config_dir.path());
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let result: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(result["success"], true);
+
+    let notifications = get_notifications(data_dir.path());
+    assert_eq!(notifications.len(), 1);
+    assert_eq!(notifications[0].repo, "");
+}
+
+#[test]
+fn body_truncation() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    let long_message = "a".repeat(500);
+    let json = serde_json::json!({
+        "type": "agent-turn-complete",
+        "cwd": env!("CARGO_MANIFEST_DIR"),
+        "last-assistant-message": long_message
+    })
+    .to_string();
+
+    let output = run_hook_codex(&json, data_dir.path(), config_dir.path());
+    assert!(output.status.success());
+
+    let notifications = get_notifications(data_dir.path());
+    assert_eq!(notifications.len(), 1);
+    assert!(
+        notifications[0].body.len() <= 203, // 200 + "..."
+        "body should be truncated to ~200 chars, got {}",
+        notifications[0].body.len()
+    );
+    assert!(notifications[0].body.ends_with("..."));
+}
+
+#[test]
+fn include_body_false() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    write_config(
+        config_dir.path(),
+        r#"
+[hook.codex]
+include_body = false
+"#,
+    );
+
+    let json = serde_json::json!({
+        "type": "agent-turn-complete",
+        "cwd": env!("CARGO_MANIFEST_DIR"),
+        "last-assistant-message": "This should not appear"
+    })
+    .to_string();
+
+    let output = run_hook_codex(&json, data_dir.path(), config_dir.path());
+    assert!(output.status.success());
+
+    let notifications = get_notifications(data_dir.path());
+    assert_eq!(notifications.len(), 1);
+    assert_eq!(
+        notifications[0].body, "",
+        "body should be empty when include_body=false"
+    );
+}
+
+#[test]
+fn tmux_pane_from_env() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    let json = serde_json::json!({
+        "type": "agent-turn-complete",
+        "cwd": env!("CARGO_MANIFEST_DIR")
+    })
+    .to_string();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_agentoast"))
+        .args(["hook", "codex", &json])
+        .env("XDG_DATA_HOME", data_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .env("TMUX_PANE", "%42")
+        .env_remove("__CFBundleIdentifier")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn agentoast")
+        .wait_with_output()
+        .expect("Failed to wait for output");
+
+    assert!(output.status.success());
+
+    let notifications = get_notifications(data_dir.path());
+    assert_eq!(notifications.len(), 1);
+    assert_eq!(notifications[0].tmux_pane, "%42");
+}

--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -333,14 +333,8 @@ events = ["agent-turn-complete"]
 focus_events = ["agent-turn-complete"]
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(
-            config.hook.codex.events,
-            vec!["agent-turn-complete"]
-        );
-        assert_eq!(
-            config.hook.codex.focus_events,
-            vec!["agent-turn-complete"]
-        );
+        assert_eq!(config.hook.codex.events, vec!["agent-turn-complete"]);
+        assert_eq!(config.hook.codex.focus_events, vec!["agent-turn-complete"]);
         assert!(config.hook.codex.include_body);
     }
 

--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -110,6 +110,8 @@ fn default_toggle_panel() -> String {
 pub struct HookConfig {
     #[serde(default)]
     pub claude: ClaudeHookConfig,
+    #[serde(default)]
+    pub codex: CodexHookConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -127,6 +129,34 @@ impl Default for ClaudeHookConfig {
             focus_events: Vec::new(),
         }
     }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CodexHookConfig {
+    #[serde(default = "default_codex_events")]
+    pub events: Vec<String>,
+    #[serde(default)]
+    pub focus_events: Vec<String>,
+    #[serde(default = "default_true")]
+    pub include_body: bool,
+}
+
+impl Default for CodexHookConfig {
+    fn default() -> Self {
+        Self {
+            events: default_codex_events(),
+            focus_events: Vec::new(),
+            include_body: true,
+        }
+    }
+}
+
+fn default_codex_events() -> Vec<String> {
+    vec!["agent-turn-complete".to_string()]
+}
+
+fn default_true() -> bool {
+    true
 }
 
 fn default_claude_events() -> Vec<String> {
@@ -215,6 +245,18 @@ fn default_config_template() -> &'static str {
 # These events set force_focus=true, causing silent terminal focus without toast (when not muted)
 # focus_events = []
 
+# Codex hook settings
+[hook.codex]
+# Events that trigger notifications
+# Available: agent-turn-complete
+# events = ["agent-turn-complete"]
+
+# Events that auto-focus the terminal (default: none)
+# focus_events = []
+
+# Include last-assistant-message as notification body (default: true, truncated to 200 chars)
+# include_body = true
+
 "#
 }
 
@@ -273,6 +315,44 @@ focus_events = ["Stop", "permission_prompt"]
         );
         // Events should still have defaults (4 without idle_prompt)
         assert_eq!(config.hook.claude.events.len(), 4);
+    }
+
+    #[test]
+    fn default_codex_hook_config() {
+        let config = CodexHookConfig::default();
+        assert_eq!(config.events, vec!["agent-turn-complete"]);
+        assert!(config.focus_events.is_empty());
+        assert!(config.include_body);
+    }
+
+    #[test]
+    fn parse_codex_events() {
+        let toml_str = r#"
+[hook.codex]
+events = ["agent-turn-complete"]
+focus_events = ["agent-turn-complete"]
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.hook.codex.events,
+            vec!["agent-turn-complete"]
+        );
+        assert_eq!(
+            config.hook.codex.focus_events,
+            vec!["agent-turn-complete"]
+        );
+        assert!(config.hook.codex.include_body);
+    }
+
+    #[test]
+    fn parse_codex_include_body_false() {
+        let toml_str = r#"
+[hook.codex]
+include_body = false
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert!(!config.hook.codex.include_body);
+        assert_eq!(config.hook.codex.events, vec!["agent-turn-complete"]);
     }
 
     #[test]

--- a/examples/notify/codex.ts
+++ b/examples/notify/codex.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env -S deno run --allow-run --allow-env --allow-read
+// NOTE: `agentoast hook codex` is the recommended approach (no Deno dependency).
+// This script is kept as a reference implementation.
 
 interface CodexPayload {
   type: string


### PR DESCRIPTION
## Summary

- Add built-in `agentoast hook codex` CLI subcommand that reads Codex hook JSON from the last CLI argument and writes directly to the SQLite DB, eliminating the Deno dependency
- Add `[hook.codex]` config section with `events`, `focus_events`, and `include_body` options
- Badge mapped to "Stop" / green (consistent with Claude Code's Stop event)
- `last-assistant-message` included as body text (truncated to 200 chars), configurable via `include_body = false`

## Changes

- `crates/agentoast-shared/src/config.rs` — `CodexHookConfig` struct, default config template, unit tests
- `crates/agentoast-cli/src/main.rs` — `HookAgent::Codex` variant, `CodexHookData`, `run_codex_hook()` / `handle_codex_hook()`
- `crates/agentoast-cli/tests/hook_codex.rs` — 9 integration tests
- `README.md` — Updated Codex section to recommend native hook
- `examples/notify/codex.ts` — Added reference implementation note
