### PR TITLE
feat: add [system] config for manual tmux/git binary path override

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ A toast pops up whenever an agent completes or needs attention — click it to j
 
 <img src="docs/assets/toast.png" width="400" alt="toast" />
 
+## Requirements
+
+| Command | Purpose                                | Required |
+| ------- | -------------------------------------- | -------- |
+| `tmux`  | Session/pane management, agent status  | Yes      |
+| `git`   | Repository detection, branch info      | Yes      |
+| `ps`    | Agent process detection (process tree) | Built-in |
+
+agentoast auto-detects binary paths by searching well-known locations (Homebrew, system, Nix). If the Sessions panel is empty, see the [`[system]` config](#system-binary-paths) to set paths manually.
+
 ## Installation
 
 ```bash
@@ -138,6 +148,30 @@ Editor resolution priority is `config.toml` `editor` field → `$EDITOR` → `vi
 # Format: modifier+key (modifiers: ctrl, shift, alt/option, super/cmd)
 # Set to "" to disable
 # toggle_panel = "super+ctrl+n"
+
+# System settings
+# Override auto-detected binary paths (useful when auto-detection fails)
+# [system]
+# tmux = "/custom/path/to/tmux"
+# git = "/custom/path/to/git"
+```
+
+#### System Binary Paths
+
+agentoast auto-detects `tmux` and `git` by searching in this order.
+
+1. **Well-known paths** — Homebrew (Apple Silicon / Intel), system (`/usr/bin`)
+2. **Nix paths** — Home Manager (`/etc/profiles/per-user/$USER/bin/`), single-user (`/nix/var/nix/profiles/default/bin/`)
+3. **`$PATH` fallback** — scans `$PATH` entries (mise, asdf, etc.)
+
+> **Note:** The `$PATH` fallback only works when the app is launched from a terminal. Finder / Dock / Spotlight launches do not inherit the shell `$PATH`.
+
+If auto-detection fails (Sessions panel is empty), override the path in `config.toml`.
+
+```toml
+[system]
+tmux = "/your/custom/path/to/tmux"
+git = "/your/custom/path/to/git"
 ```
 
 ### Keyboard Shortcuts

--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -44,6 +44,8 @@ pub struct AppConfig {
     pub keybinding: KeybindingConfig,
     #[serde(default)]
     pub update: UpdateConfig,
+    #[serde(default)]
+    pub system: SystemConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -230,6 +232,12 @@ impl Default for UpdateConfig {
     }
 }
 
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SystemConfig {
+    pub tmux: Option<String>,
+    pub git: Option<String>,
+}
+
 fn default_claude_code_events() -> Vec<String> {
     vec![
         "Stop".to_string(),
@@ -356,6 +364,12 @@ fn default_config_template() -> &'static str {
 [update]
 # Enable auto-update check (default: true)
 # enabled = true
+
+# System settings
+# Override auto-detected binary paths (useful when auto-detection fails)
+# [system]
+# tmux = "/custom/path/to/tmux"
+# git = "/custom/path/to/git"
 
 "#
 }

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -1,5 +1,14 @@
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::OnceLock;
+
+use agentoast_shared::config::{self, AppConfig};
+
+static CONFIG: OnceLock<AppConfig> = OnceLock::new();
+
+fn get_config() -> &'static AppConfig {
+    CONFIG.get_or_init(config::load_config)
+}
 
 const KNOWN_TERMINAL_BUNDLE_IDS: &[&str] = &[
     "com.github.wez.wezterm",
@@ -11,6 +20,18 @@ const KNOWN_TERMINAL_BUNDLE_IDS: &[&str] = &[
 ];
 
 pub(crate) fn find_tmux() -> Option<PathBuf> {
+    // config.toml override (highest priority)
+    if let Some(ref path) = get_config().system.tmux {
+        let p = PathBuf::from(path);
+        if p.exists() {
+            return Some(p);
+        }
+        log::warn!(
+            "config.toml system.tmux={} not found, falling back to auto-detection",
+            path
+        );
+    }
+
     let mut candidates: Vec<PathBuf> = vec![
         PathBuf::from("/opt/homebrew/bin/tmux"), // Homebrew (Apple Silicon)
         PathBuf::from("/usr/local/bin/tmux"),    // Homebrew (Intel) / manual
@@ -45,6 +66,18 @@ pub(crate) fn find_tmux() -> Option<PathBuf> {
 }
 
 pub(crate) fn find_git() -> Option<PathBuf> {
+    // config.toml override (highest priority)
+    if let Some(ref path) = get_config().system.git {
+        let p = PathBuf::from(path);
+        if p.exists() {
+            return Some(p);
+        }
+        log::warn!(
+            "config.toml system.git={} not found, falling back to auto-detection",
+            path
+        );
+    }
+
     let mut candidates: Vec<PathBuf> = vec![
         PathBuf::from("/usr/bin/git"),          // system (Xcode CLT)
         PathBuf::from("/opt/homebrew/bin/git"), // Homebrew (Apple Silicon)


### PR DESCRIPTION
## Summary

- Add `[system]` section to `config.toml` for manual `tmux` / `git` binary path override
- Auto-detection (Homebrew → system → Nix → `$PATH`) may fail when launched from Finder/Dock since `$PATH` is not inherited from the shell
- If the configured path does not exist, a warning is logged and auto-detection is used as fallback

## Changes

- `crates/agentoast-shared/src/config.rs` — `SystemConfig` struct, `AppConfig.system` field, config template
- `src-tauri/src/terminal.rs` — `OnceLock<AppConfig>` for config, override check in `find_tmux()` / `find_git()`
- `README.md` — Requirements section (external dependencies), `[system]` config documentation


