### PR TITLE
feat: add Agent Teams subgroup display in Sessions tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ brew uninstall shuntaka9576/tap/agentoast-cli
 
 | Agent | Hook Config | Events | Status Detection |
 |---|---|---|---|
-| [Claude Code](https://github.com/anthropics/claude-code) | `~/.claude/settings.json` | Stop, Permission, Auth, Elicitation | Running / Idle / Waiting |
+| [Claude Code](https://github.com/anthropics/claude-code) | `~/.claude/settings.json` | Stop, Permission, Auth, Elicitation | Running / Idle / Waiting / Agent Teams |
 | [Codex](https://github.com/openai/codex) | `~/.codex/config.toml` | Turn Complete | Running / Idle / Waiting |
 | [opencode](https://github.com/anomalyco/opencode) | Plugin (`~/.config/opencode/plugins/`) | Session Idle, Error, Permission | Running / Idle / Waiting |
 | 🚧 [Kiro CLI](https://github.com/aws/kiro-cli) | — | — | — |

--- a/crates/agentoast-shared/src/models.rs
+++ b/crates/agentoast-shared/src/models.rs
@@ -80,6 +80,8 @@ pub struct TmuxPane {
     pub agent_status: Option<AgentStatus>,
     pub waiting_reason: Option<String>,
     pub agent_modes: Vec<String>,
+    pub team_role: Option<String>,  // "lead" or "teammate" (Agent Teams)
+    pub team_name: Option<String>,  // "@agent-alpha" (teammate only)
     pub git_repo_root: Option<String>,
     pub git_branch: Option<String>,
 }

--- a/crates/agentoast-shared/src/models.rs
+++ b/crates/agentoast-shared/src/models.rs
@@ -80,8 +80,8 @@ pub struct TmuxPane {
     pub agent_status: Option<AgentStatus>,
     pub waiting_reason: Option<String>,
     pub agent_modes: Vec<String>,
-    pub team_role: Option<String>,  // "lead" or "teammate" (Agent Teams)
-    pub team_name: Option<String>,  // "@agent-alpha" (teammate only)
+    pub team_role: Option<String>, // "lead" or "teammate" (Agent Teams)
+    pub team_name: Option<String>, // "@agent-alpha" (teammate only)
     pub git_repo_root: Option<String>,
     pub git_branch: Option<String>,
 }

--- a/cspell.json
+++ b/cspell.json
@@ -10,7 +10,8 @@
     "Cargo.lock",
     "src-tauri/gen",
     "src-tauri/icons",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "captures"
   ],
   "dictionaries": ["npm", "node", "typescript", "html", "css", "bash", "rust"],
   "words": [

--- a/src-tauri/src/sessions/agents/claude.rs
+++ b/src-tauri/src/sessions/agents/claude.rs
@@ -226,7 +226,7 @@ fn check_claude_pane_content(pane_id: &str) -> ClaudePaneContentInfo {
             team_role = Some("lead".to_string());
         }
 
-        // Teammate: separator "──── @agentname ──"
+        // Teammate: separator "──── @agent-name ──"
         if team_role.is_none() && trimmed.starts_with('\u{2500}') {
             if let Some(name) = extract_team_agent_name(trimmed) {
                 log::debug!(

--- a/src-tauri/src/sessions/agents/claude.rs
+++ b/src-tauri/src/sessions/agents/claude.rs
@@ -1,6 +1,6 @@
 use agentoast_shared::{db, models::AgentStatus};
 
-use super::{capture_pane, is_numbered_option};
+use super::{capture_pane, is_numbered_option, AgentDetectionResult};
 
 struct ClaudePaneContentInfo {
     has_spinner: bool, // Spinner chars + "…" / "esc to interrupt" (real-time, reliable)
@@ -9,12 +9,14 @@ struct ClaudePaneContentInfo {
     has_question_dialog: bool, // "Enter to select" navigation hint (AskUserQuestion dialog)
     has_plan_approval: bool,   // ❯ N. selection cursor + 2+ numbered options (plan approval etc.)
     agent_modes: Vec<String>,
+    team_role: Option<String>, // "lead" or "teammate" (Agent Teams feature)
+    team_name: Option<String>, // "@agent-alpha" for teammates
 }
 
 pub(super) fn detect_claude_status(
     db_conn: &Option<db::Connection>,
     pane_id: &str,
-) -> (AgentStatus, Option<String>, Vec<String>) {
+) -> AgentDetectionResult {
     let info = check_claude_pane_content(pane_id);
 
     log::debug!(
@@ -59,7 +61,13 @@ pub(super) fn detect_claude_status(
         (AgentStatus::Running, None)
     };
 
-    (status, waiting_reason, info.agent_modes)
+    AgentDetectionResult {
+        status,
+        waiting_reason,
+        agent_modes: info.agent_modes,
+        team_role: info.team_role,
+        team_name: info.team_name,
+    }
 }
 
 /// Claude Code spinner characters that appear at the start of running lines.
@@ -80,6 +88,8 @@ fn check_claude_pane_content(pane_id: &str) -> ClaudePaneContentInfo {
         has_question_dialog: false,
         has_plan_approval: false,
         agent_modes: Vec::new(),
+        team_role: None,
+        team_name: None,
     };
 
     let content = match capture_pane(pane_id) {
@@ -178,6 +188,59 @@ fn check_claude_pane_content(pane_id: &str) -> ClaudePaneContentInfo {
         }
     }
 
+    // Agent Teams detection: scan only the status bar area (bottom ~7 lines)
+    // to avoid false positives from conversation text containing "teammate"
+    // or "· ↓ to expand" strings.
+    let status_area = &last_lines[..last_lines.len().min(7)];
+    let mut team_role: Option<String> = None;
+    let mut team_name: Option<String> = None;
+
+    for line in status_area {
+        let trimmed = line.trim();
+
+        // Lead: mode line (⏵/⏸) containing "teammate"
+        //   e.g., "⏸ plan mode on · 3 teammates"
+        if team_role.is_none() {
+            let is_mode_line = trimmed.starts_with('⏵') || trimmed.starts_with('⏸');
+            if is_mode_line && trimmed.contains("teammate") {
+                log::debug!(
+                    "check_claude_pane_content({}): agent team lead detected (mode line): {:?}",
+                    pane_id,
+                    trimmed
+                );
+                team_role = Some("lead".to_string());
+            }
+        }
+
+        // Lead: team listing starting with @ and containing "· ↓ to expand"
+        //   e.g., "@main @agent-alpha @agent-beta @agent-gamma · ↓ to expand"
+        if team_role.is_none()
+            && trimmed.starts_with('@')
+            && trimmed.contains("\u{00B7} \u{2193} to expand")
+        {
+            log::debug!(
+                "check_claude_pane_content({}): agent team lead detected (team listing): {:?}",
+                pane_id,
+                trimmed
+            );
+            team_role = Some("lead".to_string());
+        }
+
+        // Teammate: separator "──── @agentname ──"
+        if team_role.is_none() && trimmed.starts_with('\u{2500}') {
+            if let Some(name) = extract_team_agent_name(trimmed) {
+                log::debug!(
+                    "check_claude_pane_content({}): agent team teammate '{}' detected: {:?}",
+                    pane_id,
+                    name,
+                    trimmed
+                );
+                team_role = Some("teammate".to_string());
+                team_name = Some(name);
+            }
+        }
+    }
+
     // Plan approval: requires ❯ N. selection cursor AND 2+ total numbered option lines.
     // Without the selection cursor, numbered lines are just markdown content (e.g., "1. PR特定").
     let has_plan_approval = has_selection_cursor && numbered_option_count >= 2;
@@ -206,6 +269,23 @@ fn check_claude_pane_content(pane_id: &str) -> ClaudePaneContentInfo {
         has_question_dialog,
         has_plan_approval,
         agent_modes,
+        team_role,
+        team_name,
+    }
+}
+
+/// Extract agent name from an Agent Teams teammate separator line.
+/// "──────── @agent-alpha ──" → Some("@agent-alpha")
+/// Lines start with ─ (U+2500) and contain " @name " pattern.
+fn extract_team_agent_name(line: &str) -> Option<String> {
+    let at_pos = line.find(" @")?;
+    let rest = &line[at_pos + 1..]; // "@agent-alpha ──"
+    let end = rest.find(' ').unwrap_or(rest.len());
+    let name = &rest[..end];
+    if name.starts_with('@') && name.len() > 1 {
+        Some(name.to_string())
+    } else {
+        None
     }
 }
 

--- a/src-tauri/src/sessions/agents/codex.rs
+++ b/src-tauri/src/sessions/agents/codex.rs
@@ -1,6 +1,6 @@
 use agentoast_shared::{db, models::AgentStatus};
 
-use super::{capture_pane, is_numbered_option};
+use super::{capture_pane, is_numbered_option, AgentDetectionResult};
 
 struct CodexPaneContentInfo {
     is_running: bool,          // "(XXs • esc to interrupt)" pattern
@@ -12,7 +12,7 @@ struct CodexPaneContentInfo {
 pub(super) fn detect_codex_status(
     db_conn: &Option<db::Connection>,
     pane_id: &str,
-) -> (AgentStatus, Option<String>, Vec<String>) {
+) -> AgentDetectionResult {
     let info = check_codex_pane_content(pane_id);
 
     log::debug!(
@@ -46,8 +46,14 @@ pub(super) fn detect_codex_status(
         (AgentStatus::Running, None)
     };
 
-    // Codex has no mode indicators (plan/bypass/accept)
-    (status, waiting_reason, Vec::new())
+    // Codex has no mode indicators (plan/bypass/accept) or Agent Teams support
+    AgentDetectionResult {
+        status,
+        waiting_reason,
+        agent_modes: Vec::new(),
+        team_role: None,
+        team_name: None,
+    }
 }
 
 fn check_codex_pane_content(pane_id: &str) -> CodexPaneContentInfo {

--- a/src-tauri/src/sessions/agents/mod.rs
+++ b/src-tauri/src/sessions/agents/mod.rs
@@ -8,6 +8,14 @@ mod claude;
 mod codex;
 mod opencode;
 
+pub(super) struct AgentDetectionResult {
+    pub status: AgentStatus,
+    pub waiting_reason: Option<String>,
+    pub agent_modes: Vec<String>,
+    pub team_role: Option<String>, // "lead" or "teammate"
+    pub team_name: Option<String>, // "@agent-alpha" (teammate only)
+}
+
 /// Capture tmux pane content as plain text.
 /// Returns None if tmux is not found or the capture command fails.
 pub(super) fn capture_pane(pane_id: &str) -> Option<String> {
@@ -44,7 +52,7 @@ pub(super) fn detect_agent_status(
     db_conn: &Option<db::Connection>,
     pane_id: &str,
     agent_type: &str,
-) -> (AgentStatus, Option<String>, Vec<String>) {
+) -> AgentDetectionResult {
     match agent_type {
         "claude-code" => claude::detect_claude_status(db_conn, pane_id),
         "codex" => codex::detect_codex_status(db_conn, pane_id),
@@ -55,7 +63,13 @@ pub(super) fn detect_agent_status(
                 pane_id,
                 agent_type
             );
-            (AgentStatus::Running, None, Vec::new())
+            AgentDetectionResult {
+                status: AgentStatus::Running,
+                waiting_reason: None,
+                agent_modes: Vec::new(),
+                team_role: None,
+                team_name: None,
+            }
         }
     }
 }

--- a/src-tauri/src/sessions/agents/opencode.rs
+++ b/src-tauri/src/sessions/agents/opencode.rs
@@ -1,6 +1,6 @@
 use agentoast_shared::{db, models::AgentStatus};
 
-use super::capture_pane;
+use super::{capture_pane, AgentDetectionResult};
 
 /// OpenCode mode patterns: (substring after ▣ prefix, label for frontend)
 const OPENCODE_MODE_PATTERNS: &[(&str, &str)] = &[("Plan", "plan"), ("Build", "build")];
@@ -15,7 +15,7 @@ struct OpencodePaneContentInfo {
 pub(super) fn detect_opencode_status(
     db_conn: &Option<db::Connection>,
     pane_id: &str,
-) -> (AgentStatus, Option<String>, Vec<String>) {
+) -> AgentDetectionResult {
     let info = check_opencode_pane_content(pane_id);
 
     log::debug!(
@@ -43,7 +43,14 @@ pub(super) fn detect_opencode_status(
         }
     };
 
-    (status, waiting_reason, info.agent_modes)
+    // OpenCode does not support Agent Teams
+    AgentDetectionResult {
+        status,
+        waiting_reason,
+        agent_modes: info.agent_modes,
+        team_role: None,
+        team_name: None,
+    }
 }
 
 fn check_opencode_pane_content(pane_id: &str) -> OpencodePaneContentInfo {

--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -247,12 +247,13 @@ pub fn list_tmux_panes_grouped() -> Result<Vec<TmuxPaneGroup>, String> {
         .into_iter()
         .map(|rp| {
             let git_info = git_cache.get(&rp.current_path).and_then(|o| o.as_ref());
-            let (agent_status, waiting_reason, agent_modes) = if let Some(ref at) = rp.agent_type {
-                let (status, reason, modes) = detect_agent_status(&db_conn, &rp.pane_id, at);
-                (Some(status), reason, modes)
-            } else {
-                (None, None, Vec::new())
-            };
+            let (agent_status, waiting_reason, agent_modes, team_role, team_name) =
+                if let Some(ref at) = rp.agent_type {
+                    let r = detect_agent_status(&db_conn, &rp.pane_id, at);
+                    (Some(r.status), r.waiting_reason, r.agent_modes, r.team_role, r.team_name)
+                } else {
+                    (None, None, Vec::new(), None, None)
+                };
             TmuxPane {
                 pane_id: rp.pane_id,
                 pane_pid: rp.pane_pid,
@@ -264,6 +265,8 @@ pub fn list_tmux_panes_grouped() -> Result<Vec<TmuxPaneGroup>, String> {
                 agent_status,
                 waiting_reason,
                 agent_modes,
+                team_role,
+                team_name,
                 git_repo_root: git_info.map(|g| g.repo_root.clone()),
                 git_branch: git_info.and_then(|g| g.branch.clone()),
             }

--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -387,6 +387,10 @@ fn detect_agent(tree: &ProcessTree, pane_pid: u32) -> Option<String> {
                             return Some(agent_type.to_string());
                         }
                     }
+                    // Agent Teams spawns the versioned binary directly (e.g. /…/claude/versions/2.1.59)
+                    if comm.contains("/claude/versions/") {
+                        return Some("claude-code".to_string());
+                    }
                 }
                 stack.push(child);
             }

--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -250,7 +250,13 @@ pub fn list_tmux_panes_grouped() -> Result<Vec<TmuxPaneGroup>, String> {
             let (agent_status, waiting_reason, agent_modes, team_role, team_name) =
                 if let Some(ref at) = rp.agent_type {
                     let r = detect_agent_status(&db_conn, &rp.pane_id, at);
-                    (Some(r.status), r.waiting_reason, r.agent_modes, r.team_role, r.team_name)
+                    (
+                        Some(r.status),
+                        r.waiting_reason,
+                        r.agent_modes,
+                        r.team_role,
+                        r.team_name,
+                    )
                 } else {
                     (None, None, Vec::new(), None, None)
                 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -154,6 +154,8 @@ export function App() {
           agentStatus: null,
           waitingReason: null,
           agentModes: [],
+          teamRole: null,
+          teamName: null,
           gitRepoRoot: null,
           gitBranch: null,
         },
@@ -179,6 +181,37 @@ export function App() {
 
         return 0;
       });
+    }
+
+    // Consolidate team panes: all teams first (lead first per team), then solo panes.
+    // This ensures flatItems order matches the visual render order in ExpandedPanes,
+    // which always renders teamGroups before soloItems.
+    for (const ug of result) {
+      if (!ug.paneItems.some((pi) => pi.pane.teamRole)) continue;
+
+      const teamMap = new Map<string, PaneItem[]>();
+      const solos: PaneItem[] = [];
+      for (const pi of ug.paneItems) {
+        if (!pi.pane.teamRole) {
+          solos.push(pi);
+        } else {
+          const key = `${pi.pane.sessionName}:${pi.pane.windowName}`;
+          if (!teamMap.has(key)) teamMap.set(key, []);
+          teamMap.get(key)!.push(pi);
+        }
+      }
+
+      const reordered: PaneItem[] = [];
+      for (const members of teamMap.values()) {
+        const lead = members.find((p) => p.pane.teamRole === "lead");
+        const teammates = members
+          .filter((p) => p.pane.teamRole === "teammate")
+          .sort((a, b) => (a.pane.teamName ?? "").localeCompare(b.pane.teamName ?? ""));
+        if (lead) reordered.push(lead);
+        reordered.push(...teammates);
+      }
+      reordered.push(...solos);
+      ug.paneItems = reordered;
     }
 
     // Sort: notifications first (createdAt desc), then by agent status (waiting > running > idle > none), then alphabetically

--- a/src/components/pane-card.tsx
+++ b/src/components/pane-card.tsx
@@ -129,6 +129,16 @@ export function PaneCard({
                 {mode}
               </span>
             ))}
+            {pane.teamRole === "lead" && (
+              <span className="text-[10px] text-[var(--text-muted)] flex-shrink-0">
+                @main
+              </span>
+            )}
+            {pane.teamName && (
+              <span className="text-[10px] text-[var(--text-muted)] flex-shrink-0">
+                {pane.teamName}
+              </span>
+            )}
             {notification?.badge && badgeClass && (
               <span
                 className={cn(

--- a/src/components/repo-group.tsx
+++ b/src/components/repo-group.tsx
@@ -1,4 +1,5 @@
-import { Bell, BellOff, ChevronDown, ChevronRight, GitBranch, Folder, FolderGit2, Trash2 } from "lucide-react";
+import { Bell, BellOff, ChevronDown, ChevronRight, GitBranch, Folder, FolderGit2, Trash2, Users } from "lucide-react";
+import { useMemo } from "react";
 import { cn } from "@/lib/utils";
 import type { PaneItem, FlatItem } from "@/lib/types";
 import { PaneCard } from "./pane-card";
@@ -134,27 +135,107 @@ export function RepoGroup({
       </button>
 
       {expanded && (
-        <div className="py-0.5">
-          {paneItems.map((pi) => {
-            const navIndex = flatItems.findIndex(
-              (f) => f.type === "pane-item" && f.paneItem.pane.paneId === pi.pane.paneId,
-            );
-            const isSelected =
-              pi.pane.paneId === selectedPaneId ||
-              (pi.notification !== null && pi.notification.id === selectedId);
-            return (
-              <PaneCard
-                key={`pane-${pi.pane.paneId}`}
-                paneItem={pi}
-                isNew={pi.notification !== null && newIds.has(pi.notification.id)}
-                isSelected={isSelected}
-                navIndex={navIndex}
-                onDeleteNotification={onDeleteNotification}
-              />
-            );
-          })}
-        </div>
+        <ExpandedPanes
+          paneItems={paneItems}
+          flatItems={flatItems}
+          newIds={newIds}
+          selectedId={selectedId}
+          selectedPaneId={selectedPaneId}
+          onDeleteNotification={onDeleteNotification}
+        />
       )}
+    </div>
+  );
+}
+
+interface ExpandedPanesProps {
+  paneItems: PaneItem[];
+  flatItems: FlatItem[];
+  newIds: Set<number>;
+  selectedId: number | null;
+  selectedPaneId: string | null;
+  onDeleteNotification: (id: number) => void;
+}
+
+function ExpandedPanes({
+  paneItems,
+  flatItems,
+  newIds,
+  selectedId,
+  selectedPaneId,
+  onDeleteNotification,
+}: ExpandedPanesProps) {
+  // Group panes by Agent Teams membership (session:window key)
+  const { teamGroups, soloItems } = useMemo(() => {
+    const teamMap = new Map<string, PaneItem[]>();
+    const solo: PaneItem[] = [];
+    for (const pi of paneItems) {
+      const { teamRole, sessionName, windowName } = pi.pane;
+      if (teamRole) {
+        const key = `${sessionName}:${windowName}`;
+        if (!teamMap.has(key)) teamMap.set(key, []);
+        teamMap.get(key)!.push(pi);
+      } else {
+        solo.push(pi);
+      }
+    }
+    return { teamGroups: Array.from(teamMap.values()), soloItems: solo };
+  }, [paneItems]);
+
+  const renderPaneCard = (pi: PaneItem) => {
+    const navIndex = flatItems.findIndex(
+      (f) => f.type === "pane-item" && f.paneItem.pane.paneId === pi.pane.paneId,
+    );
+    const isSelected =
+      pi.pane.paneId === selectedPaneId ||
+      (pi.notification !== null && pi.notification.id === selectedId);
+    return (
+      <PaneCard
+        key={`pane-${pi.pane.paneId}`}
+        paneItem={pi}
+        isNew={pi.notification !== null && newIds.has(pi.notification.id)}
+        isSelected={isSelected}
+        navIndex={navIndex}
+        onDeleteNotification={onDeleteNotification}
+      />
+    );
+  };
+
+  return (
+    <div className="py-0.5">
+      {teamGroups.map((teamPanes) => {
+        const lead = teamPanes.find((pi) => pi.pane.teamRole === "lead");
+        const teammates = teamPanes.filter((pi) => pi.pane.teamRole === "teammate");
+        const leadName = lead
+          ? (teamPanes.find((pi) => pi.pane.teamRole === "teammate")
+              ? "@main"
+              : "@main")
+          : null;
+        const teamKey = lead
+          ? `${lead.pane.sessionName}:${lead.pane.windowName}`
+          : teamPanes[0].pane.paneId;
+        return (
+          <div key={teamKey} className="mx-3 my-1 border border-[var(--border-subtle)] rounded-md">
+            {/* Team sub-header */}
+            <div className="flex items-center gap-1.5 px-2 py-1 border-b border-[var(--border-subtle)]">
+              <Users size={10} className="text-[var(--text-muted)] flex-shrink-0" />
+              <span className="text-[10px] text-[var(--text-muted)]">
+                {leadName ?? "@main"}
+                {teammates.length > 0 && (
+                  <span className="ml-1">· {teammates.length} {teammates.length === 1 ? "teammate" : "teammates"}</span>
+                )}
+              </span>
+            </div>
+            {/* Sort: lead first, then teammates */}
+            {[
+              ...(lead ? [lead] : []),
+              ...teammates,
+              ...teamPanes.filter((pi) => pi.pane.teamRole !== "lead" && pi.pane.teamRole !== "teammate"),
+            ].map(renderPaneCard)}
+          </div>
+        );
+      })}
+      {soloItems.map(renderPaneCard)}
     </div>
   );
 }

--- a/src/components/repo-group.tsx
+++ b/src/components/repo-group.tsx
@@ -206,24 +206,25 @@ function ExpandedPanes({
       {teamGroups.map((teamPanes) => {
         const lead = teamPanes.find((pi) => pi.pane.teamRole === "lead");
         const teammates = teamPanes.filter((pi) => pi.pane.teamRole === "teammate");
-        const leadName = lead
-          ? (teamPanes.find((pi) => pi.pane.teamRole === "teammate")
-              ? "@main"
-              : "@main")
-          : null;
         const teamKey = lead
           ? `${lead.pane.sessionName}:${lead.pane.windowName}`
           : teamPanes[0].pane.paneId;
+        const memberCount = teamPanes.length;
+        const hasSelectedMember = teamPanes.some(
+          (pi) =>
+            pi.pane.paneId === selectedPaneId ||
+            (pi.notification !== null && pi.notification.id === selectedId),
+        );
         return (
-          <div key={teamKey} className="mx-3 my-1 border border-[var(--border-subtle)] rounded-md">
+          <div key={teamKey} className={cn(
+            "mx-3 my-1 border rounded-md",
+            hasSelectedMember ? "border-violet-500/60" : "border-[var(--border-subtle)]",
+          )}>
             {/* Team sub-header */}
             <div className="flex items-center gap-1.5 px-2 py-1 border-b border-[var(--border-subtle)]">
               <Users size={10} className="text-[var(--text-muted)] flex-shrink-0" />
               <span className="text-[10px] text-[var(--text-muted)]">
-                {leadName ?? "@main"}
-                {teammates.length > 0 && (
-                  <span className="ml-1">· {teammates.length} {teammates.length === 1 ? "teammate" : "teammates"}</span>
-                )}
+                Agent Teams({memberCount})
               </span>
             </div>
             {/* Sort: lead first, then teammates */}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,8 @@ export interface TmuxPane {
   agentStatus: AgentStatus | null;
   waitingReason: string | null;
   agentModes: string[];
+  teamRole: "lead" | "teammate" | null;
+  teamName: string | null; // "@agent-alpha" for teammates
   gitRepoRoot: string | null;
   gitBranch: string | null;
 }


### PR DESCRIPTION
## Summary

- Display Claude Code Agent Teams (split panes mode) Lead + Teammate panes as visual subgroups within repository groups in the Sessions tab
- Scan only the status bar area (bottom 7 lines) of capture-pane output to detect team roles, preventing false positives from conversation text
- Support detection of Agent Teams processes launched via versioned binary paths

## Changes

### Backend (Rust)
- Add `team_role` / `team_name` fields to `AgentDetectionResult` struct (`agents/mod.rs`)
- `claude.rs`: Team detection limited to status bar area (bottom 7 lines)
  - Lead: mode line (⏵/⏸) containing "teammate", or team listing line (`@` + `· ↓ to expand`)
  - Teammate: separator pattern (`── @agent-name ──`)
- `sessions/mod.rs`: Detect versioned binary path (`/claude/versions/`) for Agent Teams processes
- `models.rs`: Add `team_role` / `team_name` fields to `TmuxPane`
- `codex.rs`, `opencode.rs`: Update return type to `AgentDetectionResult`

### Frontend (React/TypeScript)
- `types.ts`: Add `teamRole` / `teamName` to `TmuxPane` interface
- `repo-group.tsx`: `ExpandedPanes` component renders team subgroups in bordered boxes with violet highlight on cursor selection
- `pane-card.tsx`: Show `@main` badge for lead, `@agent-name` badge for teammates
- `App.tsx`: Consolidate team panes in flatItems sort order to prevent cursor jumping during j/k navigation

### Other
- `cspell.json`: Add `captures` directory to ignorePaths
- `README.md`: Note Agent Teams support in Supported Agents table


