### PR TITLE
docs: simplify Installation section into a single block

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,14 @@ A toast pops up whenever an agent completes or needs attention — click it to j
 
 ## Installation
 
-### CLI
-
 ```bash
 brew install shuntaka9576/tap/agentoast-cli
-```
-
-### App
-
-Download the DMG from [Releases](https://github.com/shuntaka9576/agentoast/releases) or install via Homebrew Cask.
-
-```bash
 brew install --cask shuntaka9576/tap/agentoast
 ```
 
-### Uninstall
+Or download the DMG from [Releases](https://github.com/shuntaka9576/agentoast/releases).
+
+To uninstall:
 
 ```bash
 brew uninstall --cask shuntaka9576/tap/agentoast

--- a/README.md
+++ b/README.md
@@ -36,10 +36,7 @@ Download the DMG from [Releases](https://github.com/shuntaka9576/agentoast/relea
 
 ```bash
 brew install --cask shuntaka9576/tap/agentoast
-xattr -cr /Applications/Agentoast.app
 ```
-
-> The app is not yet signed with an Apple Developer ID. macOS Gatekeeper may flag it as "damaged" — the `xattr` command above removes the quarantine attribute to fix this. Apple Developer signing is in progress and will remove this requirement in a future release.
 
 ### Uninstall
 


### PR DESCRIPTION
## Summary
- Remove `xattr -cr /Applications/Agentoast.app` instruction and unsigned app warning from README, now that the app is signed and notarized with Apple Developer ID

