### PR TITLE
fix: sort panes within group by agent status priority

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -154,7 +154,8 @@ export function App() {
 
     const result = Array.from(map.values());
 
-    // Sort panes within each group: notified panes first (latest notification on top)
+    // Sort panes within each group: notified panes first (latest notification on top),
+    // then by agent status priority (waiting > running > idle > none)
     for (const ug of result) {
       ug.paneItems.sort((a, b) => {
         if (a.notification && b.notification) {
@@ -162,6 +163,11 @@ export function App() {
         }
         if (a.notification && !b.notification) return -1;
         if (!a.notification && b.notification) return 1;
+
+        const aPri = getPaneAgentPriority(a);
+        const bPri = getPaneAgentPriority(b);
+        if (aPri !== bPri) return aPri - bPri;
+
         return 0;
       });
     }
@@ -573,6 +579,14 @@ function getLatestTime(ug: UnifiedGroup): string | null {
     }
   }
   return latest;
+}
+
+function getPaneAgentPriority(pi: PaneItem): number {
+  const s = pi.pane.agentStatus;
+  if (s === "waiting") return 1;
+  if (s === "running") return 2;
+  if (s === "idle") return 3;
+  return 4;
 }
 
 function getGroupAgentPriority(ug: UnifiedGroup): number {


### PR DESCRIPTION
## Summary

- Add agent status priority sorting (waiting > running > idle > none) for panes within a group
- Fix panes without notifications being displayed in arbitrary order, causing running panes to appear between idle panes

## Changes

- `src/App.tsx`: Add `getPaneAgentPriority()` as a secondary sort criterion in within-group pane sorting
- `src/App.tsx`: Add `getPaneAgentPriority()` helper function (same priority mapping as existing `getGroupAgentPriority()`, applied per-pane)

## Sort Order

1. Panes with notifications (by `createdAt` descending)
2. No notification + waiting
3. No notification + running
4. No notification + idle
5. No notification + none

