### PR TITLE
fix: emit notifications:refresh on notification deletion to update agent status dots

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -146,6 +146,7 @@ fn delete_notification(
         let _ = app_handle.emit("notifications:unread-count", count);
         watcher::update_tray_icon(&app_handle, count);
     }
+    let _ = app_handle.emit("notifications:refresh", ());
     Ok(())
 }
 
@@ -162,6 +163,7 @@ fn delete_notifications_by_pane(
         let _ = app_handle.emit("notifications:unread-count", count);
         watcher::update_tray_icon(&app_handle, count);
     }
+    let _ = app_handle.emit("notifications:refresh", ());
     Ok(())
 }
 
@@ -178,6 +180,7 @@ fn delete_notifications_by_panes(
         let _ = app_handle.emit("notifications:unread-count", count);
         watcher::update_tray_icon(&app_handle, count);
     }
+    let _ = app_handle.emit("notifications:refresh", ());
     Ok(())
 }
 
@@ -240,6 +243,7 @@ fn delete_all_notifications(
     db::delete_all_notifications(&conn).map_err(|e| e.to_string())?;
     let _ = app_handle.emit("notifications:unread-count", 0i64);
     watcher::update_tray_icon(&app_handle, 0);
+    let _ = app_handle.emit("notifications:refresh", ());
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Emit `notifications:refresh` event in all four notification deletion commands (`delete_notification`, `delete_notifications_by_pane`, `delete_notifications_by_panes`, `delete_all_notifications`)
- Fix stale amber status dot when deleting a notification-only Waiting pane (`at_prompt` + DB notification). Previously, sessions data was not refreshed after deletion, so the amber dot persisted until the panel was reopened.

 