### PR TITLE
fix: detect .opencode binary for mise/npm installed OpenCode

### DIFF
--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -13,6 +13,7 @@ const AGENT_PROCESSES: &[(&str, &str)] = &[
     ("claude", "claude-code"),
     ("codex", "codex"),
     ("opencode", "opencode"),
+    (".opencode", "opencode"), // mise/npm install: actual Go binary is named .opencode
 ];
 
 struct GitInfo {


### PR DESCRIPTION
## Summary

- Add `.opencode` to `AGENT_PROCESSES` so OpenCode installed via mise/npm is correctly detected as an active agent in the Sessions panel

## Background

When OpenCode is installed via mise or npm (`npm-opencode-ai` package), the actual Go binary inside the package is named `.opencode` (dot-prefixed hidden file). The `opencode` command in PATH is a wrapper that invokes node, which then spawns `.opencode` as a child process.

Process tree seen in `ps -eo pid,ppid,comm`:
```
<pane-pid>   -zsh
<node-pid>   node
<bin-pid>    /.../.local/share/mise/installs/npm-opencode-ai/1.2.14/node_modules/opencode-ai/bin/.opencode
```

`detect_agent()` extracts the basename via `comm.rsplit('/').next()`, yielding `.opencode`, which did not match the existing `"opencode"` entry — so `agent_type` was `None` and the pane was filtered out.

Direct binary installs (future Homebrew formula, manual download) use `opencode` without the dot, so both entries are needed.


