### PR TITLE
chore: add gh-infra config for repository settings management

### DIFF
--- a/.github/infra/agentoast.yaml
+++ b/.github/infra/agentoast.yaml
@@ -1,0 +1,57 @@
+apiVersion: gh-infra/v1
+kind: Repository
+metadata:
+  name: agentoast
+  owner: shuntaka9576
+spec:
+  description: 🍞 Toast notifications from AI coding agents on your macOS menu bar, with tmux pane switching
+  visibility: public
+  archived: false
+  topics:
+    - anthropic
+    - claude
+    - claude-code
+    - codex
+    - openai
+    - opencode
+    - tmux
+    - claude-ai
+  features:
+    issues: true
+    projects: true
+    wiki: true
+    discussions: false
+  merge_strategy:
+    allow_merge_commit: true
+    allow_squash_merge: true
+    allow_rebase_merge: true
+    auto_delete_head_branches: true
+    squash_merge_commit_title: COMMIT_OR_PR_TITLE
+    squash_merge_commit_message: COMMIT_MESSAGES
+    merge_commit_title: MERGE_MESSAGE
+    merge_commit_message: PR_TITLE
+  release_immutability: true
+  rulesets:
+    - name: main
+      target: branch
+      enforcement: active
+      conditions:
+        ref_name:
+          include:
+            - ~DEFAULT_BRANCH
+      rules:
+        non_fast_forward: true
+        deletion: true
+        creation: false
+        required_linear_history: false
+        required_signatures: false
+  variables:
+    - name: APP_ID
+      value: "2861791"
+  actions:
+    enabled: true
+    allowed_actions: all
+    sha_pinning_required: false
+    workflow_permissions: read
+    can_approve_pull_requests: true
+    fork_pr_approval: first_time_contributors

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -214,6 +214,14 @@ description = "Run all linters (Rust + frontend)"
 dependencies = ["fmt-check", "clippy", "fmt-check-vp", "lint-vp", "spell-check"]
 
 # ---------------------------------------------------------------------------
+# Infra (gh-infra)
+# ---------------------------------------------------------------------------
+[tasks.gh-validate]
+description = "Validate GitHub repository config"
+command = "gh"
+args = ["infra", "validate", ".github/infra/"]
+
+# ---------------------------------------------------------------------------
 # Clean
 # ---------------------------------------------------------------------------
 [tasks.clean]


### PR DESCRIPTION
## Summary
- Add `gh-infra` repository config at `.github/infra/agentoast.yaml`
- Add `gh-validate` task to `Makefile.toml` for validating repository config

