### PR TITLE
chore: pin linker to Apple clang for macOS builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-apple-darwin]
+linker = "/usr/bin/cc"


### PR DESCRIPTION
## Summary
- Pin linker to `/usr/bin/cc` (Apple clang) for macOS aarch64 builds
- Fixes `-liconv` linker errors when nix-installed GCC takes precedence in PATH

## Changes
- **`.cargo/config.toml`**: New file, sets `[target.aarch64-apple-darwin] linker = "/usr/bin/cc"`


