### PR TITLE
revert: remove auto-update support due to Apple notarization stalling

### DIFF
--- a/.github/actions/release-app/action.yaml
+++ b/.github/actions/release-app/action.yaml
@@ -7,34 +7,6 @@ inputs:
   homebrew_tap_token:
     description: "PAT for homebrew-tap repository"
     required: true
-  tauri_signing_private_key:
-    description: "Tauri updater signing private key"
-    required: true
-  tauri_signing_private_key_password:
-    description: "Tauri updater signing private key password"
-    required: false
-    default: ""
-  apple_certificate:
-    description: "Apple Developer ID certificate (base64)"
-    required: true
-  apple_certificate_password:
-    description: "Apple certificate password"
-    required: true
-  apple_signing_identity:
-    description: "Apple signing identity"
-    required: true
-  apple_id:
-    description: "Apple ID for notarization"
-    required: true
-  apple_password:
-    description: "Apple app-specific password"
-    required: true
-  apple_team_id:
-    description: "Apple Developer Team ID"
-    required: true
-  keychain_password:
-    description: "CI keychain password"
-    required: true
 
 runs:
   using: composite
@@ -47,47 +19,10 @@ runs:
   - name: "Install frontend dependencies"
     shell: bash
     run: bun install
-  - name: "Import Apple Developer Certificate"
+  - name: "Build Tauri app"
     shell: bash
-    env:
-      APPLE_CERTIFICATE: ${{ inputs.apple_certificate }}
-      APPLE_CERTIFICATE_PASSWORD: ${{ inputs.apple_certificate_password }}
-      KEYCHAIN_PASSWORD: ${{ inputs.keychain_password }}
-    run: |
-      echo "$APPLE_CERTIFICATE" | base64 --decode > certificate.p12
-      security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
-      security default-keychain -s build.keychain
-      security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
-      security set-keychain-settings -t 3600 -u build.keychain
-      security import certificate.p12 -k build.keychain \
-        -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
-      security set-key-partition-list -S apple-tool:,apple:,codesign: \
-        -s -k "$KEYCHAIN_PASSWORD" build.keychain
-      rm certificate.p12
-  - name: "Build and release with tauri-action"
-    uses: tauri-apps/tauri-action@v0
-    env:
-      GITHUB_TOKEN: ${{ github.token }}
-      TAURI_SIGNING_PRIVATE_KEY: ${{ inputs.tauri_signing_private_key }}
-      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ inputs.tauri_signing_private_key_password }}
-      APPLE_SIGNING_IDENTITY: ${{ inputs.apple_signing_identity }}
-      APPLE_ID: ${{ inputs.apple_id }}
-      APPLE_PASSWORD: ${{ inputs.apple_password }}
-      APPLE_TEAM_ID: ${{ inputs.apple_team_id }}
-    with:
-      tagName: ${{ inputs.tag }}
-      releaseDraft: true
-      includeUpdaterJson: true
-  - name: "Verify updater assets"
-    shell: bash
-    env:
-      GITHUB_TOKEN: ${{ github.token }}
-    run: |
-      TAG="${{ inputs.tag }}"
-      ASSETS=$(gh release view "${TAG}" --json assets --jq '.assets[].name')
-      printf '%s\n' "$ASSETS" | grep -Fxq 'latest.json' || { echo "ERROR: Missing latest.json"; exit 1; }
-      printf '%s\n' "$ASSETS" | grep -Eq '\.sig$' || { echo "ERROR: Missing .sig file"; exit 1; }
-  - name: "Update Homebrew Cask"
+    run: bun run tauri build
+  - name: "Upload DMG and update Cask"
     shell: bash
     env:
       GITHUB_TOKEN: ${{ github.token }}
@@ -96,10 +31,15 @@ runs:
       TAG="${{ inputs.tag }}"
       VERSION="${TAG#v}"
       DMG_NAME="Agentoast_${VERSION}_aarch64.dmg"
+      DMG_PATH="target/release/bundle/dmg/${DMG_NAME}"
 
-      # Download DMG from release to compute SHA256
-      gh release download "${TAG}" --pattern "${DMG_NAME}" --dir /tmp
-      SHA256=$(shasum -a 256 "/tmp/${DMG_NAME}" | awk '{print $1}')
+      echo "Publishing Agentoast app ${TAG}..."
+
+      # Upload DMG to GitHub Release
+      gh release upload "${TAG}" "${DMG_PATH}" --clobber
+
+      # Update Cask via GitHub Contents API (use GH_PAT for cross-repo access)
+      SHA256=$(shasum -a 256 "${DMG_PATH}" | awk '{print $1}')
       DMG_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/${DMG_NAME}"
 
       CASK_CONTENT=$(cat <<CASK_EOF
@@ -112,7 +52,6 @@ runs:
         desc "macOS menu bar notification app for AI coding agents"
         homepage "https://github.com/${{ github.repository }}"
 
-        auto_updates true
         app "Agentoast.app"
 
         zap trash: [

--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -71,15 +71,6 @@ jobs:
       with:
         tag: ${{ needs.tagpr.outputs.tag }}
         homebrew_tap_token: ${{ steps.app-token.outputs.token }}
-        tauri_signing_private_key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-        tauri_signing_private_key_password: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        apple_certificate: ${{ secrets.APPLE_CERTIFICATE }}
-        apple_certificate_password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        apple_signing_identity: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-        apple_id: ${{ secrets.APPLE_ID }}
-        apple_password: ${{ secrets.APPLE_PASSWORD }}
-        apple_team_id: ${{ secrets.APPLE_TEAM_ID }}
-        keychain_password: ${{ secrets.KEYCHAIN_PASSWORD }}
 
   publish-release:
     needs: [tagpr, release-cli, release-app]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,14 +27,11 @@ dependencies = [
  "objc2-quartz-core",
  "objc2-web-kit",
  "serde",
- "serde_json",
  "tauri",
  "tauri-build",
  "tauri-nspanel",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-opener",
- "tauri-plugin-process",
- "tauri-plugin-updater",
 ]
 
 [[package]]
@@ -148,15 +145,6 @@ name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
-
-[[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
 
 [[package]]
 name = "async-broadcast"
@@ -805,17 +793,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.115",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,17 +1084,6 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1743,22 +1709,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.27.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,7 +2183,6 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall 0.7.1",
 ]
 
 [[package]]
@@ -2331,12 +2280,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minisign-verify"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e856fdd13623a2f5f2f54676a4ee49502a96a80ef4a62bcedd23d52427c44d43"
 
 [[package]]
 name = "miniz_oxide"
@@ -2675,18 +2618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-osa-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
-dependencies = [
- "bitflags 2.10.0",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
-]
-
-[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2767,12 +2698,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,20 +2711,6 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
-]
-
-[[package]]
-name = "osakit"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
-dependencies = [
- "objc2",
- "objc2-foundation",
- "objc2-osa-kit",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2851,7 +2762,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -3332,15 +3243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
-dependencies = [
- "bitflags 2.10.0",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3414,20 +3316,15 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3437,20 +3334,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3501,79 +3384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.23.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
-dependencies = [
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3586,15 +3396,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3653,29 +3454,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "3.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "selectors"
@@ -3945,7 +3723,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -4026,12 +3804,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -4148,17 +3920,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.115",
-]
-
-[[package]]
-name = "tar"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
 ]
 
 [[package]]
@@ -4346,49 +4107,6 @@ dependencies = [
  "url",
  "windows",
  "zbus",
-]
-
-[[package]]
-name = "tauri-plugin-process"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
-dependencies = [
- "tauri",
- "tauri-plugin",
-]
-
-[[package]]
-name = "tauri-plugin-updater"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe8e9bebd88fc222938ffdfbdcfa0307081423bd01e3252fc337d8bde81fc61"
-dependencies = [
- "base64 0.22.1",
- "dirs",
- "flate2",
- "futures-util",
- "http",
- "infer",
- "log",
- "minisign-verify",
- "osakit",
- "percent-encoding",
- "reqwest",
- "rustls",
- "semver",
- "serde",
- "serde_json",
- "tar",
- "tauri",
- "tauri-plugin",
- "tempfile",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "url",
- "windows-sys 0.60.2",
- "zip",
 ]
 
 [[package]]
@@ -4609,16 +4327,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
 ]
 
 [[package]]
@@ -4953,12 +4661,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5218,15 +4920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5454,15 +5147,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5820,16 +5504,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix",
-]
-
-[[package]]
 name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5961,12 +5635,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-
-[[package]]
 name = "zerotrie"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5997,18 +5665,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.115",
-]
-
-[[package]]
-name = "zip"
-version = "4.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
-dependencies = [
- "arbitrary",
- "crc32fast",
- "indexmap 2.13.0",
- "memchr",
 ]
 
 [[package]]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -110,7 +110,7 @@ gh release upload "${TAG}" "target/release/bundle/dmg/${DMG_NAME}" --clobber
 
 # 3. Update Cask via GitHub Contents API
 SHA256=$(shasum -a 256 "target/release/bundle/dmg/${DMG_NAME}" | awk '{print $1}')
-DMG_URL="https://github.com/shuntaka9576/agentoast/releases/download/${TAG}/${DMG_NAME}"
+DMG_URL="https://github.com/shuntaka9576/agent-notify/releases/download/${TAG}/${DMG_NAME}"
 
 CASK_CONTENT=$(cat <<CASK_EOF
 cask "agentoast" do
@@ -120,9 +120,8 @@ cask "agentoast" do
   url "${DMG_URL}"
   name "Agentoast"
   desc "macOS menu bar notification app for AI coding agents"
-  homepage "https://github.com/shuntaka9576/agentoast"
+  homepage "https://github.com/shuntaka9576/agent-notify"
 
-  auto_updates true
   app "Agentoast.app"
 
   zap trash: [
@@ -147,35 +146,6 @@ else
     --method PUT \
     -f message="Add agentoast cask ${TAG}" \
     -f content="${ENCODED}"
-fi
-
-# Upload updater artifacts (if available from signed build)
-TAR_GZ="target/release/bundle/macos/Agentoast.app.tar.gz"
-SIG_FILE="target/release/bundle/macos/Agentoast.app.tar.gz.sig"
-
-if [ -f "${TAR_GZ}" ] && [ -f "${SIG_FILE}" ]; then
-  gh release upload "${TAG}" "${TAR_GZ}" "${SIG_FILE}" --clobber
-
-  SIGNATURE=$(cat "${SIG_FILE}")
-  TAR_GZ_URL="https://github.com/shuntaka9576/agentoast/releases/download/${TAG}/Agentoast.app.tar.gz"
-
-  cat > /tmp/latest.json <<EOF
-{
-  "version": "${VERSION}",
-  "notes": "Release ${TAG}",
-  "pub_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "platforms": {
-    "darwin-aarch64": {
-      "signature": "${SIGNATURE}",
-      "url": "${TAR_GZ_URL}"
-    }
-  }
-}
-EOF
-
-  gh release upload "${TAG}" /tmp/latest.json --clobber
-  rm /tmp/latest.json
-  echo "Uploaded updater artifacts"
 fi
 
 echo "Done! Published ${TAG}"

--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -42,8 +42,6 @@ pub struct AppConfig {
     pub notification: NotificationConfig,
     #[serde(default)]
     pub keybinding: KeybindingConfig,
-    #[serde(default)]
-    pub update: UpdateConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -189,18 +187,6 @@ fn default_true() -> bool {
     true
 }
 
-#[derive(Debug, Clone, Deserialize)]
-pub struct UpdateConfig {
-    #[serde(default = "default_true")]
-    pub enabled: bool,
-}
-
-impl Default for UpdateConfig {
-    fn default() -> Self {
-        Self { enabled: true }
-    }
-}
-
 fn default_claude_events() -> Vec<String> {
     vec![
         "Stop".to_string(),
@@ -307,11 +293,6 @@ fn default_config_template() -> &'static str {
 # Format: modifier+key (modifiers: ctrl, shift, alt/option, super/cmd)
 # Set to "" to disable
 # toggle_panel = "super+ctrl+n"
-
-# Auto-update settings
-[update]
-# Enable auto-update check (default: true)
-# enabled = true
 
 "#
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,8 +16,6 @@ agentoast-shared = { path = "../crates/agentoast-shared" }
 tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
 tauri-plugin-global-shortcut = "2"
-tauri-plugin-updater = "2"
-tauri-plugin-process = "2"
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
 log = "0.4"
 env_logger = "0.11"
@@ -25,7 +23,6 @@ fern = "0.7"
 humantime = "2"
 notify = "8"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,8 +12,6 @@
     "core:window:allow-inner-size",
     "core:window:allow-scale-factor",
     "opener:default",
-    "global-shortcut:default",
-    "updater:default",
-    "process:allow-restart"
+    "global-shortcut:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -231,12 +231,6 @@ fn save_filter_notified_only(
 }
 
 #[tauri::command]
-fn get_update_enabled(state: tauri::State<'_, Mutex<AppState>>) -> Result<bool, String> {
-    let state = state.lock().map_err(|e| e.to_string())?;
-    Ok(state.config.update.enabled)
-}
-
-#[tauri::command]
 fn delete_all_notifications(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, Mutex<AppState>>,
@@ -284,7 +278,6 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_nspanel::init())
-        .plugin(tauri_plugin_process::init())
         .invoke_handler(tauri::generate_handler![
             init_panel,
             hide_panel,
@@ -298,7 +291,6 @@ pub fn run() {
             delete_notifications_by_pane,
             delete_notifications_by_panes,
             delete_all_notifications,
-            get_update_enabled,
             get_filter_notified_only,
             save_filter_notified_only,
             get_mute_state,
@@ -374,10 +366,6 @@ pub fn run() {
             } else {
                 log::info!("Global shortcut disabled (empty string in config)");
             }
-
-            // Register updater plugin
-            app.handle()
-                .plugin(tauri_plugin_updater::Builder::new().build())?;
 
             // Initialize native toast panel
             #[cfg(target_os = "macos")]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,15 +39,6 @@
     "resources": [
       "icons/tray-icon.png",
       "icons/tray-icon-notification.png"
-    ],
-    "createUpdaterArtifacts": true
-  },
-  "plugins": {
-    "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IERGNTU5Q0FGNEZDODM4MDEKUldRQk9NaFByNXhWMzVWckRYOTJ6bTNtSXVNRmRoS0VvMEhKbG84bnFXUDhSTG43YXdMTi9kTXAK",
-      "endpoints": [
-        "https://github.com/shuntaka9576/agentoast/releases/latest/download/latest.json"
-      ]
-    }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Revert commit 47b8f62 (feat: add auto-update support with Apple signing and tauri-action CI #51)
- Apple notarization (`xcrun notarytool submit --wait`) stalls for 3+ hours on CI, blocking releases
- Removes `tauri-plugin-updater`, `tauri-plugin-process`, Apple signing CI steps, and frontend update UI
- Will re-add once Apple notarization issue is resolved
