### PR TITLE
chore: remove unused dependencies (env_logger, objc2-web-kit)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,6 @@ version = "0.22.0"
 dependencies = [
  "agentoast-shared",
  "block2",
- "env_logger",
  "fern",
  "humantime",
  "log",
@@ -25,7 +24,6 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "objc2-quartz-core",
- "objc2-web-kit",
  "serde",
  "serde_json",
  "tauri",
@@ -990,29 +988,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.115",
-]
-
-[[package]]
-name = "env_filter"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -2059,30 +2034,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89a5b5e10d5a9ad6e5d1f4bd58225f655d6fe9767575a5e8ac5a6fe64e04495"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7a39c8862fc1369215ccf0a8f12dd4598c7f6484704359f0351bd617034dbf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.115",
-]
-
-[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3088,21 +3039,6 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
-dependencies = [
- "portable-atomic",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,7 +20,6 @@ tauri-plugin-updater = "2.10.0"
 tauri-plugin-process = "2.3.1"
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
 log = "0.4.29"
-env_logger = "0.11.9"
 fern = "0.7.1"
 humantime = "2.3.0"
 notify = "8.2.0"
@@ -34,7 +33,6 @@ objc2-foundation = { version = "0.3.2", features = [
     "NSGeometry", "NSTimer",
     "NSData",
 ] }
-objc2-web-kit = { version = "0.3.2", features = ["WKPreferences", "WKWebView", "WKWebViewConfiguration"] }
 objc2-app-kit = { version = "0.3.2", features = [
     "NSRunningApplication", "NSWorkspace",
     "NSPanel", "NSWindow", "NSView", "NSVisualEffectView",


### PR DESCRIPTION
## Summary

- Remove unused `env_logger` dependency (logging uses `fern`)
- Remove unused `objc2-web-kit` dependency (`webkit_config.rs` was removed during native_toast migration)


