### PR TITLE
perf(panel): parallelize get_sessions and eliminate panel open/close lag

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,6 +86,7 @@ fn show_panel(app_handle: tauri::AppHandle) {
     panel::init(&app_handle).ok();
     use tauri_nspanel::ManagerExt;
     if let Ok(panel) = app_handle.get_webview_panel("main") {
+        let _ = app_handle.emit("panel:shown", ());
         let _ = app_handle.emit("notifications:refresh", ());
         panel.show();
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -105,10 +105,12 @@ fn focus_terminal(tmux_pane: String, terminal_bundle_id: String) -> Result<(), S
 }
 
 #[tauri::command]
-fn get_sessions() -> Result<Vec<TmuxPaneGroup>, String> {
+async fn get_sessions() -> Result<Vec<TmuxPaneGroup>, String> {
     #[cfg(target_os = "macos")]
     {
-        sessions::list_tmux_panes_grouped()
+        tauri::async_runtime::spawn_blocking(sessions::list_tmux_panes_grouped)
+            .await
+            .map_err(|e| e.to_string())?
     }
     #[cfg(not(target_os = "macos"))]
     {

--- a/src-tauri/src/sessions/agents/claude.rs
+++ b/src-tauri/src/sessions/agents/claude.rs
@@ -1,6 +1,6 @@
 use agentoast_shared::{db, models::AgentStatus};
 
-use super::{capture_pane, is_numbered_option, AgentDetectionResult};
+use super::{is_numbered_option, AgentDetectionResult};
 
 struct ClaudePaneContentInfo {
     has_spinner: bool, // Spinner chars + "…" / "esc to interrupt" (real-time, reliable)
@@ -17,8 +17,9 @@ struct ClaudePaneContentInfo {
 pub(super) fn detect_claude_status(
     db_conn: &Option<db::Connection>,
     pane_id: &str,
+    content: Option<&str>,
 ) -> AgentDetectionResult {
-    let info = check_claude_pane_content(pane_id);
+    let info = check_claude_pane_content(pane_id, content);
 
     log::debug!(
         "detect_claude_status({}): spinner={} status_running={} question_dialog={} plan_approval={} prompt={}",
@@ -84,7 +85,7 @@ const MODE_PATTERNS: &[(&str, &str)] = &[
     ("accept edits on", "accept"),
 ];
 
-fn check_claude_pane_content(pane_id: &str) -> ClaudePaneContentInfo {
+fn check_claude_pane_content(pane_id: &str, content: Option<&str>) -> ClaudePaneContentInfo {
     let default = ClaudePaneContentInfo {
         has_spinner: false,
         has_status_running: false,
@@ -97,11 +98,11 @@ fn check_claude_pane_content(pane_id: &str) -> ClaudePaneContentInfo {
         team_name: None,
     };
 
-    let content = match capture_pane(pane_id) {
+    let content = match content {
         Some(c) => c,
         None => {
             log::debug!(
-                "check_claude_pane_content({}): capture-pane failed",
+                "check_claude_pane_content({}): no content available",
                 pane_id
             );
             return default;

--- a/src-tauri/src/sessions/agents/codex.rs
+++ b/src-tauri/src/sessions/agents/codex.rs
@@ -68,7 +68,10 @@ fn check_codex_pane_content(pane_id: &str, content: Option<&str>) -> CodexPaneCo
     let content = match content {
         Some(c) => c,
         None => {
-            log::debug!("check_codex_pane_content({}): no content available", pane_id);
+            log::debug!(
+                "check_codex_pane_content({}): no content available",
+                pane_id
+            );
             return default;
         }
     };

--- a/src-tauri/src/sessions/agents/codex.rs
+++ b/src-tauri/src/sessions/agents/codex.rs
@@ -1,6 +1,6 @@
 use agentoast_shared::{db, models::AgentStatus};
 
-use super::{capture_pane, is_numbered_option, AgentDetectionResult};
+use super::{is_numbered_option, AgentDetectionResult};
 
 struct CodexPaneContentInfo {
     is_running: bool,          // "(XXs • esc to interrupt)" pattern
@@ -12,8 +12,9 @@ struct CodexPaneContentInfo {
 pub(super) fn detect_codex_status(
     db_conn: &Option<db::Connection>,
     pane_id: &str,
+    content: Option<&str>,
 ) -> AgentDetectionResult {
-    let info = check_codex_pane_content(pane_id);
+    let info = check_codex_pane_content(pane_id, content);
 
     log::debug!(
         "detect_codex_status({}): running={} question_dialog={} plan_approval={} prompt={}",
@@ -56,7 +57,7 @@ pub(super) fn detect_codex_status(
     }
 }
 
-fn check_codex_pane_content(pane_id: &str) -> CodexPaneContentInfo {
+fn check_codex_pane_content(pane_id: &str, content: Option<&str>) -> CodexPaneContentInfo {
     let default = CodexPaneContentInfo {
         is_running: false,
         has_question_dialog: false,
@@ -64,10 +65,10 @@ fn check_codex_pane_content(pane_id: &str) -> CodexPaneContentInfo {
         at_prompt: false,
     };
 
-    let content = match capture_pane(pane_id) {
+    let content = match content {
         Some(c) => c,
         None => {
-            log::debug!("check_codex_pane_content({}): capture-pane failed", pane_id);
+            log::debug!("check_codex_pane_content({}): no content available", pane_id);
             return default;
         }
     };

--- a/src-tauri/src/sessions/agents/copilot.rs
+++ b/src-tauri/src/sessions/agents/copilot.rs
@@ -1,6 +1,6 @@
 use agentoast_shared::{db, models::AgentStatus};
 
-use super::{capture_pane, is_numbered_option, AgentDetectionResult};
+use super::{is_numbered_option, AgentDetectionResult};
 
 /// Copilot CLI spinner characters that cycle during "Thinking" state.
 const COPILOT_SPINNER_CHARS: &[char] = &[
@@ -34,8 +34,9 @@ struct CopilotPaneContentInfo {
 pub(super) fn detect_copilot_status(
     db_conn: &Option<db::Connection>,
     pane_id: &str,
+    content: Option<&str>,
 ) -> AgentDetectionResult {
-    let info = check_copilot_pane_content(pane_id);
+    let info = check_copilot_pane_content(pane_id, content);
 
     log::debug!(
         "detect_copilot_status({}): spinner={} selection={} tool_approval={} prompt={}",
@@ -79,7 +80,7 @@ pub(super) fn detect_copilot_status(
     }
 }
 
-fn check_copilot_pane_content(pane_id: &str) -> CopilotPaneContentInfo {
+fn check_copilot_pane_content(pane_id: &str, content: Option<&str>) -> CopilotPaneContentInfo {
     let default = CopilotPaneContentInfo {
         has_spinner: false,
         has_selection_dialog: false,
@@ -88,11 +89,11 @@ fn check_copilot_pane_content(pane_id: &str) -> CopilotPaneContentInfo {
         agent_modes: Vec::new(),
     };
 
-    let content = match capture_pane(pane_id) {
+    let content = match content {
         Some(c) => c,
         None => {
             log::debug!(
-                "check_copilot_pane_content({}): capture-pane failed",
+                "check_copilot_pane_content({}): no content available",
                 pane_id
             );
             return default;

--- a/src-tauri/src/sessions/agents/mod.rs
+++ b/src-tauri/src/sessions/agents/mod.rs
@@ -100,16 +100,30 @@ fn is_universal_running_line(line: &str) -> bool {
     false
 }
 
+#[allow(dead_code)]
 pub(super) fn detect_agent_status(
     db_conn: &Option<db::Connection>,
     pane_id: &str,
     agent_type: &str,
 ) -> AgentDetectionResult {
+    let content = capture_pane(pane_id);
+    detect_agent_status_with_content(db_conn, pane_id, agent_type, content.as_deref())
+}
+
+/// Detect agent status using pre-captured pane content.
+/// This avoids redundant capture-pane calls when content is already available
+/// (e.g., captured in parallel by the caller).
+pub(super) fn detect_agent_status_with_content(
+    db_conn: &Option<db::Connection>,
+    pane_id: &str,
+    agent_type: &str,
+    content: Option<&str>,
+) -> AgentDetectionResult {
     match agent_type {
-        "claude-code" => claude::detect_claude_status(db_conn, pane_id),
-        "codex" => codex::detect_codex_status(db_conn, pane_id),
-        "copilot-cli" => copilot::detect_copilot_status(db_conn, pane_id),
-        "opencode" => opencode::detect_opencode_status(db_conn, pane_id),
+        "claude-code" => claude::detect_claude_status(db_conn, pane_id, content),
+        "codex" => codex::detect_codex_status(db_conn, pane_id, content),
+        "copilot-cli" => copilot::detect_copilot_status(db_conn, pane_id, content),
+        "opencode" => opencode::detect_opencode_status(db_conn, pane_id, content),
         _ => {
             log::debug!(
                 "detect_agent_status({}): unknown agent_type='{}', defaulting to Running",

--- a/src-tauri/src/sessions/agents/opencode.rs
+++ b/src-tauri/src/sessions/agents/opencode.rs
@@ -1,6 +1,6 @@
 use agentoast_shared::{db, models::AgentStatus};
 
-use super::{capture_pane, AgentDetectionResult};
+use super::AgentDetectionResult;
 
 /// OpenCode mode patterns: (substring after ▣ prefix, label for frontend)
 const OPENCODE_MODE_PATTERNS: &[(&str, &str)] = &[("Plan", "plan"), ("Build", "build")];
@@ -15,8 +15,9 @@ struct OpencodePaneContentInfo {
 pub(super) fn detect_opencode_status(
     db_conn: &Option<db::Connection>,
     pane_id: &str,
+    content: Option<&str>,
 ) -> AgentDetectionResult {
-    let info = check_opencode_pane_content(pane_id);
+    let info = check_opencode_pane_content(pane_id, content);
 
     log::debug!(
         "detect_opencode_status({}): running={} permission={} selection={}",
@@ -53,7 +54,7 @@ pub(super) fn detect_opencode_status(
     }
 }
 
-fn check_opencode_pane_content(pane_id: &str) -> OpencodePaneContentInfo {
+fn check_opencode_pane_content(pane_id: &str, content: Option<&str>) -> OpencodePaneContentInfo {
     let default = OpencodePaneContentInfo {
         is_running: false,
         has_selection_dialog: false,
@@ -61,11 +62,11 @@ fn check_opencode_pane_content(pane_id: &str) -> OpencodePaneContentInfo {
         agent_modes: Vec::new(),
     };
 
-    let content = match capture_pane(pane_id) {
+    let content = match content {
         Some(c) => c,
         None => {
             log::debug!(
-                "check_opencode_pane_content({}): capture-pane failed",
+                "check_opencode_pane_content({}): no content available",
                 pane_id
             );
             return default;

--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -7,7 +7,7 @@ use agentoast_shared::{config, db};
 use crate::terminal::{find_git, find_tmux};
 
 pub(crate) mod agents;
-use agents::detect_agent_status;
+use agents::{capture_pane, detect_agent_status_with_content};
 
 const AGENT_PROCESSES: &[(&str, &str)] = &[
     ("claude", "claude-code"),
@@ -23,95 +23,102 @@ struct GitInfo {
     branch: Option<String>,
 }
 
-/// Resolve git info for each unique path. Caches results per polling cycle.
-fn resolve_git_info(paths: &[String]) -> HashMap<String, Option<GitInfo>> {
-    let mut cache: HashMap<String, Option<GitInfo>> = HashMap::new();
+/// Resolve git info for a single path (3 git commands: rev-parse, remote, branch).
+fn resolve_single_git_info(git_path: &std::path::Path, path: &str) -> Option<GitInfo> {
+    // git rev-parse --show-toplevel
+    let repo_root = Command::new(git_path)
+        .env_remove("TMPDIR")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(path)
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })?;
 
+    // git remote get-url origin → extract repo name from URL
+    let repo_name = Command::new(git_path)
+        .env_remove("TMPDIR")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(path)
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                let url = String::from_utf8_lossy(&o.stdout).trim().to_string();
+                extract_repo_name_from_url(&url)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| {
+            // Fallback: last component of repo_root
+            repo_root
+                .rsplit('/')
+                .next()
+                .unwrap_or(&repo_root)
+                .to_string()
+        });
+
+    // git branch --show-current
+    let branch = Command::new(git_path)
+        .env_remove("TMPDIR")
+        .args(["branch", "--show-current"])
+        .current_dir(path)
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                let b = String::from_utf8_lossy(&o.stdout).trim().to_string();
+                if b.is_empty() { None } else { Some(b) }
+            } else {
+                None
+            }
+        });
+
+    Some(GitInfo {
+        repo_root,
+        repo_name,
+        branch,
+    })
+}
+
+/// Resolve git info for each unique path in parallel.
+fn resolve_git_info(paths: &[String]) -> HashMap<String, Option<GitInfo>> {
     let git_path = match find_git() {
         Some(p) => p,
         None => {
-            for path in paths {
-                cache.insert(path.clone(), None);
-            }
-            return cache;
+            return paths.iter().map(|p| (p.clone(), None)).collect();
         }
     };
 
-    for path in paths {
-        if cache.contains_key(path) {
-            continue;
-        }
+    // Deduplicate paths
+    let unique: Vec<&String> = paths
+        .iter()
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
 
-        // git rev-parse --show-toplevel
-        let repo_root = Command::new(&git_path)
-            .env_remove("TMPDIR")
-            .args(["rev-parse", "--show-toplevel"])
-            .current_dir(path)
-            .output()
-            .ok()
-            .and_then(|o| {
-                if o.status.success() {
-                    Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
-                } else {
-                    None
-                }
-            });
+    // Resolve git info in parallel (one thread per unique path)
+    std::thread::scope(|s| {
+        let handles: Vec<_> = unique
+            .iter()
+            .map(|path| {
+                let git_path = &git_path;
+                let path_str = path.as_str();
+                s.spawn(move || (path_str.to_string(), resolve_single_git_info(git_path, path_str)))
+            })
+            .collect();
 
-        let info = match repo_root {
-            Some(root) => {
-                // git remote get-url origin → extract repo name from URL
-                let repo_name = Command::new(&git_path)
-                    .env_remove("TMPDIR")
-                    .args(["remote", "get-url", "origin"])
-                    .current_dir(path)
-                    .output()
-                    .ok()
-                    .and_then(|o| {
-                        if o.status.success() {
-                            let url = String::from_utf8_lossy(&o.stdout).trim().to_string();
-                            extract_repo_name_from_url(&url)
-                        } else {
-                            None
-                        }
-                    })
-                    .unwrap_or_else(|| {
-                        // Fallback: last component of repo_root
-                        root.rsplit('/').next().unwrap_or(&root).to_string()
-                    });
-
-                // git branch --show-current
-                let branch = Command::new(&git_path)
-                    .env_remove("TMPDIR")
-                    .args(["branch", "--show-current"])
-                    .current_dir(path)
-                    .output()
-                    .ok()
-                    .and_then(|o| {
-                        if o.status.success() {
-                            let b = String::from_utf8_lossy(&o.stdout).trim().to_string();
-                            if b.is_empty() {
-                                None
-                            } else {
-                                Some(b)
-                            }
-                        } else {
-                            None
-                        }
-                    });
-
-                Some(GitInfo {
-                    repo_root: root,
-                    repo_name,
-                    branch,
-                })
-            }
-            None => None,
-        };
-
-        cache.insert(path.clone(), info);
-    }
-
-    cache
+        handles
+            .into_iter()
+            .map(|h| h.join().unwrap())
+            .collect()
+    })
 }
 
 /// Extract repository name from a git remote URL.
@@ -234,23 +241,57 @@ pub fn list_tmux_panes_grouped() -> Result<Vec<TmuxPaneGroup>, String> {
     // Open DB connection for agent status detection (read-only, no schema init)
     let db_conn = db::open_reader(&config::db_path()).ok();
 
-    // Resolve git info for all unique paths
+    // Collect unique paths and agent panes for parallel execution
     let unique_paths: Vec<String> = raw_panes
         .iter()
         .map(|p| p.current_path.clone())
         .collect::<std::collections::HashSet<_>>()
         .into_iter()
         .collect();
-    let git_cache = resolve_git_info(&unique_paths);
 
-    // Build TmuxPane with git info and agent status
+    // Collect agent pane indices for parallel capture-pane
+    let agent_pane_indices: Vec<usize> = raw_panes
+        .iter()
+        .enumerate()
+        .filter(|(_, rp)| rp.agent_type.is_some())
+        .map(|(i, _)| i)
+        .collect();
+
+    // Run git info resolution and capture-pane in parallel
+    let (git_cache, captured_contents) = std::thread::scope(|s| {
+        // Git info: one thread per unique path
+        let git_handle = s.spawn(|| resolve_git_info(&unique_paths));
+
+        // Capture-pane: one thread per agent pane
+        let capture_handles: Vec<_> = agent_pane_indices
+            .iter()
+            .map(|&idx| {
+                let pane_id = raw_panes[idx].pane_id.as_str();
+                s.spawn(move || (idx, capture_pane(pane_id)))
+            })
+            .collect();
+
+        let git_cache = git_handle.join().unwrap();
+        let captured: HashMap<usize, Option<String>> = capture_handles
+            .into_iter()
+            .map(|h| h.join().unwrap())
+            .collect();
+
+        (git_cache, captured)
+    });
+
+    // Build TmuxPane with git info and agent status (DB lookups on main thread)
     let panes: Vec<TmuxPane> = raw_panes
         .into_iter()
-        .map(|rp| {
+        .enumerate()
+        .map(|(idx, rp)| {
             let git_info = git_cache.get(&rp.current_path).and_then(|o| o.as_ref());
             let (agent_status, waiting_reason, agent_modes, team_role, team_name) =
                 if let Some(ref at) = rp.agent_type {
-                    let r = detect_agent_status(&db_conn, &rp.pane_id, at);
+                    let content = captured_contents
+                        .get(&idx)
+                        .and_then(|c| c.as_deref());
+                    let r = detect_agent_status_with_content(&db_conn, &rp.pane_id, at, content);
                     (
                         Some(r.status),
                         r.waiting_reason,

--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -74,7 +74,11 @@ fn resolve_single_git_info(git_path: &std::path::Path, path: &str) -> Option<Git
         .and_then(|o| {
             if o.status.success() {
                 let b = String::from_utf8_lossy(&o.stdout).trim().to_string();
-                if b.is_empty() { None } else { Some(b) }
+                if b.is_empty() {
+                    None
+                } else {
+                    Some(b)
+                }
             } else {
                 None
             }
@@ -110,14 +114,16 @@ fn resolve_git_info(paths: &[String]) -> HashMap<String, Option<GitInfo>> {
             .map(|path| {
                 let git_path = &git_path;
                 let path_str = path.as_str();
-                s.spawn(move || (path_str.to_string(), resolve_single_git_info(git_path, path_str)))
+                s.spawn(move || {
+                    (
+                        path_str.to_string(),
+                        resolve_single_git_info(git_path, path_str),
+                    )
+                })
             })
             .collect();
 
-        handles
-            .into_iter()
-            .map(|h| h.join().unwrap())
-            .collect()
+        handles.into_iter().map(|h| h.join().unwrap()).collect()
     })
 }
 
@@ -288,9 +294,7 @@ pub fn list_tmux_panes_grouped() -> Result<Vec<TmuxPaneGroup>, String> {
             let git_info = git_cache.get(&rp.current_path).and_then(|o| o.as_ref());
             let (agent_status, waiting_reason, agent_modes, team_role, team_name) =
                 if let Some(ref at) = rp.agent_type {
-                    let content = captured_contents
-                        .get(&idx)
-                        .and_then(|c| c.as_deref());
+                    let content = captured_contents.get(&idx).and_then(|c| c.as_deref());
                     let r = detect_agent_status_with_content(&db_conn, &rp.pane_id, at, content);
                     (
                         Some(r.status),

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -35,6 +35,7 @@ macro_rules! get_or_init_panel {
 
 fn show_panel(app_handle: &AppHandle) {
     if let Some(panel) = get_or_init_panel!(app_handle) {
+        let _ = app_handle.emit("panel:shown", ());
         let _ = app_handle.emit("notifications:refresh", ());
         panel.show_and_make_key();
     }
@@ -47,6 +48,7 @@ pub fn toggle_panel(app_handle: &AppHandle) {
     if panel.is_visible() {
         panel.hide();
     } else {
+        let _ = app_handle.emit("panel:shown", ());
         let _ = app_handle.emit("notifications:refresh", ());
         panel.set_alpha_value(0.0);
         panel.show_and_make_key();
@@ -116,6 +118,8 @@ pub fn create(app_handle: &AppHandle) -> tauri::Result<()> {
                         return;
                     }
 
+                    let _ = app_handle.emit("panel:shown", ());
+                    let _ = app_handle.emit("notifications:refresh", ());
                     panel.set_alpha_value(0.0);
                     panel.show_and_make_key();
                     position_panel_at_tray_icon(app_handle, rect.position, rect.size);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -446,8 +446,8 @@ export function App() {
         if (item.type === "group-header") {
           toggleGroupExpanded(item.groupKey);
         } else if (item.type === "pane-item") {
-          activatePaneItem(item.paneItem);
           void invoke("hide_panel");
+          activatePaneItem(item.paneItem);
         }
         break;
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,7 @@ export function App() {
   const autoExpandTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const needFetchVersionRef = useRef(-1);
-  const pendingRepositionRef = useRef(true); // true for initial mount
+  const repositionCancelledRef = useRef(false);
   const fetchVersionRef = useRef(fetchVersion);
   fetchVersionRef.current = fetchVersion;
 
@@ -296,10 +296,11 @@ export function App() {
     return result;
   }, [displayGroups, collapsedGroups]);
 
-  // Mark for cursor repositioning when panel is shown (don't reset selectedIndex)
+  // Reset selection when panel is shown
   useEffect(() => {
-    const unlisten = listen("notifications:refresh", () => {
-      pendingRepositionRef.current = true;
+    const unlisten = listen("panel:shown", () => {
+      setSelectedIndex(-1);
+      repositionCancelledRef.current = false;
       needFetchVersionRef.current = fetchVersionRef.current;
     });
     return () => {
@@ -311,15 +312,11 @@ export function App() {
   useEffect(() => {
     setSelectedIndex((prev) => {
       if (flatItems.length === 0) return -1;
-
-      if (pendingRepositionRef.current) {
+      if (prev < 0 && !repositionCancelledRef.current) {
         // Wait until sessions data is fresh after panel show
         if (needFetchVersionRef.current >= 0 && fetchVersion <= needFetchVersionRef.current) {
-          // Keep current cursor position (optimistic UI — don't reset to -1)
-          return prev < 0 ? prev : Math.min(prev, flatItems.length - 1);
+          return -1;
         }
-        // Fresh data arrived — reposition cursor
-        pendingRepositionRef.current = false;
         needFetchVersionRef.current = -1;
 
         // If notifications exist, focus the pane with the most recent notification
@@ -347,7 +344,6 @@ export function App() {
         const idx = flatItems.findIndex((f) => f.type !== "group-header");
         return idx >= 0 ? idx : 0;
       }
-
       return Math.min(prev, flatItems.length - 1);
     });
   }, [flatItems, filterNotifiedOnly, fetchVersion]);
@@ -430,6 +426,7 @@ export function App() {
       case "j":
         if (showHelp) break;
         e.preventDefault();
+        repositionCancelledRef.current = true;
         if (flatItems.length > 0) {
           setSelectedIndex((prev) => Math.min(prev + 1, flatItems.length - 1));
         }
@@ -437,6 +434,7 @@ export function App() {
       case "k":
         if (showHelp) break;
         e.preventDefault();
+        repositionCancelledRef.current = true;
         if (flatItems.length > 0) {
           setSelectedIndex((prev) => Math.max(prev - 1, 0));
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ export function App() {
   const autoExpandTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const needFetchVersionRef = useRef(-1);
+  const pendingRepositionRef = useRef(true); // true for initial mount
   const fetchVersionRef = useRef(fetchVersion);
   fetchVersionRef.current = fetchVersion;
 
@@ -295,10 +296,10 @@ export function App() {
     return result;
   }, [displayGroups, collapsedGroups]);
 
-  // Reset selection when panel is shown
+  // Mark for cursor repositioning when panel is shown (don't reset selectedIndex)
   useEffect(() => {
     const unlisten = listen("notifications:refresh", () => {
-      setSelectedIndex(-1);
+      pendingRepositionRef.current = true;
       needFetchVersionRef.current = fetchVersionRef.current;
     });
     return () => {
@@ -306,15 +307,19 @@ export function App() {
     };
   }, []);
 
-  // Clamp selectedIndex when items change
+  // Clamp selectedIndex when items change; reposition cursor when fresh data arrives
   useEffect(() => {
     setSelectedIndex((prev) => {
       if (flatItems.length === 0) return -1;
-      if (prev < 0) {
+
+      if (pendingRepositionRef.current) {
         // Wait until sessions data is fresh after panel show
         if (needFetchVersionRef.current >= 0 && fetchVersion <= needFetchVersionRef.current) {
-          return -1;
+          // Keep current cursor position (optimistic UI — don't reset to -1)
+          return prev < 0 ? prev : Math.min(prev, flatItems.length - 1);
         }
+        // Fresh data arrived — reposition cursor
+        pendingRepositionRef.current = false;
         needFetchVersionRef.current = -1;
 
         // If notifications exist, focus the pane with the most recent notification
@@ -342,6 +347,7 @@ export function App() {
         const idx = flatItems.findIndex((f) => f.type !== "group-header");
         return idx >= 0 ? idx : 0;
       }
+
       return Math.min(prev, flatItems.length - 1);
     });
   }, [flatItems, filterNotifiedOnly, fetchVersion]);

--- a/src/components/notification-card.tsx
+++ b/src/components/notification-card.tsx
@@ -37,6 +37,7 @@ export function NotificationCard({
         isSelected && "bg-[var(--hover-bg)]",
       )}
       onClick={() => {
+        void invoke("hide_panel");
         if (notification.tmuxPane) {
           void invoke("delete_notifications_by_pane", {
             tmuxPane: notification.tmuxPane,
@@ -48,7 +49,6 @@ export function NotificationCard({
           tmuxPane: notification.tmuxPane,
           terminalBundleId: notification.terminalBundleId,
         });
-        void invoke("hide_panel");
       }}
     >
       <div className="flex items-start gap-2.5">

--- a/src/components/pane-card.tsx
+++ b/src/components/pane-card.tsx
@@ -77,6 +77,7 @@ export function PaneCard({
     : [];
 
   const handleClick = () => {
+    void invoke("hide_panel");
     if (notification) {
       void invoke("delete_notifications_by_pane", {
         tmuxPane: notification.tmuxPane,
@@ -86,7 +87,6 @@ export function PaneCard({
       tmuxPane: pane.paneId,
       terminalBundleId: notification?.terminalBundleId ?? "",
     });
-    void invoke("hide_panel");
   };
 
   const icon = pane.agentType ?? notification?.icon ?? "agentoast";

--- a/src/hooks/use-notifications.ts
+++ b/src/hooks/use-notifications.ts
@@ -44,7 +44,6 @@ export function useNotifications() {
 
     const unlisten2 = listen<number>("notifications:unread-count", (event) => {
       setUnreadCount(event.payload);
-      void refresh();
     });
 
     const unlisten3 = listen("notifications:refresh", () => {

--- a/src/hooks/use-sessions.ts
+++ b/src/hooks/use-sessions.ts
@@ -1,7 +1,37 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import type { TmuxPaneGroup } from "@/lib/types";
+import type { TmuxPane, TmuxPaneGroup } from "@/lib/types";
+
+function shallowEqualPanes(a: TmuxPane, b: TmuxPane): boolean {
+  return (
+    a.paneId === b.paneId &&
+    a.agentType === b.agentType &&
+    a.agentStatus === b.agentStatus &&
+    a.waitingReason === b.waitingReason &&
+    a.teamRole === b.teamRole &&
+    a.teamName === b.teamName &&
+    a.isActive === b.isActive &&
+    a.agentModes.length === b.agentModes.length &&
+    a.agentModes.every((m, i) => m === b.agentModes[i])
+  );
+}
+
+function shallowEqualGroups(
+  a: TmuxPaneGroup[],
+  b: TmuxPaneGroup[],
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].currentPath !== b[i].currentPath) return false;
+    if (a[i].gitBranch !== b[i].gitBranch) return false;
+    if (a[i].panes.length !== b[i].panes.length) return false;
+    for (let j = 0; j < a[i].panes.length; j++) {
+      if (!shallowEqualPanes(a[i].panes[j], b[i].panes[j])) return false;
+    }
+  }
+  return true;
+}
 
 export function useSessions() {
   const [groups, setGroups] = useState<TmuxPaneGroup[]>([]);
@@ -15,7 +45,7 @@ export function useSessions() {
       const result = await invoke<TmuxPaneGroup[]>("get_sessions");
       if (mountedRef.current) {
         setGroups((prev) => {
-          if (JSON.stringify(prev) === JSON.stringify(result)) return prev;
+          if (shallowEqualGroups(prev, result)) return prev;
           return result;
         });
         setFetchVersion((v) => v + 1);

--- a/src/hooks/use-sessions.ts
+++ b/src/hooks/use-sessions.ts
@@ -17,10 +17,7 @@ function shallowEqualPanes(a: TmuxPane, b: TmuxPane): boolean {
   );
 }
 
-function shallowEqualGroups(
-  a: TmuxPaneGroup[],
-  b: TmuxPaneGroup[],
-): boolean {
+function shallowEqualGroups(a: TmuxPaneGroup[], b: TmuxPaneGroup[]): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
     if (a[i].currentPath !== b[i].currentPath) return false;


### PR DESCRIPTION
## Summary

Improve perceived performance across all phases of panel interaction: opening, navigating, and closing.

- Parallelize git commands and capture-pane calls in `get_sessions` via `std::thread::scope` (serial ~160ms → parallel ~50ms)
- Move `get_sessions` to `async fn` + `spawn_blocking` so it no longer blocks the main thread (keyboard input is responsive immediately while data loads)
- Call `hide_panel` before `focus_terminal` on item selection so the panel disappears instantly, with tmux pane switching (~280ms) running in the background
- Eliminate redundant frontend refresh calls and replace `JSON.stringify` comparison with shallow field-level equality

## Changes

### Backend

**`src-tauri/src/sessions/mod.rs`**
- `resolve_git_info`: parallelize per-repo git commands via `std::thread::scope` (3 repos × 3 commands serial → 3 repos parallel)
- `list_tmux_panes_grouped`: run git info resolution and capture-pane concurrently
- Extract `resolve_single_git_info` for parallelization

**`src-tauri/src/sessions/agents/mod.rs`**
- Add `detect_agent_status_with_content()` that accepts pre-captured content, eliminating redundant capture-pane calls

**`src-tauri/src/sessions/agents/{claude,codex,copilot,opencode}.rs`**
- Change `check_*_pane_content()` to accept `Option<&str>` content instead of calling `capture_pane` internally

**`src-tauri/src/lib.rs`**
- Change `get_sessions` to `async fn` + `tauri::async_runtime::spawn_blocking` to unblock the main thread
- Emit `panel:shown` event from `show_panel` command

**`src-tauri/src/tray.rs`**
- Emit `panel:shown` + `notifications:refresh` on all panel-show paths (tray click, shortcut, menu)
- Separate `panel:shown` (cursor repositioning) from `notifications:refresh` (data refresh) to prevent unexpected cursor jumps during background data updates

### Frontend

**`src/App.tsx`**
- Listen to `panel:shown` for cursor reset (`selectedIndex = -1`) with `repositionCancelledRef` for j/k cancellation
- When user presses j/k before data arrives, cancel auto-reposition
- Call `hide_panel` before `focus_terminal` on Enter/click selection

**`src/components/{pane-card,notification-card}.tsx`**
- Reorder `hide_panel` before `focus_terminal` invocations

**`src/hooks/use-sessions.ts`**
- Replace `JSON.stringify` comparison with `shallowEqualGroups`

**`src/hooks/use-notifications.ts`**
- Remove redundant `refresh()` from `notifications:unread-count` listener
