### PR TITLE
feat: add --version/-v flag to CLI with git revision

### DIFF
--- a/crates/agentoast-cli/build.rs
+++ b/crates/agentoast-cli/build.rs
@@ -1,0 +1,12 @@
+use std::process::Command;
+
+fn main() {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .expect("Failed to retrieve Git commit hash.");
+    let git_hash =
+        String::from_utf8(output.stdout).expect("Failed to convert Git commit hash to string.");
+
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash.trim());
+}

--- a/crates/agentoast-cli/src/main.rs
+++ b/crates/agentoast-cli/src/main.rs
@@ -6,11 +6,28 @@ use clap::{Parser, Subcommand};
 
 use hooks::{get_git_info, parse_metadata};
 
+const APP_VERSION: &str = concat!(
+    env!("CARGO_PKG_NAME"),
+    " version ",
+    env!("CARGO_PKG_VERSION"),
+    " (rev:",
+    env!("GIT_HASH"),
+    ")"
+);
+
 #[derive(Parser)]
-#[command(name = "agentoast", about = "Agentoast - CLI notification tool")]
+#[command(
+    name = "agentoast",
+    about = "Agentoast - CLI notification tool",
+    disable_version_flag = true
+)]
 struct Cli {
+    /// Print version
+    #[arg(long, short = 'v')]
+    version: bool,
+
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 }
 
 #[derive(Subcommand)]
@@ -97,7 +114,18 @@ enum HookAgent {
 fn main() {
     let cli = Cli::parse();
 
-    match cli.command {
+    if cli.version {
+        println!("{APP_VERSION}");
+        return;
+    }
+
+    let Some(command) = cli.command else {
+        use clap::CommandFactory;
+        Cli::command().print_help().unwrap();
+        std::process::exit(1);
+    };
+
+    match command {
         Commands::Send {
             badge,
             body,


### PR DESCRIPTION
## Summary

- Add `--version` / `-v` flag to the `agentoast` CLI
- Display format: `agentoast-cli version X.Y.Z (rev:abcdef0)`
- Uses `build.rs` to capture git commit hash at compile time

## Changes

- **`crates/agentoast-cli/build.rs`** (new): Build script that runs `git rev-parse --short HEAD` and sets `GIT_HASH` env var
- **`crates/agentoast-cli/src/main.rs`**: Add `APP_VERSION` constant, `disable_version_flag = true`, custom `-v`/`--version` flag, and version handling before subcommand dispatch

