### PR TITLE
feat: detect and display Claude Code background bash tasks

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -44,6 +44,7 @@
     "pids",
     "pkill",
     "prefs",
+    "rfind",
     "rlib",
     "rsplit",
     "rusqlite",

--- a/src-tauri/src/sessions/agents/claude.rs
+++ b/src-tauri/src/sessions/agents/claude.rs
@@ -192,7 +192,6 @@ fn check_claude_pane_content(pane_id: &str) -> ClaudePaneContentInfo {
                 agent_modes.push(label.to_string());
             }
         }
-
     }
 
     // Scan the status bar area (bottom ~7 lines) for background bash count,

--- a/src-tauri/src/sessions/agents/claude.rs
+++ b/src-tauri/src/sessions/agents/claude.rs
@@ -8,6 +8,7 @@ struct ClaudePaneContentInfo {
     at_prompt: bool,
     has_question_dialog: bool, // "Enter to select" navigation hint (AskUserQuestion dialog)
     has_plan_approval: bool,   // ❯ N. selection cursor + 2+ numbered options (plan approval etc.)
+    bash_count: Option<u32>,   // Background bash task count from "· N bash" in mode line
     agent_modes: Vec<String>,
     team_role: Option<String>, // "lead" or "teammate" (Agent Teams feature)
     team_name: Option<String>, // "@agent-alpha" for teammates
@@ -47,7 +48,10 @@ pub(super) fn detect_claude_status(
         // content still visible on screen.
         (AgentStatus::Waiting, Some("respond".to_string()))
     } else if info.at_prompt {
-        if let Some(conn) = db_conn {
+        // Background bash tasks mean work is still in progress — treat as Running
+        if info.bash_count.is_some_and(|c| c > 0) {
+            (AgentStatus::Running, None)
+        } else if let Some(conn) = db_conn {
             if let Ok(Some(_)) = db::get_latest_notification_by_pane(conn, pane_id) {
                 (AgentStatus::Waiting, None)
             } else {
@@ -87,6 +91,7 @@ fn check_claude_pane_content(pane_id: &str) -> ClaudePaneContentInfo {
         at_prompt: false,
         has_question_dialog: false,
         has_plan_approval: false,
+        bash_count: None,
         agent_modes: Vec::new(),
         team_role: None,
         team_name: None,
@@ -129,6 +134,7 @@ fn check_claude_pane_content(pane_id: &str) -> ClaudePaneContentInfo {
     let mut has_selection_cursor = false;
     let mut numbered_option_count: usize = 0;
     let mut agent_modes: Vec<String> = Vec::new();
+    let mut bash_count: Option<u32> = None; // set in status_area scan below
 
     for line in &last_lines {
         let trimmed = line.trim();
@@ -186,17 +192,25 @@ fn check_claude_pane_content(pane_id: &str) -> ClaudePaneContentInfo {
                 agent_modes.push(label.to_string());
             }
         }
+
     }
 
-    // Agent Teams detection: scan only the status bar area (bottom ~7 lines)
-    // to avoid false positives from conversation text containing "teammate"
-    // or "· ↓ to expand" strings.
+    // Scan the status bar area (bottom ~7 lines) for background bash count,
+    // Agent Teams detection, etc. Limited to 7 lines to avoid false positives
+    // from conversation text.
     let status_area = &last_lines[..last_lines.len().min(7)];
     let mut team_role: Option<String> = None;
     let mut team_name: Option<String> = None;
 
     for line in status_area {
         let trimmed = line.trim();
+
+        // Background bash task detection: "· N bash" pattern anywhere in status area.
+        // Can appear on the mode line ("⏵⏵ bypass permissions on · 1 bash")
+        // or as a standalone status line ("1 bash · PR #1381").
+        if bash_count.is_none() {
+            bash_count = extract_bash_count(trimmed);
+        }
 
         // Lead: mode line (⏵/⏸) containing "teammate"
         //   e.g., "⏸ plan mode on · 3 teammates"
@@ -262,12 +276,25 @@ fn check_claude_pane_content(pane_id: &str) -> ClaudePaneContentInfo {
         );
     }
 
+    // Add background bash count to agent_modes if detected
+    if let Some(count) = bash_count {
+        if count > 0 {
+            log::debug!(
+                "check_claude_pane_content({}): {} background bash task(s) detected",
+                pane_id,
+                count
+            );
+            agent_modes.push(format!("{} bash", count));
+        }
+    }
+
     ClaudePaneContentInfo {
         has_spinner,
         has_status_running,
         at_prompt,
         has_question_dialog,
         has_plan_approval,
+        bash_count,
         agent_modes,
         team_role,
         team_name,
@@ -287,6 +314,35 @@ fn extract_team_agent_name(line: &str) -> Option<String> {
     } else {
         None
     }
+}
+
+/// Extract background bash task count from a status bar line.
+/// Pattern 1 (mode line suffix): "⏵⏵ bypass permissions on · 1 bash" → Some(1)
+/// Pattern 2 (standalone line):  "1 bash · PR #1381" → Some(1)
+fn extract_bash_count(line: &str) -> Option<u32> {
+    let trimmed = line.trim();
+
+    // Pattern 1: "· N bash" suffix (· = U+00B7 MIDDLE DOT)
+    let marker = "\u{00B7} ";
+    if let Some(pos) = trimmed.rfind(marker) {
+        let after = trimmed[pos + marker.len()..].trim();
+        let mut parts = after.split_whitespace();
+        if let Some(count) = parts.next().and_then(|s| s.parse::<u32>().ok()) {
+            if parts.next() == Some("bash") {
+                return Some(count);
+            }
+        }
+    }
+
+    // Pattern 2: "N bash" at line start (e.g., "1 bash · PR #1381")
+    let mut parts = trimmed.split_whitespace();
+    if let Some(count) = parts.next().and_then(|s| s.parse::<u32>().ok()) {
+        if parts.next() == Some("bash") {
+            return Some(count);
+        }
+    }
+
+    None
 }
 
 /// Check if a line indicates Claude Code is actively running.

--- a/src/components/pane-card.tsx
+++ b/src/components/pane-card.tsx
@@ -1,7 +1,7 @@
 import { X, Circle, GitBranch } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { cn, formatRelativeTime } from "@/lib/utils";
-import type { PaneItem, AgentStatus, TmuxPane } from "@/lib/types";
+import type { PaneItem, TmuxPane } from "@/lib/types";
 import { IconPreset, TmuxIcon } from "@/components/icons/source-icon";
 
 interface PaneCardProps {
@@ -13,7 +13,7 @@ interface PaneCardProps {
   onDeleteNotification: (id: number) => void;
 }
 
-function statusDotClass(status: AgentStatus | null): string {
+function statusDotClass(status: TmuxPane["agentStatus"]): string {
   switch (status) {
     case "running":
       return "text-green-500 fill-green-500";
@@ -127,7 +127,10 @@ export function PaneCard({
               </span>
             )}
             {pane.agentModes.map((mode) => (
-              <span key={mode} className="text-[10px] text-[var(--text-muted)] font-medium flex-shrink-0">
+              <span key={mode} className={cn(
+                "text-[10px] font-medium flex-shrink-0",
+                mode.endsWith("bash") ? "text-green-500" : "text-[var(--text-muted)]",
+              )}>
                 {mode}
               </span>
             ))}


### PR DESCRIPTION
## Summary
- Detect Claude Code background bash tasks from the status bar (`· N bash` suffix or `N bash` at line start)
- Show panes with background bash as Running (green dot + green "N bash" badge)
- Scan the status bar area (bottom 7 lines) for two patterns:
  - Mode line suffix: `⏵⏵ bypass permissions on · 1 bash`
  - Standalone status line: `1 bash · PR #1381`

## Changes
- `src-tauri/src/sessions/agents/claude.rs`: Add `extract_bash_count()`, `bash_count` field, status override (Idle + bash → Running)
- `src/components/pane-card.tsx`: Green color for bash mode badges
- `cspell.json`: Add `rfind` to dictionary

