### PR TITLE
feat: rename config sections for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,10 +255,10 @@ Editor resolution priority is `config.toml` `editor` field → `$EDITOR` → `vi
 
 # Keyboard shortcuts
 [keybinding]
-# Shortcut to toggle the notification panel (default: ctrl+alt+n)
+# Shortcut to toggle the notification panel (default: super+ctrl+n)
 # Format: modifier+key (modifiers: ctrl, shift, alt/option, super/cmd)
 # Set to "" to disable
-# toggle_panel = "ctrl+alt+n"
+# toggle_panel = "super+ctrl+n"
 ```
 
 ### Keyboard Shortcuts
@@ -277,7 +277,7 @@ Panel shortcuts (press `?` in the panel to see this list).
 | `Esc` | Close |
 | `?` | Help |
 
-The global shortcut to toggle the panel is `Ctrl+Alt+N` (configurable in `config.toml`).
+The global shortcut to toggle the panel is `Cmd+Ctrl+N` (configurable in `config.toml`).
 
 ### Tips
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ No Deno dependency required. The CLI reads hook data from the last command-line 
 
 ##### opencode
 
-Drop the plugin file into `~/.config/opencode/plugins/` and it gets picked up automatically. The plugin forwards all events to `agentoast hook opencode`. Event filtering and notification mapping are configured in `config.toml` `[hook.opencode]`.
+Drop the plugin file into `~/.config/opencode/plugins/` and it gets picked up automatically. The plugin forwards all events to `agentoast hook opencode`. Event filtering and notification mapping are configured in `config.toml` `[notification.agents.opencode]`.
 
 ```bash
 mkdir -p ~/.config/opencode/plugins
@@ -213,23 +213,16 @@ Editor resolution priority is `config.toml` `editor` field → `$EDITOR` → `vi
 # Keep toast visible until clicked (default: false)
 # persistent = false
 
-# Menu bar notification panel
-[panel]
+# Notification settings
+[notification]
 # Mute all notifications (default: false)
 # muted = false
 
 # Show only groups with notifications (default: false)
 # filter_notified_only = false
 
-# Global keyboard shortcut
-[shortcut]
-# Shortcut to toggle the notification panel (default: ctrl+alt+n)
-# Format: modifier+key (modifiers: ctrl, shift, alt/option, super/cmd)
-# Set to "" to disable
-# toggle_panel = "ctrl+alt+n"
-
-# Claude Code hook settings
-[hook.claude]
+# Claude Code agent settings
+[notification.agents.claude]
 # Events that trigger notifications
 # Available: Stop, permission_prompt, idle_prompt, auth_success, elicitation_dialog
 # idle_prompt is excluded by default (noisy); add it back if you want idle notifications
@@ -239,8 +232,8 @@ Editor resolution priority is `config.toml` `editor` field → `$EDITOR` → `vi
 # These events set force_focus=true, causing silent terminal focus without toast (when not muted)
 # focus_events = []
 
-# Codex hook settings
-[hook.codex]
+# Codex agent settings
+[notification.agents.codex]
 # Events that trigger notifications
 # Available: agent-turn-complete
 # events = ["agent-turn-complete"]
@@ -251,14 +244,21 @@ Editor resolution priority is `config.toml` `editor` field → `$EDITOR` → `vi
 # Include last-assistant-message as notification body (default: true, truncated to 200 chars)
 # include_body = true
 
-# OpenCode hook settings
-[hook.opencode]
+# OpenCode agent settings
+[notification.agents.opencode]
 # Events that trigger notifications
 # Available: session.status (idle only), session.error, permission.asked
 # events = ["session.status", "session.error", "permission.asked"]
 
 # Events that auto-focus the terminal (default: none)
 # focus_events = []
+
+# Keyboard shortcuts
+[keybinding]
+# Shortcut to toggle the notification panel (default: ctrl+alt+n)
+# Format: modifier+key (modifiers: ctrl, shift, alt/option, super/cmd)
+# Set to "" to disable
+# toggle_panel = "ctrl+alt+n"
 ```
 
 ### Keyboard Shortcuts

--- a/crates/agentoast-cli/src/main.rs
+++ b/crates/agentoast-cli/src/main.rs
@@ -221,7 +221,7 @@ fn run_claude_hook() -> Result<(), String> {
         .as_deref()
         .unwrap_or(&data.hook_event_name);
 
-    let hook_config = config::load_config().hook.claude;
+    let hook_config = config::load_config().notification.agents.claude;
 
     if !hook_config.events.iter().any(|e| e == event_key) {
         return Ok(());
@@ -291,7 +291,7 @@ fn run_codex_hook(json_arg: &str) -> Result<(), String> {
     let data: CodexHookData =
         serde_json::from_str(json_arg).map_err(|e| format!("Failed to parse JSON: {}", e))?;
 
-    let hook_config = config::load_config().hook.codex;
+    let hook_config = config::load_config().notification.agents.codex;
 
     if !hook_config.events.iter().any(|e| e == &data.event_type) {
         return Ok(());
@@ -371,7 +371,7 @@ fn run_opencode_hook(json_arg: &str) -> Result<(), String> {
     let data: OpenCodeHookData =
         serde_json::from_str(json_arg).map_err(|e| format!("Failed to parse JSON: {}", e))?;
 
-    let hook_config = config::load_config().hook.opencode;
+    let hook_config = config::load_config().notification.agents.opencode;
 
     if !hook_config.events.iter().any(|e| e == &data.event_type) {
         return Ok(());

--- a/crates/agentoast-cli/tests/hook_claude.rs
+++ b/crates/agentoast-cli/tests/hook_claude.rs
@@ -132,7 +132,7 @@ fn event_filtered_by_config() {
     write_config(
         config_dir.path(),
         r#"
-[hook.claude]
+[notification.agents.claude]
 events = ["Stop"]
 "#,
     );
@@ -169,7 +169,7 @@ fn focus_events_config() {
     write_config(
         config_dir.path(),
         r#"
-[hook.claude]
+[notification.agents.claude]
 focus_events = ["Stop"]
 "#,
     );

--- a/crates/agentoast-cli/tests/hook_codex.rs
+++ b/crates/agentoast-cli/tests/hook_codex.rs
@@ -101,7 +101,7 @@ fn event_filtered_by_config() {
     write_config(
         config_dir.path(),
         r#"
-[hook.codex]
+[notification.agents.codex]
 events = []
 "#,
     );
@@ -135,7 +135,7 @@ fn focus_events_config() {
     write_config(
         config_dir.path(),
         r#"
-[hook.codex]
+[notification.agents.codex]
 focus_events = ["agent-turn-complete"]
 "#,
     );
@@ -245,7 +245,7 @@ fn include_body_false() {
     write_config(
         config_dir.path(),
         r#"
-[hook.codex]
+[notification.agents.codex]
 include_body = false
 "#,
     );

--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -39,11 +39,9 @@ pub struct AppConfig {
     #[serde(default)]
     pub toast: ToastConfig,
     #[serde(default)]
-    pub panel: PanelConfig,
+    pub notification: NotificationConfig,
     #[serde(default)]
-    pub shortcut: ShortcutConfig,
-    #[serde(default)]
-    pub hook: HookConfig,
+    pub keybinding: KeybindingConfig,
     #[serde(default)]
     pub update: UpdateConfig,
 }
@@ -66,18 +64,21 @@ impl Default for ToastConfig {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct PanelConfig {
+pub struct NotificationConfig {
     #[serde(default)]
     pub muted: bool,
     #[serde(default = "default_filter_notified_only")]
     pub filter_notified_only: bool,
+    #[serde(default)]
+    pub agents: AgentsConfig,
 }
 
-impl Default for PanelConfig {
+impl Default for NotificationConfig {
     fn default() -> Self {
         Self {
             muted: false,
             filter_notified_only: default_filter_notified_only(),
+            agents: AgentsConfig::default(),
         }
     }
 }
@@ -91,12 +92,12 @@ fn default_toast_duration() -> u64 {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct ShortcutConfig {
+pub struct KeybindingConfig {
     #[serde(default = "default_toggle_panel")]
     pub toggle_panel: String,
 }
 
-impl Default for ShortcutConfig {
+impl Default for KeybindingConfig {
     fn default() -> Self {
         Self {
             toggle_panel: default_toggle_panel(),
@@ -109,7 +110,7 @@ fn default_toggle_panel() -> String {
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
-pub struct HookConfig {
+pub struct AgentsConfig {
     #[serde(default)]
     pub claude: ClaudeHookConfig,
     #[serde(default)]
@@ -226,21 +227,21 @@ pub fn load_config() -> AppConfig {
     }
 }
 
-/// Update [panel] muted in config.toml, preserving existing comments and formatting.
-pub fn save_panel_muted(muted: bool) -> io::Result<()> {
+/// Update [notification] muted in config.toml, preserving existing comments and formatting.
+pub fn save_notification_muted(muted: bool) -> io::Result<()> {
     let path = config_path();
     let content = std::fs::read_to_string(&path).unwrap_or_default();
     let mut doc: DocumentMut = content.parse().unwrap_or_default();
-    doc["panel"]["muted"] = toml_edit::value(muted);
+    doc["notification"]["muted"] = toml_edit::value(muted);
     std::fs::write(&path, doc.to_string())
 }
 
-/// Update [panel] filter_notified_only in config.toml, preserving existing comments and formatting.
-pub fn save_panel_filter_notified_only(value: bool) -> io::Result<()> {
+/// Update [notification] filter_notified_only in config.toml, preserving existing comments and formatting.
+pub fn save_notification_filter_notified_only(value: bool) -> io::Result<()> {
     let path = config_path();
     let content = std::fs::read_to_string(&path).unwrap_or_default();
     let mut doc: DocumentMut = content.parse().unwrap_or_default();
-    doc["panel"]["filter_notified_only"] = toml_edit::value(value);
+    doc["notification"]["filter_notified_only"] = toml_edit::value(value);
     std::fs::write(&path, doc.to_string())
 }
 
@@ -260,23 +261,16 @@ fn default_config_template() -> &'static str {
 # Keep toast visible until clicked (default: false)
 # persistent = false
 
-# Menu bar notification panel
-[panel]
+# Notification settings
+[notification]
 # Mute all notifications (default: false)
 # muted = false
 
 # Show only groups with notifications (default: false)
 # filter_notified_only = false
 
-# Global keyboard shortcut
-[shortcut]
-# Shortcut to toggle the notification panel (default: ctrl+alt+n)
-# Format: modifier+key (modifiers: ctrl, shift, alt/option, super/cmd)
-# Set to "" to disable
-# toggle_panel = "ctrl+alt+n"
-
-# Claude Code hook settings
-[hook.claude]
+# Claude Code agent settings
+[notification.agents.claude]
 # Events that trigger notifications
 # Available: Stop, permission_prompt, idle_prompt, auth_success, elicitation_dialog
 # idle_prompt is excluded by default (noisy); add it back if you want idle notifications
@@ -286,8 +280,8 @@ fn default_config_template() -> &'static str {
 # These events set force_focus=true, causing silent terminal focus without toast (when not muted)
 # focus_events = []
 
-# Codex hook settings
-[hook.codex]
+# Codex agent settings
+[notification.agents.codex]
 # Events that trigger notifications
 # Available: agent-turn-complete
 # events = ["agent-turn-complete"]
@@ -298,14 +292,21 @@ fn default_config_template() -> &'static str {
 # Include last-assistant-message as notification body (default: true, truncated to 200 chars)
 # include_body = true
 
-# OpenCode hook settings
-[hook.opencode]
+# OpenCode agent settings
+[notification.agents.opencode]
 # Events that trigger notifications
 # Available: session.status (idle only), session.error, permission.asked
 # events = ["session.status", "session.error", "permission.asked"]
 
 # Events that auto-focus the terminal (default: none)
 # focus_events = []
+
+# Keyboard shortcuts
+[keybinding]
+# Shortcut to toggle the notification panel (default: ctrl+alt+n)
+# Format: modifier+key (modifiers: ctrl, shift, alt/option, super/cmd)
+# Set to "" to disable
+# toggle_panel = "ctrl+alt+n"
 
 # Auto-update settings
 [update]
@@ -349,27 +350,27 @@ mod tests {
     #[test]
     fn parse_custom_events() {
         let toml_str = r#"
-[hook.claude]
+[notification.agents.claude]
 events = ["Stop"]
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.hook.claude.events, vec!["Stop"]);
-        assert!(config.hook.claude.focus_events.is_empty());
+        assert_eq!(config.notification.agents.claude.events, vec!["Stop"]);
+        assert!(config.notification.agents.claude.focus_events.is_empty());
     }
 
     #[test]
     fn parse_focus_events() {
         let toml_str = r#"
-[hook.claude]
+[notification.agents.claude]
 focus_events = ["Stop", "permission_prompt"]
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(
-            config.hook.claude.focus_events,
+            config.notification.agents.claude.focus_events,
             vec!["Stop", "permission_prompt"]
         );
         // Events should still have defaults (4 without idle_prompt)
-        assert_eq!(config.hook.claude.events.len(), 4);
+        assert_eq!(config.notification.agents.claude.events.len(), 4);
     }
 
     #[test]
@@ -383,25 +384,34 @@ focus_events = ["Stop", "permission_prompt"]
     #[test]
     fn parse_codex_events() {
         let toml_str = r#"
-[hook.codex]
+[notification.agents.codex]
 events = ["agent-turn-complete"]
 focus_events = ["agent-turn-complete"]
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.hook.codex.events, vec!["agent-turn-complete"]);
-        assert_eq!(config.hook.codex.focus_events, vec!["agent-turn-complete"]);
-        assert!(config.hook.codex.include_body);
+        assert_eq!(
+            config.notification.agents.codex.events,
+            vec!["agent-turn-complete"]
+        );
+        assert_eq!(
+            config.notification.agents.codex.focus_events,
+            vec!["agent-turn-complete"]
+        );
+        assert!(config.notification.agents.codex.include_body);
     }
 
     #[test]
     fn parse_codex_include_body_false() {
         let toml_str = r#"
-[hook.codex]
+[notification.agents.codex]
 include_body = false
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
-        assert!(!config.hook.codex.include_body);
-        assert_eq!(config.hook.codex.events, vec!["agent-turn-complete"]);
+        assert!(!config.notification.agents.codex.include_body);
+        assert_eq!(
+            config.notification.agents.codex.events,
+            vec!["agent-turn-complete"]
+        );
     }
 
     #[test]
@@ -417,38 +427,44 @@ include_body = false
     #[test]
     fn parse_opencode_events() {
         let toml_str = r#"
-[hook.opencode]
+[notification.agents.opencode]
 events = ["session.status"]
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.hook.opencode.events, vec!["session.status"]);
-        assert!(config.hook.opencode.focus_events.is_empty());
+        assert_eq!(
+            config.notification.agents.opencode.events,
+            vec!["session.status"]
+        );
+        assert!(config.notification.agents.opencode.focus_events.is_empty());
     }
 
     #[test]
     fn parse_opencode_focus_events() {
         let toml_str = r#"
-[hook.opencode]
+[notification.agents.opencode]
 focus_events = ["permission.asked"]
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.hook.opencode.focus_events, vec!["permission.asked"]);
-        assert_eq!(config.hook.opencode.events.len(), 3);
+        assert_eq!(
+            config.notification.agents.opencode.focus_events,
+            vec!["permission.asked"]
+        );
+        assert_eq!(config.notification.agents.opencode.events.len(), 3);
     }
 
     #[test]
-    fn parse_empty_hook_section() {
+    fn parse_empty_agents_section() {
         let toml_str = r#"
 [toast]
 duration_ms = 5000
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
-        // Hook.claude should use defaults (4 without idle_prompt)
-        assert_eq!(config.hook.claude.events.len(), 4);
-        assert!(config.hook.claude.focus_events.is_empty());
-        // Hook.opencode should use defaults (3 events)
-        assert_eq!(config.hook.opencode.events.len(), 3);
-        assert!(config.hook.opencode.focus_events.is_empty());
+        // notification.agents.claude should use defaults (4 without idle_prompt)
+        assert_eq!(config.notification.agents.claude.events.len(), 4);
+        assert!(config.notification.agents.claude.focus_events.is_empty());
+        // notification.agents.opencode should use defaults (3 events)
+        assert_eq!(config.notification.agents.opencode.events.len(), 3);
+        assert!(config.notification.agents.opencode.focus_events.is_empty());
     }
 }
 

--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -106,7 +106,7 @@ impl Default for KeybindingConfig {
 }
 
 fn default_toggle_panel() -> String {
-    "ctrl+alt+n".to_string()
+    "super+ctrl+n".to_string()
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -303,10 +303,10 @@ fn default_config_template() -> &'static str {
 
 # Keyboard shortcuts
 [keybinding]
-# Shortcut to toggle the notification panel (default: ctrl+alt+n)
+# Shortcut to toggle the notification panel (default: super+ctrl+n)
 # Format: modifier+key (modifiers: ctrl, shift, alt/option, super/cmd)
 # Set to "" to disable
-# toggle_panel = "ctrl+alt+n"
+# toggle_panel = "super+ctrl+n"
 
 # Auto-update settings
 [update]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,7 +56,7 @@ pub fn do_toggle_global_mute(app_handle: &tauri::AppHandle) -> Result<MuteStateP
     let payload = state.to_payload();
     let _ = app_handle.emit("mute:changed", &payload);
     tray::update_mute_menu(app_handle, payload.global_muted);
-    if let Err(e) = config::save_panel_muted(payload.global_muted) {
+    if let Err(e) = config::save_notification_muted(payload.global_muted) {
         log::warn!("Failed to save mute state to config.toml: {}", e);
     }
     Ok(payload)
@@ -212,7 +212,7 @@ fn toggle_repo_mute(
 #[tauri::command]
 fn get_filter_notified_only(state: tauri::State<'_, Mutex<AppState>>) -> Result<bool, String> {
     let state = state.lock().map_err(|e| e.to_string())?;
-    Ok(state.config.panel.filter_notified_only)
+    Ok(state.config.notification.filter_notified_only)
 }
 
 #[tauri::command]
@@ -222,9 +222,9 @@ fn save_filter_notified_only(
 ) -> Result<(), String> {
     {
         let mut state = state.lock().map_err(|e| e.to_string())?;
-        state.config.panel.filter_notified_only = value;
+        state.config.notification.filter_notified_only = value;
     }
-    if let Err(e) = config::save_panel_filter_notified_only(value) {
+    if let Err(e) = config::save_notification_filter_notified_only(value) {
         log::warn!("Failed to save filter_notified_only to config.toml: {}", e);
     }
     Ok(())
@@ -319,8 +319,8 @@ pub fn run() {
             log::info!("DB path: {:?}", db_path);
             log::info!("Config: {:?}", app_config);
 
-            let shortcut_str = app_config.shortcut.toggle_panel.clone();
-            let initial_muted = app_config.panel.muted;
+            let shortcut_str = app_config.keybinding.toggle_panel.clone();
+            let initial_muted = app_config.notification.muted;
 
             // Ensure DB is initialized
             let _ = db::open(&db_path).expect("Failed to initialize database");


### PR DESCRIPTION
## Summary

- Rename `[panel]` → `[notification]` for clearer semantics
- Rename `[hook.*]` → `[notification.agents.*]` to group agent settings under notification
- Rename `[shortcut]` → `[keybinding]` for more standard naming
- Change default keybinding from `Ctrl+Alt+N` to `Cmd+Ctrl+N` to reduce conflicts with environment automation tools

## Changes

### `crates/agentoast-shared/src/config.rs`
- `PanelConfig` → `NotificationConfig` (with nested `agents: AgentsConfig`)
- `HookConfig` → `AgentsConfig`
- `ShortcutConfig` → `KeybindingConfig`
- `save_panel_muted()` → `save_notification_muted()`
- `save_panel_filter_notified_only()` → `save_notification_filter_notified_only()`
- Default keybinding: `ctrl+alt+n` → `super+ctrl+n`
- Updated default config template and all unit tests

### `src-tauri/src/lib.rs`
- Updated all field access paths (`config.panel.*` → `config.notification.*`, `config.shortcut.*` → `config.keybinding.*`)

### `crates/agentoast-cli/src/main.rs`
- Updated hook config access (`config.hook.*` → `config.notification.agents.*`)

### Tests
- Updated TOML literals in `hook_claude.rs` and `hook_codex.rs`

### `README.md`
- Updated config.toml example to reflect new section names
- Updated default keybinding documentation (`Ctrl+Alt+N` → `Cmd+Ctrl+N`)

## Breaking change

Existing `config.toml` files using old section names will fall back to defaults silently. Users need to update their config manually.