### PR TITLE
fix: change agent status sort priority to waiting > running > idle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -166,7 +166,7 @@ export function App() {
       });
     }
 
-    // Sort: notifications first (createdAt desc), then by agent status (waiting > idle > running > none), then alphabetically
+    // Sort: notifications first (createdAt desc), then by agent status (waiting > running > idle > none), then alphabetically
     result.sort((a, b) => {
       const aLatestTime = getLatestTime(a);
       const bLatestTime = getLatestTime(b);
@@ -580,8 +580,8 @@ function getGroupAgentPriority(ug: UnifiedGroup): number {
   for (const pi of ug.paneItems) {
     const s = pi.pane.agentStatus;
     if (s === "waiting" && best > 1) best = 1;
-    else if (s === "idle" && best > 2) best = 2;
-    else if (s === "running" && best > 3) best = 3;
+    else if (s === "running" && best > 2) best = 2;
+    else if (s === "idle" && best > 3) best = 3;
   }
   return best;
 }

--- a/src/hooks/use-sessions.ts
+++ b/src/hooks/use-sessions.ts
@@ -51,14 +51,6 @@ export function useSessions() {
     };
   }, [refresh]);
 
-  useEffect(() => {
-    const unlisten = listen("notifications:new", () => {
-      void refresh();
-    });
-    return () => {
-      unlisten.then((f) => f()).catch(() => {});
-    };
-  }, [refresh]);
 
   return { groups, loading, error, refresh, fetchVersion };
 }


### PR DESCRIPTION
## Summary

- Change agent status sort priority from `waiting > idle > running > none` to `waiting > running > idle > none` so groups with running agents appear above idle-only groups
- Remove `notifications:new` event listener from `useSessions` to comply with `keyboard-navigation-performance.md` rules (session data updates limited to mount + `notifications:refresh` only)

## Changed files

- `src/App.tsx`: Update `getGroupAgentPriority()` to swap idle/running priority, fix sort comment
- `src/hooks/use-sessions.ts`: Remove `notifications:new` listener


