### PR TITLE
feat: add TeammateIdle and TaskCompleted hook events for Agent Teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Editor resolution priority is `config.toml` `editor` field → `$EDITOR` → `vi
 # Claude Code agent settings
 [notification.agents.claude_code]
 # Events that trigger notifications
-# Available: Stop, permission_prompt, idle_prompt, auth_success, elicitation_dialog
-# idle_prompt is excluded by default (noisy); add it back if you want idle notifications
+# Available: Stop, permission_prompt, idle_prompt, auth_success, elicitation_dialog, TeammateIdle, TaskCompleted
+# idle_prompt, TeammateIdle, TaskCompleted are excluded by default
 # events = ["Stop", "permission_prompt", "auth_success", "elicitation_dialog"]
 
 # Events that auto-focus the terminal (default: none)

--- a/crates/agentoast-cli/src/hooks/claude.rs
+++ b/crates/agentoast-cli/src/hooks/claude.rs
@@ -15,6 +15,13 @@ struct ClaudeHookData {
     notification_type: Option<String>,
     message: Option<String>,
     last_assistant_message: Option<String>,
+    // Agent Teams fields
+    teammate_name: Option<String>,
+    team_name: Option<String>,
+    task_id: Option<String>,
+    task_subject: Option<String>,
+    #[allow(dead_code)]
+    task_description: Option<String>,
 }
 
 pub fn run() -> Result<(), String> {
@@ -39,6 +46,8 @@ pub fn run() -> Result<(), String> {
 
     let force_focus = hook_config.focus_events.iter().any(|e| e == event_key);
 
+    let (repo_name, mut metadata) = collect_git_metadata(data.cwd.as_deref());
+
     let (badge, badge_color, body) = match data.hook_event_name.as_str() {
         "Stop" => {
             let body = if hook_config.include_body {
@@ -51,13 +60,32 @@ pub fn run() -> Result<(), String> {
             };
             ("Stop", "green", body)
         }
+        "TeammateIdle" => {
+            let teammate = data.teammate_name.as_deref().unwrap_or("unknown");
+            let team = data.team_name.as_deref().unwrap_or("unknown");
+            metadata.insert("teammate".to_string(), teammate.to_string());
+            metadata.insert("team".to_string(), team.to_string());
+            let body = format!("@{} is idle ({})", teammate, team);
+            ("Teammate Idle", "gray", body)
+        }
+        "TaskCompleted" => {
+            let body = data.task_subject.unwrap_or_default();
+            if let Some(ref task_id) = data.task_id {
+                metadata.insert("task".to_string(), task_id.clone());
+            }
+            if let Some(ref teammate) = data.teammate_name {
+                metadata.insert("teammate".to_string(), teammate.clone());
+            }
+            if let Some(ref team) = data.team_name {
+                metadata.insert("team".to_string(), team.clone());
+            }
+            ("Task Done", "green", body)
+        }
         _ => {
             let body = data.message.unwrap_or_default();
             ("Notification", "blue", body)
         }
     };
-
-    let (repo_name, metadata) = collect_git_metadata(data.cwd.as_deref());
     let ctx = HookContext::from_env();
 
     insert_notification(

--- a/crates/agentoast-cli/tests/hook_claude.rs
+++ b/crates/agentoast-cli/tests/hook_claude.rs
@@ -327,3 +327,199 @@ fn missing_cwd() {
     assert_eq!(notifications.len(), 1);
     assert_eq!(notifications[0].repo, "");
 }
+
+#[test]
+fn teammate_idle_event() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    write_config(
+        config_dir.path(),
+        r#"
+[notification.agents.claude_code]
+events = ["TeammateIdle"]
+"#,
+    );
+
+    let json = serde_json::json!({
+        "hook_event_name": "TeammateIdle",
+        "teammate_name": "researcher",
+        "team_name": "my-project",
+        "cwd": env!("CARGO_MANIFEST_DIR")
+    })
+    .to_string();
+
+    let output = run_hook_claude(&json, data_dir.path(), config_dir.path());
+    assert!(output.status.success());
+
+    let notifications = get_notifications(data_dir.path());
+    assert_eq!(notifications.len(), 1);
+    assert_eq!(notifications[0].badge, "Teammate Idle");
+    assert_eq!(notifications[0].badge_color, "gray");
+    assert_eq!(notifications[0].body, "@researcher is idle (my-project)");
+    assert_eq!(notifications[0].icon, "claude-code");
+    assert_eq!(
+        notifications[0].metadata.get("teammate").unwrap(),
+        "researcher"
+    );
+    assert_eq!(notifications[0].metadata.get("team").unwrap(), "my-project");
+}
+
+#[test]
+fn task_completed_event() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    write_config(
+        config_dir.path(),
+        r#"
+[notification.agents.claude_code]
+events = ["TaskCompleted"]
+"#,
+    );
+
+    let json = serde_json::json!({
+        "hook_event_name": "TaskCompleted",
+        "task_id": "task-001",
+        "task_subject": "Implement user authentication",
+        "task_description": "Add login and signup endpoints",
+        "teammate_name": "implementer",
+        "team_name": "my-project",
+        "cwd": env!("CARGO_MANIFEST_DIR")
+    })
+    .to_string();
+
+    let output = run_hook_claude(&json, data_dir.path(), config_dir.path());
+    assert!(output.status.success());
+
+    let notifications = get_notifications(data_dir.path());
+    assert_eq!(notifications.len(), 1);
+    assert_eq!(notifications[0].badge, "Task Done");
+    assert_eq!(notifications[0].badge_color, "green");
+    assert_eq!(notifications[0].body, "Implement user authentication");
+    assert_eq!(notifications[0].icon, "claude-code");
+    assert_eq!(notifications[0].metadata.get("task").unwrap(), "task-001");
+    assert_eq!(
+        notifications[0].metadata.get("teammate").unwrap(),
+        "implementer"
+    );
+    assert_eq!(notifications[0].metadata.get("team").unwrap(), "my-project");
+}
+
+#[test]
+fn teammate_idle_filtered_by_default() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    let json = serde_json::json!({
+        "hook_event_name": "TeammateIdle",
+        "teammate_name": "researcher",
+        "team_name": "my-project",
+        "cwd": env!("CARGO_MANIFEST_DIR")
+    })
+    .to_string();
+
+    let output = run_hook_claude(&json, data_dir.path(), config_dir.path());
+    assert!(output.status.success());
+
+    let notifications = get_notifications(data_dir.path());
+    assert!(
+        notifications.is_empty(),
+        "TeammateIdle should be filtered by default config"
+    );
+}
+
+#[test]
+fn task_completed_filtered_by_default() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    let json = serde_json::json!({
+        "hook_event_name": "TaskCompleted",
+        "task_id": "task-001",
+        "task_subject": "Implement auth",
+        "cwd": env!("CARGO_MANIFEST_DIR")
+    })
+    .to_string();
+
+    let output = run_hook_claude(&json, data_dir.path(), config_dir.path());
+    assert!(output.status.success());
+
+    let notifications = get_notifications(data_dir.path());
+    assert!(
+        notifications.is_empty(),
+        "TaskCompleted should be filtered by default config"
+    );
+}
+
+#[test]
+fn task_completed_without_optional_fields() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    write_config(
+        config_dir.path(),
+        r#"
+[notification.agents.claude_code]
+events = ["TaskCompleted"]
+"#,
+    );
+
+    let json = serde_json::json!({
+        "hook_event_name": "TaskCompleted",
+        "task_id": "task-002",
+        "task_subject": "Fix bug",
+        "cwd": env!("CARGO_MANIFEST_DIR")
+    })
+    .to_string();
+
+    let output = run_hook_claude(&json, data_dir.path(), config_dir.path());
+    assert!(output.status.success());
+
+    let notifications = get_notifications(data_dir.path());
+    assert_eq!(notifications.len(), 1);
+    assert_eq!(notifications[0].badge, "Task Done");
+    assert_eq!(notifications[0].body, "Fix bug");
+    assert_eq!(notifications[0].metadata.get("task").unwrap(), "task-002");
+    assert!(!notifications[0].metadata.contains_key("teammate"));
+    assert!(!notifications[0].metadata.contains_key("team"));
+}
+
+#[test]
+fn teammate_idle_focus_event() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    setup_db(data_dir.path());
+
+    write_config(
+        config_dir.path(),
+        r#"
+[notification.agents.claude_code]
+events = ["TeammateIdle"]
+focus_events = ["TeammateIdle"]
+"#,
+    );
+
+    let json = serde_json::json!({
+        "hook_event_name": "TeammateIdle",
+        "teammate_name": "researcher",
+        "team_name": "my-project",
+        "cwd": env!("CARGO_MANIFEST_DIR")
+    })
+    .to_string();
+
+    let output = run_hook_claude(&json, data_dir.path(), config_dir.path());
+    assert!(output.status.success());
+
+    let notifications = get_notifications(data_dir.path());
+    assert_eq!(notifications.len(), 1);
+    assert!(
+        notifications[0].force_focus,
+        "TeammateIdle should have force_focus=true when in focus_events"
+    );
+}

--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -275,8 +275,8 @@ fn default_config_template() -> &'static str {
 # Claude Code agent settings
 [notification.agents.claude_code]
 # Events that trigger notifications
-# Available: Stop, permission_prompt, idle_prompt, auth_success, elicitation_dialog
-# idle_prompt is excluded by default (noisy); add it back if you want idle notifications
+# Available: Stop, permission_prompt, idle_prompt, auth_success, elicitation_dialog, TeammateIdle, TaskCompleted
+# idle_prompt, TeammateIdle, TaskCompleted are excluded by default
 # events = ["Stop", "permission_prompt", "auth_success", "elicitation_dialog"]
 
 # Events that auto-focus the terminal (default: none)

--- a/examples/notify/claude.ts
+++ b/examples/notify/claude.ts
@@ -6,9 +6,15 @@
 interface HookData {
   session_id: string
   transcript_path: string
-  hook_event_name: "Stop" | "Notification"
+  hook_event_name: "Stop" | "Notification" | "TeammateIdle" | "TaskCompleted"
   notification_type?: "permission_prompt" | "idle_prompt" | "auth_success" | "elicitation_dialog"
   stop_hook_active?: boolean
+  // Agent Teams fields
+  teammate_name?: string
+  team_name?: string
+  task_id?: string
+  task_subject?: string
+  task_description?: string
 }
 
 // Set to true to auto-focus terminal on Stop/permission_prompt/elicitation_dialog events


### PR DESCRIPTION
## Summary
- Add `TeammateIdle` and `TaskCompleted` hook event handling for Claude Code Agent Teams
- Both events are opt-in (excluded from default events list)
- Team/teammate/task info is stored in notification metadata

## Changes
- **`claude.rs`**: Add `TeammateIdle` (gray badge) and `TaskCompleted` (green badge) match arms with metadata insertion
- **`config.rs`**: Update config template `Available:` comment to list new events
- **`hook_claude.rs` (tests)**: Add 6 tests (happy path, default filtering, optional fields, focus_events)
- **`ai-coding-agent-notify-spec.md`**: Document new event types and payload schemas
- **`claude.ts`**: Update HookData interface with Agent Teams fields
- **`README.md`**: Update config example with new available events

## Notification mapping

| Event | Badge | Color | Body |
|---|---|---|---|
| `TeammateIdle` | Teammate Idle | gray | `@{name} is idle ({team})` |
| `TaskCompleted` | Task Done | green | `{task_subject}` |

## Test plan
- [x] `cargo check -p agentoast-cli --tests`
- [x] `cargo fmt --check` + `cargo clippy` (pre-push hook)
