### PR TITLE
fix: regenerate updater signing keypair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## [v0.20.0](https://github.com/shuntaka9576/agentoast/compare/v0.19.0...v0.20.0) - 2026-02-23
-- feat: re-add auto-update support with Apple signing and tauri-action CI by @shuntaka9576 in https://github.com/shuntaka9576/agentoast/pull/60
-
 ## [v0.19.0](https://github.com/shuntaka9576/agentoast/compare/v0.18.1...v0.19.0) - 2026-02-23
 - fix: unify waiting_reason 'ask' and 'approve' into 'respond' by @shuntaka9576 in https://github.com/shuntaka9576/agentoast/pull/64
 - feat: detect Codex question dialog and plan approval as Waiting by @shuntaka9576 in https://github.com/shuntaka9576/agentoast/pull/66

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,7 +44,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IERGNTU5Q0FGNEZDODM4MDEKUldRQk9NaFByNXhWMzVWckRYOTJ6bTNtSXVNRmRoS0VvMEhKbG84bnFXUDhSTG43YXdMTi9kTXAK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDA2MjFGMkExNTUwM0ZDOEYKUldTUC9BTlZvZkloQm5qU0JUTWRqbFZhZWZ0b2tLN0czTHo3RTJaZWpzM2NTSWVmRmdIZDgyVTIK",
       "endpoints": [
         "https://github.com/shuntaka9576/agentoast/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
## Summary
- Regenerate updater signing keypair with explicit password (previous key silently encrypted even with empty Enter)
- Update pubkey in `tauri.conf.json` to match new keypair
- Remove stale v0.20.0 CHANGELOG entry (will be recreated by TAGPR)

## Note
After merging, the following manual steps are needed:
1. `gh release delete v0.20.0 --yes && git push origin --delete v0.20.0 && git tag -d v0.20.0`
2. `gh secret set TAURI_SIGNING_PRIVATE_KEY < ~/.tauri/agentoast.key`
3. `echo -n "<cert passwrod>" | gh secret set TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
4. Push to main triggers TAGPR → new v0.20.0 release
