### PR TITLE
fix: unify waiting_reason 'ask' and 'approve' into 'respond'

### DIFF
--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -420,14 +420,14 @@ fn detect_claude_status(
         // Elicitation dialog ("Enter to select" detected) — always Waiting.
         // Checked before at_prompt because elicitation option description text
         // (indented continuation lines) causes is_prompt_line() to return false.
-        (AgentStatus::Waiting, Some("ask".to_string()))
+        (AgentStatus::Waiting, Some("respond".to_string()))
     } else if info.has_selection_dialog && !info.at_prompt {
         // Selection dialog without "Enter to select" (e.g., plan approval).
         // Detected via ❯ N. selection cursor + 2+ numbered options.
         // Only valid when no prompt is detected — if at_prompt is true, the user
         // has already completed the selection and the dialog text is just stale
         // content still visible on screen.
-        (AgentStatus::Waiting, Some("approve".to_string()))
+        (AgentStatus::Waiting, Some("respond".to_string()))
     } else if info.at_prompt {
         if let Some(conn) = db_conn {
             if let Ok(Some(_)) = db::get_latest_notification_by_pane(conn, pane_id) {
@@ -989,7 +989,7 @@ fn detect_opencode_status(
     let (status, waiting_reason) = if info.is_running {
         (AgentStatus::Running, None)
     } else if info.has_permission_dialog || info.has_selection_dialog {
-        (AgentStatus::Waiting, Some("approve".to_string()))
+        (AgentStatus::Waiting, Some("respond".to_string()))
     } else {
         // No running signal — check DB for pending notifications
         if let Some(conn) = db_conn {

--- a/src/components/pane-card.tsx
+++ b/src/components/pane-card.tsx
@@ -34,8 +34,8 @@ function statusTooltip(pane: TmuxPane): string {
     case "idle":
       return `${agent}: idle${modeStr}`;
     case "waiting": {
-      const reasonStr = pane.waitingReason ? ` (${pane.waitingReason})` : "";
-      return `${agent}: waiting for input${reasonStr}${modeStr}`;
+      const label = pane.waitingReason ? "waiting for response" : "waiting for input";
+      return `${agent}: ${label}${modeStr}`;
     }
     default:
       return agent;


### PR DESCRIPTION
## Summary

- Unify `waitingReason` values `"ask"` (elicitation dialog) and `"approve"` (selection dialog) into a single `"respond"` label
- Both represent the same user-facing state: the agent needs user input to proceed, so the distinction added no value
- Simplify tooltip text: `"waiting for response"` when reason is present, `"waiting for input"` when waiting due to DB notification only

## Changed files

- `src-tauri/src/sessions.rs` — Replace `"ask"` and `"approve"` with `"respond"` (3 locations: Claude Code elicitation, Claude Code selection dialog, OpenCode permission/selection dialog)
- `src/components/pane-card.tsx` — Update tooltip to remove redundant parenthetical reason text


