### PR TITLE
feat: add last_assistant_message body to Claude Code Stop notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Editor resolution priority is `config.toml` `editor` field → `$EDITOR` → `vi
 # These events set force_focus=true, causing silent terminal focus without toast (when not muted)
 # focus_events = []
 
+# Include last-assistant-message as notification body (default: true, truncated to 200 chars)
+# include_body = true
+
 # Codex agent settings
 [notification.agents.codex]
 # Events that trigger notifications

--- a/crates/agentoast-cli/src/hooks/claude.rs
+++ b/crates/agentoast-cli/src/hooks/claude.rs
@@ -4,7 +4,7 @@ use agentoast_shared::{config, models::IconType};
 use serde::Deserialize;
 
 use super::{
-    collect_git_metadata, emit_result, insert_notification, HookContext, HookResult,
+    collect_git_metadata, emit_result, insert_notification, truncate_body, HookContext, HookResult,
     NotificationPayload,
 };
 
@@ -14,6 +14,7 @@ struct ClaudeHookData {
     cwd: Option<String>,
     notification_type: Option<String>,
     message: Option<String>,
+    last_assistant_message: Option<String>,
 }
 
 pub fn run() -> Result<(), String> {
@@ -36,11 +37,25 @@ pub fn run() -> Result<(), String> {
         return Ok(());
     }
 
-    let is_stop = data.hook_event_name == "Stop";
-    let badge = if is_stop { "Stop" } else { "Notification" };
-    let badge_color = if is_stop { "green" } else { "blue" };
-    let body = data.message.as_deref().unwrap_or("");
     let force_focus = hook_config.focus_events.iter().any(|e| e == event_key);
+
+    let (badge, badge_color, body) = match data.hook_event_name.as_str() {
+        "Stop" => {
+            let body = if hook_config.include_body {
+                data.last_assistant_message
+                    .as_deref()
+                    .map(truncate_body)
+                    .unwrap_or_default()
+            } else {
+                String::new()
+            };
+            ("Stop", "green", body)
+        }
+        _ => {
+            let body = data.message.unwrap_or_default();
+            ("Notification", "blue", body)
+        }
+    };
 
     let (repo_name, metadata) = collect_git_metadata(data.cwd.as_deref());
     let ctx = HookContext::from_env();
@@ -49,7 +64,7 @@ pub fn run() -> Result<(), String> {
         &ctx,
         &NotificationPayload {
             badge,
-            body,
+            body: &body,
             badge_color,
             icon: &IconType::ClaudeCode,
             metadata: &metadata,

--- a/crates/agentoast-cli/src/hooks/codex.rs
+++ b/crates/agentoast-cli/src/hooks/codex.rs
@@ -2,7 +2,7 @@ use agentoast_shared::{config, models::IconType};
 use serde::Deserialize;
 
 use super::{
-    collect_git_metadata, emit_result, insert_notification, HookContext, HookResult,
+    collect_git_metadata, emit_result, insert_notification, truncate_body, HookContext, HookResult,
     NotificationPayload,
 };
 
@@ -13,23 +13,6 @@ struct CodexHookData {
     cwd: Option<String>,
     #[serde(rename = "last-assistant-message")]
     last_assistant_message: Option<String>,
-}
-
-const BODY_MAX_LEN: usize = 200;
-
-fn truncate_body(msg: &str) -> String {
-    if msg.len() <= BODY_MAX_LEN {
-        return msg.to_string();
-    }
-    let truncate_at = msg
-        .char_indices()
-        .take_while(|(i, _)| *i <= BODY_MAX_LEN)
-        .last()
-        .map(|(i, _)| i)
-        .unwrap_or(0);
-    let mut truncated = msg[..truncate_at].to_string();
-    truncated.push_str("...");
-    truncated
 }
 
 pub fn run(json_arg: &str) -> Result<(), String> {

--- a/crates/agentoast-cli/src/hooks/mod.rs
+++ b/crates/agentoast-cli/src/hooks/mod.rs
@@ -128,6 +128,25 @@ pub fn collect_git_metadata(cwd_opt: Option<&str>) -> (String, HashMap<String, S
     (repo_name, metadata)
 }
 
+const BODY_MAX_LEN: usize = 200;
+
+/// Truncates a message to BODY_MAX_LEN characters, appending "..." if truncated.
+/// Handles multi-byte characters safely by splitting at char boundaries.
+pub fn truncate_body(msg: &str) -> String {
+    if msg.len() <= BODY_MAX_LEN {
+        return msg.to_string();
+    }
+    let truncate_at = msg
+        .char_indices()
+        .take_while(|(i, _)| *i <= BODY_MAX_LEN)
+        .last()
+        .map(|(i, _)| i)
+        .unwrap_or(0);
+    let mut truncated = msg[..truncate_at].to_string();
+    truncated.push_str("...");
+    truncated
+}
+
 /// Serializes a HookResult as JSON and writes it to stdout
 pub fn emit_result(result: HookResult) {
     println!(

--- a/crates/agentoast-cli/tests/hook_claude.rs
+++ b/crates/agentoast-cli/tests/hook_claude.rs
@@ -242,7 +242,8 @@ fn stop_event_with_last_assistant_message() {
     assert_eq!(notifications[0].badge, "Stop");
     assert_eq!(notifications[0].badge_color, "green");
     assert_eq!(
-        notifications[0].body, "Refactoring complete. Changed 3 files."
+        notifications[0].body,
+        "Refactoring complete. Changed 3 files."
     );
 }
 
@@ -298,7 +299,10 @@ include_body = false
 
     let notifications = get_notifications(data_dir.path());
     assert_eq!(notifications.len(), 1);
-    assert_eq!(notifications[0].body, "", "body should be empty when include_body=false");
+    assert_eq!(
+        notifications[0].body, "",
+        "body should be empty when include_body=false"
+    );
 }
 
 #[test]

--- a/crates/agentoast-cli/tests/hook_claude.rs
+++ b/crates/agentoast-cli/tests/hook_claude.rs
@@ -222,6 +222,86 @@ fn git_info_from_cwd() {
 }
 
 #[test]
+fn stop_event_with_last_assistant_message() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    let json = serde_json::json!({
+        "hook_event_name": "Stop",
+        "last_assistant_message": "Refactoring complete. Changed 3 files.",
+        "cwd": env!("CARGO_MANIFEST_DIR")
+    })
+    .to_string();
+
+    let output = run_hook_claude(&json, data_dir.path(), config_dir.path());
+    assert!(output.status.success());
+
+    let notifications = get_notifications(data_dir.path());
+    assert_eq!(notifications.len(), 1);
+    assert_eq!(notifications[0].badge, "Stop");
+    assert_eq!(notifications[0].badge_color, "green");
+    assert_eq!(
+        notifications[0].body, "Refactoring complete. Changed 3 files."
+    );
+}
+
+#[test]
+fn stop_event_with_long_last_assistant_message() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    let long_msg = "a".repeat(300);
+    let json = serde_json::json!({
+        "hook_event_name": "Stop",
+        "last_assistant_message": long_msg,
+        "cwd": env!("CARGO_MANIFEST_DIR")
+    })
+    .to_string();
+
+    let output = run_hook_claude(&json, data_dir.path(), config_dir.path());
+    assert!(output.status.success());
+
+    let notifications = get_notifications(data_dir.path());
+    assert_eq!(notifications.len(), 1);
+    assert!(
+        notifications[0].body.len() <= 203,
+        "body should be truncated to ~200 chars + '...'"
+    );
+    assert!(notifications[0].body.ends_with("..."));
+}
+
+#[test]
+fn include_body_false() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    write_config(
+        config_dir.path(),
+        r#"
+[notification.agents.claude_code]
+include_body = false
+"#,
+    );
+
+    let json = serde_json::json!({
+        "hook_event_name": "Stop",
+        "last_assistant_message": "This should not appear in body",
+        "cwd": env!("CARGO_MANIFEST_DIR")
+    })
+    .to_string();
+
+    let output = run_hook_claude(&json, data_dir.path(), config_dir.path());
+    assert!(output.status.success());
+
+    let notifications = get_notifications(data_dir.path());
+    assert_eq!(notifications.len(), 1);
+    assert_eq!(notifications[0].body, "", "body should be empty when include_body=false");
+}
+
+#[test]
 fn missing_cwd() {
     let data_dir = tempfile::tempdir().unwrap();
     let config_dir = tempfile::tempdir().unwrap();

--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -125,6 +125,8 @@ pub struct ClaudeCodeHookConfig {
     pub events: Vec<String>,
     #[serde(default)]
     pub focus_events: Vec<String>,
+    #[serde(default = "default_true")]
+    pub include_body: bool,
 }
 
 impl Default for ClaudeCodeHookConfig {
@@ -132,6 +134,7 @@ impl Default for ClaudeCodeHookConfig {
         Self {
             events: default_claude_code_events(),
             focus_events: Vec::new(),
+            include_body: true,
         }
     }
 }
@@ -279,6 +282,9 @@ fn default_config_template() -> &'static str {
 # Events that auto-focus the terminal (default: none)
 # These events set force_focus=true, causing silent terminal focus without toast (when not muted)
 # focus_events = []
+
+# Include last-assistant-message as notification body (default: true, truncated to 200 chars)
+# include_body = true
 
 # Codex agent settings
 [notification.agents.codex]


### PR DESCRIPTION
## Summary
- Add `last_assistant_message` as notification body for Claude Code Stop events (truncated to 200 chars), matching the existing Codex behavior
- Add `include_body` config option to `[notification.agents.claude_code]` for opt-out
- Extract `truncate_body` from `codex.rs` into shared `mod.rs` utility

## Changes
- **`claude.rs`**: Parse `last_assistant_message` field, use as Stop body with truncation
- **`mod.rs`**: Add shared `truncate_body()` function (moved from `codex.rs`)
- **`codex.rs`**: Use shared `truncate_body` instead of local copy
- **`config.rs`**: Add `include_body` to `ClaudeCodeHookConfig` (default: `true`)
- **`hook_claude.rs` (tests)**: Add 3 tests (body present, truncation, include_body=false)
- **`README.md`**: Add `include_body` to Claude Code config example


