### PR TITLE
feat: auto-cleanup notifications when agent resumes running

### DIFF
--- a/crates/agentoast-shared/src/db.rs
+++ b/crates/agentoast-shared/src/db.rs
@@ -171,6 +171,14 @@ pub fn get_latest_notification_by_pane(
     }
 }
 
+pub fn get_notified_pane_ids(conn: &Connection) -> rusqlite::Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT tmux_pane FROM notifications WHERE tmux_pane != ''",
+    )?;
+    let rows = stmt.query_map([], |row| row.get(0))?;
+    rows.collect()
+}
+
 pub fn get_max_id(conn: &Connection) -> rusqlite::Result<i64> {
     conn.query_row(
         "SELECT COALESCE(MAX(id), 0) FROM notifications",

--- a/crates/agentoast-shared/src/db.rs
+++ b/crates/agentoast-shared/src/db.rs
@@ -172,9 +172,8 @@ pub fn get_latest_notification_by_pane(
 }
 
 pub fn get_notified_pane_ids(conn: &Connection) -> rusqlite::Result<Vec<String>> {
-    let mut stmt = conn.prepare(
-        "SELECT DISTINCT tmux_pane FROM notifications WHERE tmux_pane != ''",
-    )?;
+    let mut stmt =
+        conn.prepare("SELECT DISTINCT tmux_pane FROM notifications WHERE tmux_pane != ''")?;
     let rows = stmt.query_map([], |row| row.get(0))?;
     rows.collect()
 }

--- a/src-tauri/src/sessions/agents/mod.rs
+++ b/src-tauri/src/sessions/agents/mod.rs
@@ -18,7 +18,7 @@ pub(super) struct AgentDetectionResult {
 
 /// Capture tmux pane content as plain text.
 /// Returns None if tmux is not found or the capture command fails.
-pub(super) fn capture_pane(pane_id: &str) -> Option<String> {
+pub(crate) fn capture_pane(pane_id: &str) -> Option<String> {
     let tmux_path = find_tmux()?;
     let output = Command::new(&tmux_path)
         .env_remove("TMPDIR")
@@ -46,6 +46,51 @@ pub(super) fn is_numbered_option(line: &str) -> bool {
         Some(c) if c.is_ascii_digit() => chars.as_str().starts_with(". "),
         _ => false,
     }
+}
+
+/// Lightweight running check: capture a pane and check for universal running signals.
+/// Does NOT require agent_type or process tree — uses patterns common to all agents.
+pub(crate) fn is_pane_agent_running(pane_id: &str) -> bool {
+    let content = match capture_pane(pane_id) {
+        Some(c) => c,
+        None => return false,
+    };
+
+    content
+        .lines()
+        .rev()
+        .filter(|l| !l.trim().is_empty())
+        .take(30)
+        .any(|line| {
+            let trimmed = line.trim();
+            is_universal_running_line(trimmed)
+        })
+}
+
+/// Running signals common across Claude Code, Codex, and OpenCode.
+fn is_universal_running_line(line: &str) -> bool {
+    // Claude Code: spinner chars (✢✽✶✳✻·) + "esc to interrupt" or "…"
+    if let Some(c) = line.chars().next() {
+        if ['✢', '✽', '✶', '✳', '✻', '·'].contains(&c)
+            && (line.contains("esc to interrupt") || line.contains('…'))
+        {
+            return true;
+        }
+    }
+    // Claude Code: "· esc to interrupt" in status line
+    if line.contains("\u{00B7} esc to interrupt") {
+        return true;
+    }
+    // Claude Code: status bar "(running)" suffix
+    if line.ends_with("(running)") {
+        return true;
+    }
+    // Codex: "esc to interrupt" (covered by spinner check above)
+    // OpenCode: "esc interrupt" (without "to")
+    if line.contains("esc interrupt") {
+        return true;
+    }
+    false
 }
 
 pub(super) fn detect_agent_status(

--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -6,7 +6,7 @@ use agentoast_shared::{config, db};
 
 use crate::terminal::{find_git, find_tmux};
 
-mod agents;
+pub(crate) mod agents;
 use agents::detect_agent_status;
 
 const AGENT_PROCESSES: &[(&str, &str)] = &[

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -131,6 +131,7 @@ pub fn start(app_handle: AppHandle, db_path: PathBuf) {
         loop {
             std::thread::sleep(Duration::from_secs(5));
             check_new_notifications(&handle_for_poll, &conn, "polling");
+            cleanup_running_agent_notifications(&handle_for_poll, &conn);
         }
     });
 }
@@ -350,6 +351,44 @@ fn check_new_notifications(app_handle: &AppHandle, conn: &Connection, source: &s
     if let Ok(count) = db::get_unread_count(conn) {
         let _ = app_handle.emit("notifications:unread-count", count);
         update_tray_icon(app_handle, count);
+    }
+}
+
+/// Auto-delete notifications for panes where the agent has resumed running.
+/// Only runs capture-pane on panes that have pending notifications (no ps/process tree).
+fn cleanup_running_agent_notifications(app_handle: &AppHandle, conn: &Connection) {
+    let pane_ids = match db::get_notified_pane_ids(conn) {
+        Ok(ids) => ids,
+        Err(e) => {
+            log::debug!("cleanup_running: failed to get notified panes: {}", e);
+            return;
+        }
+    };
+    if pane_ids.is_empty() {
+        return;
+    }
+
+    let mut deleted_any = false;
+    for pane_id in &pane_ids {
+        if crate::sessions::agents::is_pane_agent_running(pane_id) {
+            log::info!(
+                "cleanup_running: pane {} is running, deleting notifications",
+                pane_id
+            );
+            if let Err(e) = db::delete_notifications_by_pane(conn, pane_id) {
+                log::error!("cleanup_running: delete failed for {}: {}", pane_id, e);
+            } else {
+                deleted_any = true;
+            }
+        }
+    }
+
+    if deleted_any {
+        if let Ok(count) = db::get_unread_count(conn) {
+            let _ = app_handle.emit("notifications:unread-count", count);
+            update_tray_icon(app_handle, count);
+        }
+        let _ = app_handle.emit("notifications:refresh", ());
     }
 }
 


### PR DESCRIPTION
## Summary

- Auto-delete notifications for panes where the agent has resumed running, so stale notifications don't linger in the panel
- Add lightweight `is_pane_agent_running()` check using universal running signals (spinner chars, "esc to interrupt", "(running)" suffix) — no process tree needed
- Add `get_notified_pane_ids()` DB query to efficiently find panes with pending notifications
- Cleanup runs every 5 seconds alongside the existing polling loop

## Changes

- `crates/agentoast-shared/src/db.rs`: Add `get_notified_pane_ids()` to query distinct pane IDs with notifications
- `src-tauri/src/sessions/agents/mod.rs`: Add `is_pane_agent_running()` and `is_universal_running_line()` for agent-agnostic running detection via capture-pane
- `src-tauri/src/sessions/mod.rs`: Make `agents` module `pub(crate)` for watcher access
- `src-tauri/src/watcher.rs`: Add `cleanup_running_agent_notifications()` to the polling loop

