### PR TITLE
refactor: introduce NotificationInput struct to reduce insert_notification args

### DIFF
--- a/crates/agentoast-cli/src/hooks/mod.rs
+++ b/crates/agentoast-cli/src/hooks/mod.rs
@@ -153,15 +153,17 @@ pub fn insert_notification(ctx: &HookContext, p: &NotificationPayload) -> Result
     let conn = db::open_reader(&db_path).map_err(|e| format!("Failed to open database: {}", e))?;
     db::insert_notification(
         &conn,
-        p.badge,
-        p.body,
-        p.badge_color,
-        p.icon,
-        p.metadata,
-        p.repo_name,
-        &ctx.tmux_pane,
-        &ctx.terminal_bundle_id,
-        p.force_focus,
+        &db::NotificationInput {
+            badge: p.badge,
+            body: p.body,
+            badge_color: p.badge_color,
+            icon: p.icon,
+            metadata: p.metadata,
+            repo: p.repo_name,
+            tmux_pane: &ctx.tmux_pane,
+            terminal_bundle_id: &ctx.terminal_bundle_id,
+            force_focus: p.force_focus,
+        },
     )
     .map(|_| ())
     .map_err(|e| format!("Failed to insert notification: {}", e))

--- a/crates/agentoast-cli/src/main.rs
+++ b/crates/agentoast-cli/src/main.rs
@@ -154,15 +154,17 @@ fn main() {
 
             match db::insert_notification(
                 &conn,
-                &badge,
-                &body,
-                &badge_color,
-                &icon_type,
-                &metadata,
-                &repo,
-                &tmux_pane,
-                &terminal_bundle_id,
-                focus,
+                &db::NotificationInput {
+                    badge: &badge,
+                    body: &body,
+                    badge_color: &badge_color,
+                    icon: &icon_type,
+                    metadata: &metadata,
+                    repo: &repo,
+                    tmux_pane: &tmux_pane,
+                    terminal_bundle_id: &terminal_bundle_id,
+                    force_focus: focus,
+                },
             ) {
                 Ok(id) => println!("Notification saved (id={})", id),
                 Err(e) => {

--- a/crates/agentoast-shared/src/db.rs
+++ b/crates/agentoast-shared/src/db.rs
@@ -29,20 +29,28 @@ pub fn open_reader(db_path: &Path) -> rusqlite::Result<Connection> {
     Ok(conn)
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn insert_notification(
-    conn: &Connection,
-    badge: &str,
-    body: &str,
-    badge_color: &str,
-    icon: &IconType,
-    metadata: &HashMap<String, String>,
-    repo: &str,
-    tmux_pane: &str,
-    terminal_bundle_id: &str,
-    force_focus: bool,
-) -> rusqlite::Result<i64> {
-    let metadata_json = serde_json::to_string(metadata).unwrap_or_else(|_| "{}".to_string());
+pub struct NotificationInput<'a> {
+    pub badge: &'a str,
+    pub body: &'a str,
+    pub badge_color: &'a str,
+    pub icon: &'a IconType,
+    pub metadata: &'a HashMap<String, String>,
+    pub repo: &'a str,
+    pub tmux_pane: &'a str,
+    pub terminal_bundle_id: &'a str,
+    pub force_focus: bool,
+}
+
+pub fn insert_notification(conn: &Connection, input: &NotificationInput) -> rusqlite::Result<i64> {
+    let metadata_json = serde_json::to_string(input.metadata).unwrap_or_else(|_| "{}".to_string());
+    let badge = input.badge;
+    let body = input.body;
+    let badge_color = input.badge_color;
+    let icon = input.icon;
+    let tmux_pane = input.tmux_pane;
+    let terminal_bundle_id = input.terminal_bundle_id;
+    let repo = input.repo;
+    let force_focus = input.force_focus;
 
     // Wrap DELETE+INSERT in a transaction so they produce a single WAL write,
     // preventing the file-watcher debounce from missing the INSERT.


### PR DESCRIPTION
## Summary

- Add `NotificationInput<'a>` struct to `db.rs` to group the 9 parameters of `insert_notification`
- Remove `#[allow(clippy::too_many_arguments)]` — no longer needed
- Update all call sites (`hooks/mod.rs`, `main.rs`) to use the new struct

## Changes

### `crates/agentoast-shared/src/db.rs`
- New `NotificationInput<'a>` struct with 9 fields (`badge`, `body`, `badge_color`, `icon`, `metadata`, `repo`, `tmux_pane`, `terminal_bundle_id`, `force_focus`)
- `insert_notification` signature reduced from 10 args to 2 (`conn` + `input`)

### `crates/agentoast-cli/src/hooks/mod.rs`
- Updated the `insert_notification` wrapper to construct `NotificationInput`

### `crates/agentoast-cli/src/main.rs`
- Updated the `Send` command call site to use `NotificationInput`


