### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs for supply chain security

### DIFF
--- a/.github/actions/release-app/action.yaml
+++ b/.github/actions/release-app/action.yaml
@@ -65,7 +65,7 @@ runs:
         -s -k "$KEYCHAIN_PASSWORD" build.keychain
       rm certificate.p12
   - name: "Build and release with tauri-action"
-    uses: tauri-apps/tauri-action@v0
+    uses: tauri-apps/tauri-action@73fb865345c54760d875b94642314f8c0c894afa # v0.6.1
     env:
       GITHUB_TOKEN: ${{ github.token }}
       TAURI_SIGNING_PRIVATE_KEY: ${{ inputs.tauri_signing_private_key }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: setup bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
     - name: install dependencies
       run: bun install --frozen-lockfile
     - name: install cargo-make


### PR DESCRIPTION
## Summary

- Pin `tauri-apps/tauri-action` to commit SHA (`73fb865345c54760d875b94642314f8c0c894afa`, v0.6.1) in `release-app/action.yaml`
- Pin `oven-sh/setup-bun` to commit SHA (`3d267786b128fe76c2f16a390aa2448b815359f3`, v2.1.2) in `ci.yaml`

## Why

Mutable version tags (e.g., `@v0`, `@v2`) can be moved to arbitrary commits, posing a supply chain attack risk. Pinning to specific commit SHAs ensures reproducible and tamper-resistant CI builds.


