### PR TITLE
feat: add delayed auto-expand for pane card body text

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,8 @@ export function App() {
   const [showHelp, setShowHelp] = useState(false);
   const [filterNotifiedOnly, setFilterNotifiedOnly] = useState(false);
   const [manuallyToggledGroups, setManuallyToggledGroups] = useState<Set<string>>(new Set());
+  const [autoExpandedPaneId, setAutoExpandedPaneId] = useState<string | null>(null);
+  const autoExpandTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const needFetchVersionRef = useRef(-1);
   const fetchVersionRef = useRef(fetchVersion);
@@ -361,6 +363,43 @@ export function App() {
     }
   }, [selectedIndex]);
 
+  // Delayed auto-expand: after 300ms on a selected pane with body text, expand it
+  useEffect(() => {
+    if (autoExpandTimerRef.current) {
+      clearTimeout(autoExpandTimerRef.current);
+      autoExpandTimerRef.current = null;
+    }
+    setAutoExpandedPaneId(null);
+
+    if (selectedIndex < 0) return;
+    const item = flatItems[selectedIndex];
+    if (item?.type !== "pane-item" || !item.paneItem.notification?.body) return;
+
+    const paneId = item.paneItem.pane.paneId;
+    autoExpandTimerRef.current = setTimeout(() => {
+      setAutoExpandedPaneId(paneId);
+      autoExpandTimerRef.current = null;
+    }, 300);
+
+    return () => {
+      if (autoExpandTimerRef.current) {
+        clearTimeout(autoExpandTimerRef.current);
+        autoExpandTimerRef.current = null;
+      }
+    };
+  }, [selectedIndex, flatItems]);
+
+  // Scroll into view after auto-expand (card height may change)
+  useEffect(() => {
+    if (!autoExpandedPaneId) return;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const el = container.querySelector(`[data-nav-index="${selectedIndex}"]`);
+    if (el) {
+      el.scrollIntoView({ block: "nearest" });
+    }
+  }, [autoExpandedPaneId, selectedIndex]);
+
   const activatePaneItem = useCallback(
     (paneItem: PaneItem) => {
       if (paneItem.notification) {
@@ -587,6 +626,7 @@ export function App() {
                   selectedId={selectedNotificationId}
                   selectedPaneId={selectedPaneId}
                   flatItems={flatItems}
+                  autoExpandedPaneId={autoExpandedPaneId}
                   onDeleteNotification={(id) => void deleteNotification(id)}
                   onDeleteByPanes={(paneIds) => void deleteByPanes(paneIds)}
                   onToggleRepoMute={(path) => void toggleRepoMute(path)}

--- a/src/components/pane-card.tsx
+++ b/src/components/pane-card.tsx
@@ -8,6 +8,7 @@ interface PaneCardProps {
   paneItem: PaneItem;
   isNew?: boolean;
   isSelected?: boolean;
+  isAutoExpanded?: boolean;
   navIndex?: number;
   onDeleteNotification: (id: number) => void;
 }
@@ -66,6 +67,7 @@ export function PaneCard({
   paneItem,
   isNew,
   isSelected,
+  isAutoExpanded,
   navIndex,
   onDeleteNotification,
 }: PaneCardProps) {
@@ -157,9 +159,12 @@ export function PaneCard({
             )}
           </div>
 
-          {/* Line 2: body (1 line) */}
+          {/* Line 2: body (1 line, auto-expands when selected for 300ms) */}
           {notification?.body && (
-            <p className="mt-0.5 text-[11px] text-[var(--text-secondary)] line-clamp-1">
+            <p className={cn(
+              "mt-0.5 text-[11px] text-[var(--text-secondary)]",
+              isAutoExpanded ? "" : "line-clamp-1",
+            )}>
               {notification.body}
             </p>
           )}

--- a/src/components/repo-group.tsx
+++ b/src/components/repo-group.tsx
@@ -17,6 +17,7 @@ interface RepoGroupProps {
   selectedId: number | null;
   selectedPaneId: string | null;
   flatItems: FlatItem[];
+  autoExpandedPaneId: string | null;
   onDeleteNotification: (id: number) => void;
   onDeleteByPanes: (paneIds: string[]) => void;
   onToggleRepoMute: (repoPath: string) => void;
@@ -36,6 +37,7 @@ export function RepoGroup({
   selectedId,
   selectedPaneId,
   flatItems,
+  autoExpandedPaneId,
   onDeleteNotification,
   onDeleteByPanes,
   onToggleRepoMute,
@@ -141,6 +143,7 @@ export function RepoGroup({
           newIds={newIds}
           selectedId={selectedId}
           selectedPaneId={selectedPaneId}
+          autoExpandedPaneId={autoExpandedPaneId}
           onDeleteNotification={onDeleteNotification}
         />
       )}
@@ -154,6 +157,7 @@ interface ExpandedPanesProps {
   newIds: Set<number>;
   selectedId: number | null;
   selectedPaneId: string | null;
+  autoExpandedPaneId: string | null;
   onDeleteNotification: (id: number) => void;
 }
 
@@ -163,6 +167,7 @@ function ExpandedPanes({
   newIds,
   selectedId,
   selectedPaneId,
+  autoExpandedPaneId,
   onDeleteNotification,
 }: ExpandedPanesProps) {
   // Group panes by Agent Teams membership (session:window key)
@@ -189,12 +194,14 @@ function ExpandedPanes({
     const isSelected =
       pi.pane.paneId === selectedPaneId ||
       (pi.notification !== null && pi.notification.id === selectedId);
+    const isAutoExpanded = pi.pane.paneId === autoExpandedPaneId;
     return (
       <PaneCard
         key={`pane-${pi.pane.paneId}`}
         paneItem={pi}
         isNew={pi.notification !== null && newIds.has(pi.notification.id)}
         isSelected={isSelected}
+        isAutoExpanded={isAutoExpanded}
         navIndex={navIndex}
         onDeleteNotification={onDeleteNotification}
       />


### PR DESCRIPTION
## Summary

- Add delayed auto-expand for pane card body text: when a card is selected for 300ms, the body text expands from 1-line truncation to full display
- During rapid j/k navigation, the timer resets so cards stay compact — no layout shifts
- Moving to another card immediately collapses the body back to 1 line

## Changes

- **`src/App.tsx`**: Add `autoExpandedPaneId` state and 300ms timer logic via `useEffect`. Reset on selection change. Scroll into view after expansion
- **`src/components/repo-group.tsx`**: Thread `autoExpandedPaneId` prop through `RepoGroupProps` → `ExpandedPanesProps` → `PaneCard`
- **`src/components/pane-card.tsx`**: Add `isAutoExpanded` prop. Toggle `line-clamp-1` off when auto-expanded


