### PR TITLE
chore: add postVersionCommand to auto-update Cargo.lock on release

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -3,3 +3,4 @@
 	releaseBranch = main
 	versionFile = Cargo.toml,src-tauri/tauri.conf.json,package.json
 	release = draft
+	postVersionCommand = cargo update --workspace


### PR DESCRIPTION
## Summary

- Add `postVersionCommand = cargo update --workspace` to `.tagpr` config
- This automatically updates `Cargo.lock` when TAGPR bumps workspace crate versions in release PRs
- Eliminates the manual step of running `cargo build` and pushing the lock file update

## Changes

- `.tagpr`: Added `postVersionCommand` setting


