### PR TITLE
feat: add `agentoast hook opencode` CLI subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,13 @@ brew uninstall shuntaka9576/tap/agentoast-cli
 
 ## Usage
 
-Integration samples for each agent are in [`examples/notify/`](examples/notify/). Claude Code and Codex use built-in CLI subcommands (`agentoast hook claude` / `agentoast hook codex`). opencode uses its plugin system.
+### Notification
 
-### Claude Code
+#### Integration
+
+Ready-to-use integration scripts are provided for each agent. All agents use built-in CLI subcommands (`agentoast hook claude` / `agentoast hook codex` / `agentoast hook opencode`). opencode uses its [plugin system](https://opencode.ai/docs/plugins) to receive events, then delegates to the CLI subcommand. See [`examples/notify/`](examples/notify/) for source code.
+
+##### Claude Code
 
 `~/.claude/settings.json`
 
@@ -89,7 +93,7 @@ Integration samples for each agent are in [`examples/notify/`](examples/notify/)
 
 No Deno dependency required. The CLI reads hook data from stdin and writes directly to the notification database. See [`examples/notify/claude.ts`](examples/notify/claude.ts) for a Deno-based alternative.
 
-### Codex
+##### Codex
 
 `~/.codex/config.toml`
 
@@ -101,11 +105,9 @@ notify = [
 
 No Deno dependency required. The CLI reads hook data from the last command-line argument and writes directly to the notification database. See [`examples/notify/codex.ts`](examples/notify/codex.ts) for a Deno-based alternative.
 
-### opencode
+##### opencode
 
-Plugin [`examples/notify/opencode.ts`](examples/notify/opencode.ts)
-
-opencode uses a [plugin system](https://opencode.ai/docs/plugins) rather than hook scripts. Drop the plugin file into `~/.config/opencode/plugins/` and it gets picked up automatically.
+Drop the plugin file into `~/.config/opencode/plugins/` and it gets picked up automatically. The plugin forwards all events to `agentoast hook opencode`. Event filtering and notification mapping are configured in `config.toml` `[hook.opencode]`.
 
 ```bash
 mkdir -p ~/.config/opencode/plugins
@@ -116,11 +118,11 @@ Supported events
 
 | Event | Notification |
 |---|---|
-| `session.status` (idle) | Stop (red) |
+| `session.status` (idle) | Stop (green) |
 | `session.error` | Error (red) |
 | `permission.asked` | Permission (blue) |
 
-### Send Notification
+#### Send Notification
 
 ```bash
 agentoast send \
@@ -179,7 +181,7 @@ opencode
 ```bash
 agentoast send \
   --badge "Stop" \
-  --badge-color red \
+  --badge-color green \
   --icon opencode \
   --repo your-repo \
   --tmux-pane %0 \
@@ -248,6 +250,15 @@ Editor resolution priority is `config.toml` `editor` field → `$EDITOR` → `vi
 
 # Include last-assistant-message as notification body (default: true, truncated to 200 chars)
 # include_body = true
+
+# OpenCode hook settings
+[hook.opencode]
+# Events that trigger notifications
+# Available: session.status (idle only), session.error, permission.asked
+# events = ["session.status", "session.error", "permission.asked"]
+
+# Events that auto-focus the terminal (default: none)
+# focus_events = []
 ```
 
 ### Keyboard Shortcuts

--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -432,10 +432,7 @@ events = ["session.status"]
 focus_events = ["permission.asked"]
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(
-            config.hook.opencode.focus_events,
-            vec!["permission.asked"]
-        );
+        assert_eq!(config.hook.opencode.focus_events, vec!["permission.asked"]);
         assert_eq!(config.hook.opencode.events.len(), 3);
     }
 

--- a/examples/notify/opencode.ts
+++ b/examples/notify/opencode.ts
@@ -3,33 +3,6 @@ import { appendFileSync } from "node:fs"
 const DEBUG_LOG = "/tmp/opencode-notify-debug.log"
 const log = (msg: string) => appendFileSync(DEBUG_LOG, `${new Date().toISOString()} ${msg}\n`)
 
-const ENABLE_FOCUS = false
-
-interface StatusProperties {
-  sessionID: string
-  status: { type: string }
-}
-
-const notify = (
-  eventType: string,
-  properties: Record<string, unknown>,
-): { badge: string; badgeColor: string; focus: boolean } | undefined => {
-  if (eventType === "session.status") {
-    const props = properties as unknown as StatusProperties
-    if (props.status?.type === "idle") {
-      return { badge: "Stop", badgeColor: "red", focus: true }
-    }
-    return undefined
-  }
-  if (eventType === "session.error") {
-    return { badge: "Error", badgeColor: "red", focus: false }
-  }
-  if (eventType === "permission.asked") {
-    return { badge: "Permission", badgeColor: "blue", focus: true }
-  }
-  return undefined
-}
-
 export const NotifyPlugin = async ({
   $,
   directory,
@@ -44,61 +17,19 @@ export const NotifyPlugin = async ({
   }
   directory: string
 }) => {
-  const getGitInfo = async (cwd: string) => {
-    try {
-      const remote = await $`git -C ${cwd} remote get-url origin`.text().catch(() => "")
-      let repoName = ""
-      if (remote.trim()) {
-        const match = remote.trim().match(/[/:]([^/]+?)(?:\.git)?$/)
-        repoName = match ? match[1] : ""
-      }
-      if (!repoName) {
-        repoName = cwd.split("/").pop() || ""
-      }
-      const branchName = await $`git -C ${cwd} branch --show-current`.text().catch(() => "")
-      return { repoName, branchName: branchName.trim() }
-    } catch {
-      return { repoName: cwd.split("/").pop() || "", branchName: "" }
-    }
-  }
-
   return {
     event: async ({ event }: { event: { type: string; properties: Record<string, unknown> } }) => {
       log(`event: ${event.type} props: ${JSON.stringify(event.properties)}`)
-      const config = notify(event.type, event.properties)
-      if (!config) return
-      log(`matched: ${JSON.stringify(config)}`)
 
-      const { repoName, branchName } = await getGitInfo(directory)
-      const tmuxPane = process.env.TMUX_PANE || ""
+      const payload = JSON.stringify({
+        type: event.type,
+        properties: event.properties,
+        directory,
+      })
 
-      const args = [
-        "send",
-        "--badge",
-        config.badge,
-        "--badge-color",
-        config.badgeColor,
-        "--icon",
-        "opencode",
-        "--repo",
-        repoName,
-      ]
-
-      if (tmuxPane) {
-        args.push("--tmux-pane", tmuxPane)
-      }
-
-      if (branchName) {
-        args.push("--meta", `branch=${branchName}`)
-      }
-
-      if (ENABLE_FOCUS && config.focus) {
-        args.push("--focus")
-      }
-
-      log(`agentoast args: ${args.join(" ")}`)
+      log(`agentoast hook opencode: ${payload}`)
       try {
-        await $`agentoast ${args}`.nothrow().quiet()
+        await $`agentoast hook opencode ${payload}`.nothrow().quiet()
         log("agentoast: success")
       } catch (e) {
         log(`agentoast: error ${e}`)


### PR DESCRIPTION
## Summary

- Add `agentoast hook opencode` CLI subcommand for OpenCode integration, matching the existing `agentoast hook claude` / `agentoast hook codex` pattern
- Simplify the OpenCode plugin (`examples/notify/opencode.ts`) to just forward event JSON to the CLI — event filtering, badge mapping, git info resolution, and config are all handled by `config.toml` `[hook.opencode]`
- Restructure README Usage section with `Notification > Integration` hierarchy

## Changes

**`crates/agentoast-shared/src/config.rs`**
- Add `OpenCodeHookConfig` struct with `events` and `focus_events`
- Add `opencode` field to `HookConfig`
- Add `[hook.opencode]` section to default config template
- Add 3 unit tests + extend existing test

**`crates/agentoast-cli/src/main.rs`**
- Add `HookAgent::Opencode` variant (JSON via CLI argument, like Codex)
- Add `OpenCodeHookData` struct with `serde_json::Value` for flexible properties
- Add `run_opencode_hook()` with session.status idle sub-type filtering
- Add `handle_opencode_hook()` with JSON error response

**`examples/notify/opencode.ts`**
- Remove all logic (event filtering, badge mapping, git info, tmux pane)
- Plugin now just forwards `{ type, properties, directory }` to `agentoast hook opencode`

**`README.md`**
- Restructure Usage: add `Notification > Integration` section grouping all agents
- Update opencode section to describe plugin → CLI delegation
- Update badge color from red to green (aligned with Claude/Codex "Stop")
- Add `[hook.opencode]` to config example

