### PR TITLE
fix(panel): eliminate flicker when showing panel via shortcut or tray click

### DIFF
--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -153,8 +153,53 @@ pub fn position_panel_at_tray_icon(
     let panel_x_phys =
         panel_x_phys.min(monitor_pos.x + monitor_size.width as i32 - window_width_phys);
 
-    let final_pos = tauri::PhysicalPosition::new(panel_x_phys, panel_y_phys);
-    let _ = window.set_position(final_pos);
+    set_panel_position_sync(app_handle, panel_x_phys, panel_y_phys, scale_factor);
+}
+
+/// Set panel position directly via NSPanel (synchronous, no Tauri async dispatch).
+/// Converts from Tauri physical coordinates (top-left origin) to macOS screen
+/// coordinates (bottom-left origin).
+fn set_panel_position_sync(app_handle: &tauri::AppHandle, phys_x: i32, phys_y: i32, scale: f64) {
+    let panel_handle = match app_handle.get_webview_panel("main") {
+        Ok(p) => p,
+        Err(_) => {
+            log::warn!("set_panel_position_sync: panel not found");
+            return;
+        }
+    };
+    let ns_panel = panel_handle.as_panel();
+
+    unsafe {
+        use objc2::msg_send;
+
+        // Get the panel's current frame to know window height
+        let frame: tauri_nspanel::NSRect = msg_send![ns_panel, frame];
+
+        // Get primary screen height for coordinate conversion.
+        // NSScreen.screens[0] is always the primary screen (with menu bar).
+        let screens: *const objc2::runtime::AnyObject = msg_send![objc2::class!(NSScreen), screens];
+        if screens.is_null() {
+            return;
+        }
+        let count: usize = msg_send![screens, count];
+        if count == 0 {
+            return;
+        }
+        let primary: *const objc2::runtime::AnyObject =
+            msg_send![screens, objectAtIndex: 0usize];
+        if primary.is_null() {
+            return;
+        }
+        let screen_frame: tauri_nspanel::NSRect = msg_send![primary, frame];
+
+        // Convert: physical top-left → logical bottom-left
+        let logical_x = phys_x as f64 / scale;
+        let logical_y = phys_y as f64 / scale;
+        let macos_y = screen_frame.size.height - logical_y - frame.size.height;
+
+        let origin = tauri_nspanel::NSPoint::new(logical_x, macos_y);
+        let _: () = msg_send![ns_panel, setFrameOrigin: origin];
+    }
 }
 
 /// Find the monitor whose bounds contain the given physical point.
@@ -174,7 +219,11 @@ fn find_monitor_containing(
 }
 
 /// Position panel at the top-right (menu bar area) of the given monitor.
-fn position_panel_on_monitor(window: &tauri::WebviewWindow, monitor: &tauri::Monitor) {
+fn position_panel_on_monitor(
+    app_handle: &tauri::AppHandle,
+    window: &tauri::WebviewWindow,
+    monitor: &tauri::Monitor,
+) {
     let scale = monitor.scale_factor();
     let mon_pos = monitor.position();
     let mon_size = monitor.size();
@@ -204,7 +253,7 @@ fn position_panel_on_monitor(window: &tauri::WebviewWindow, monitor: &tauri::Mon
     let panel_y = panel_y.max(mon_pos.y);
     let panel_y = panel_y.min(mon_pos.y + mon_size.height as i32 - win_size.height as i32);
 
-    let _ = window.set_position(tauri::PhysicalPosition::new(panel_x, panel_y));
+    set_panel_position_sync(app_handle, panel_x, panel_y, scale);
 }
 
 /// Position panel for shortcut-triggered toggle.
@@ -263,7 +312,7 @@ pub fn position_panel_for_shortcut(app_handle: &tauri::AppHandle) {
         // Cursor on a different monitor (or tray monitor unknown) → position on cursor's monitor
         (Some(cursor_mp), _) => {
             if let Some(monitor) = monitors.iter().find(|m| *m.position() == cursor_mp) {
-                position_panel_on_monitor(&window, monitor);
+                position_panel_on_monitor(app_handle, &window, monitor);
             }
         }
         // cursor_position() failed → fallback to tray position if available
@@ -273,7 +322,7 @@ pub fn position_panel_for_shortcut(app_handle: &tauri::AppHandle) {
         // Both failed → fallback to first monitor's top-right
         (None, None) => {
             if let Some(monitor) = monitors.first() {
-                position_panel_on_monitor(&window, monitor);
+                position_panel_on_monitor(app_handle, &window, monitor);
             }
         }
     }

--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -153,13 +153,19 @@ pub fn position_panel_at_tray_icon(
     let panel_x_phys =
         panel_x_phys.min(monitor_pos.x + monitor_size.width as i32 - window_width_phys);
 
-    set_panel_position_sync(app_handle, panel_x_phys, panel_y_phys, scale_factor);
+    set_panel_position_sync(app_handle, panel_x_phys, panel_y_phys, monitor);
 }
 
 /// Set panel position directly via NSPanel (synchronous, no Tauri async dispatch).
-/// Converts from Tauri physical coordinates (top-left origin) to macOS screen
-/// coordinates (bottom-left origin).
-fn set_panel_position_sync(app_handle: &tauri::AppHandle, phys_x: i32, phys_y: i32, scale: f64) {
+/// Converts from Tauri global physical coordinates (top-left origin) to macOS screen
+/// coordinates (bottom-left origin) using the target monitor for correct mixed-DPI
+/// multi-monitor conversion.
+fn set_panel_position_sync(
+    app_handle: &tauri::AppHandle,
+    phys_x: i32,
+    phys_y: i32,
+    monitor: &tauri::Monitor,
+) {
     let panel_handle = match app_handle.get_webview_panel("main") {
         Ok(p) => p,
         Err(_) => {
@@ -168,16 +174,28 @@ fn set_panel_position_sync(app_handle: &tauri::AppHandle, phys_x: i32, phys_y: i
         }
     };
     let ns_panel = panel_handle.as_panel();
+    let scale = monitor.scale_factor();
+    let mon_pos = monitor.position();
+    let mon_size = monitor.size();
 
     unsafe {
         use objc2::msg_send;
 
         // Get the panel's current frame to know window height
         let frame: tauri_nspanel::NSRect = msg_send![ns_panel, frame];
+        let win_height = frame.size.height;
 
-        // Get primary screen height for coordinate conversion.
-        // NSScreen.screens[0] is always the primary screen (with menu bar).
-        let screens: *const objc2::runtime::AnyObject = msg_send![objc2::class!(NSScreen), screens];
+        // Convert global physical to local physical (relative to target monitor)
+        let local_phys_x = phys_x - mon_pos.x;
+        let local_phys_y = phys_y - mon_pos.y;
+
+        // Convert local physical to local logical using the target monitor's scale
+        let local_logical_x = local_phys_x as f64 / scale;
+        let local_logical_y = local_phys_y as f64 / scale;
+
+        // Find the matching NSScreen by logical dimensions
+        let screens: *const objc2::runtime::AnyObject =
+            msg_send![objc2::class!(NSScreen), screens];
         if screens.is_null() {
             return;
         }
@@ -185,18 +203,48 @@ fn set_panel_position_sync(app_handle: &tauri::AppHandle, phys_x: i32, phys_y: i
         if count == 0 {
             return;
         }
-        let primary: *const objc2::runtime::AnyObject = msg_send![screens, objectAtIndex: 0usize];
-        if primary.is_null() {
-            return;
+
+        let mon_logical_w = mon_size.width as f64 / scale;
+        let mon_logical_h = mon_size.height as f64 / scale;
+
+        let mut screen_frame: Option<tauri_nspanel::NSRect> = None;
+        for i in 0..count {
+            let scr: *const objc2::runtime::AnyObject =
+                msg_send![screens, objectAtIndex: i];
+            if scr.is_null() {
+                continue;
+            }
+            let sf: tauri_nspanel::NSRect = msg_send![scr, frame];
+            // Match by logical dimensions (tolerance for rounding)
+            if (sf.size.width - mon_logical_w).abs() < 2.0
+                && (sf.size.height - mon_logical_h).abs() < 2.0
+            {
+                screen_frame = Some(sf);
+                break;
+            }
         }
-        let screen_frame: tauri_nspanel::NSRect = msg_send![primary, frame];
 
-        // Convert: physical top-left → logical bottom-left
-        let logical_x = phys_x as f64 / scale;
-        let logical_y = phys_y as f64 / scale;
-        let macos_y = screen_frame.size.height - logical_y - frame.size.height;
+        let screen_frame = match screen_frame {
+            Some(f) => f,
+            None => {
+                // Fallback to primary screen
+                let primary: *const objc2::runtime::AnyObject =
+                    msg_send![screens, objectAtIndex: 0usize];
+                if primary.is_null() {
+                    return;
+                }
+                msg_send![primary, frame]
+            }
+        };
 
-        let origin = tauri_nspanel::NSPoint::new(logical_x, macos_y);
+        // Convert to macOS coordinates using the matched NSScreen's frame.
+        // NSScreen origin is at bottom-left in macOS global logical coords.
+        // local_logical_y is distance from the TOP of the screen (Tauri convention).
+        let macos_x = screen_frame.origin.x + local_logical_x;
+        let macos_y =
+            screen_frame.origin.y + screen_frame.size.height - local_logical_y - win_height;
+
+        let origin = tauri_nspanel::NSPoint::new(macos_x, macos_y);
         let _: () = msg_send![ns_panel, setFrameOrigin: origin];
     }
 }
@@ -252,7 +300,7 @@ fn position_panel_on_monitor(
     let panel_y = panel_y.max(mon_pos.y);
     let panel_y = panel_y.min(mon_pos.y + mon_size.height as i32 - win_size.height as i32);
 
-    set_panel_position_sync(app_handle, panel_x, panel_y, scale);
+    set_panel_position_sync(app_handle, panel_x, panel_y, monitor);
 }
 
 /// Position panel for shortcut-triggered toggle.

--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -185,8 +185,7 @@ fn set_panel_position_sync(app_handle: &tauri::AppHandle, phys_x: i32, phys_y: i
         if count == 0 {
             return;
         }
-        let primary: *const objc2::runtime::AnyObject =
-            msg_send![screens, objectAtIndex: 0usize];
+        let primary: *const objc2::runtime::AnyObject = msg_send![screens, objectAtIndex: 0usize];
         if primary.is_null() {
             return;
         }

--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -194,8 +194,7 @@ fn set_panel_position_sync(
         let local_logical_y = local_phys_y as f64 / scale;
 
         // Find the matching NSScreen by logical dimensions
-        let screens: *const objc2::runtime::AnyObject =
-            msg_send![objc2::class!(NSScreen), screens];
+        let screens: *const objc2::runtime::AnyObject = msg_send![objc2::class!(NSScreen), screens];
         if screens.is_null() {
             return;
         }
@@ -209,8 +208,7 @@ fn set_panel_position_sync(
 
         let mut screen_frame: Option<tauri_nspanel::NSRect> = None;
         for i in 0..count {
-            let scr: *const objc2::runtime::AnyObject =
-                msg_send![screens, objectAtIndex: i];
+            let scr: *const objc2::runtime::AnyObject = msg_send![screens, objectAtIndex: i];
             if scr.is_null() {
                 continue;
             }

--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -206,7 +206,13 @@ fn set_panel_position_sync(
         let mon_logical_w = mon_size.width as f64 / scale;
         let mon_logical_h = mon_size.height as f64 / scale;
 
+        // Approximate expected NSScreen origin.x from Tauri physical position.
+        // Exact for uniform-DPI setups (the only case where duplicate sizes occur
+        // in practice); reasonable heuristic for mixed-DPI.
+        let expected_x = mon_pos.x as f64 / scale;
+
         let mut screen_frame: Option<tauri_nspanel::NSRect> = None;
+        let mut best_dist = f64::MAX;
         for i in 0..count {
             let scr: *const objc2::runtime::AnyObject = msg_send![screens, objectAtIndex: i];
             if scr.is_null() {
@@ -217,8 +223,13 @@ fn set_panel_position_sync(
             if (sf.size.width - mon_logical_w).abs() < 2.0
                 && (sf.size.height - mon_logical_h).abs() < 2.0
             {
-                screen_frame = Some(sf);
-                break;
+                // Among size-matched screens, pick the one closest to the
+                // expected origin to disambiguate identical monitors.
+                let dist = (sf.origin.x - expected_x).abs();
+                if dist < best_dist {
+                    best_dist = dist;
+                    screen_frame = Some(sf);
+                }
             }
         }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -48,8 +48,10 @@ pub fn toggle_panel(app_handle: &AppHandle) {
         panel.hide();
     } else {
         let _ = app_handle.emit("notifications:refresh", ());
+        panel.set_alpha_value(0.0);
         panel.show_and_make_key();
         crate::panel::position_panel_for_shortcut(app_handle);
+        panel.set_alpha_value(1.0);
     }
 }
 
@@ -114,8 +116,10 @@ pub fn create(app_handle: &AppHandle) -> tauri::Result<()> {
                         return;
                     }
 
+                    panel.set_alpha_value(0.0);
                     panel.show_and_make_key();
                     position_panel_at_tray_icon(app_handle, rect.position, rect.size);
+                    panel.set_alpha_value(1.0);
                 }
             }
         })


### PR DESCRIPTION
## Summary

- Fix panel flicker when toggling via global shortcut (Ctrl+Alt+N) or tray icon click
- Replace Tauri's async `window.set_position()` with synchronous `setFrameOrigin:` via `msg_send!` on the NSPanel directly
- Wrap panel show sequence in `set_alpha_value(0→1)` to ensure the panel is invisible until positioned
- Correct multi-monitor coordinate conversion for mixed-DPI and identical-monitor setups

## Details

### Problem
When the panel was shown, it briefly appeared at its previous position before moving to the correct location. This happened because Tauri's `window.set_position()` dispatches the position change asynchronously (deferred to the next run loop iteration), while tauri-nspanel's `set_alpha_value()` and `show_and_make_key()` execute synchronously via direct ObjC `msg_send!`.

### Fix
- **`panel.rs`**: Added `set_panel_position_sync()` helper that calls `[NSPanel setFrameOrigin:]` directly via `msg_send!`, bypassing Tauri's async dispatch.
- **`tray.rs`**: Both shortcut and tray click paths now use: `alpha(0)` → `show` → `position (sync)` → `alpha(1)`.

### Multi-monitor coordinate conversion
The coordinate conversion properly handles mixed-DPI and identical-monitor setups:
1. Convert global physical → monitor-local physical (subtract target monitor origin)
2. Convert local physical → local logical (divide by target monitor's scale factor)
3. Match the corresponding NSScreen by logical size + origin proximity (disambiguates identical monitors)
4. Use the matched NSScreen's `frame.origin` and `frame.size.height` for macOS coordinate conversion

## Test plan
- [ ] `cargo make dev` — app launches without errors
- [ ] Press Ctrl+Alt+N to toggle panel — no flicker at previous position
- [ ] Click tray icon to toggle panel — no flicker at previous position
- [ ] Panel appears aligned under the tray icon
- [ ] Multi-monitor: panel appears on the correct monitor
