### PR TITLE
style(panel): add inset ring to selected item for cursor visibility

### DIFF
--- a/src/components/pane-card.tsx
+++ b/src/components/pane-card.tsx
@@ -102,6 +102,7 @@ export function PaneCard({
         isNew && "animate-new-highlight",
         isSelected && "bg-[var(--hover-bg)]",
       )}
+      style={isSelected ? { boxShadow: "var(--selection-ring)" } : undefined}
       onClick={handleClick}
     >
       <div className="flex items-start gap-2.5">

--- a/src/components/repo-group.tsx
+++ b/src/components/repo-group.tsx
@@ -69,6 +69,7 @@ export function RepoGroup({
           "w-full px-4 py-2 text-left hover:bg-[var(--hover-bg)]",
           isHeaderSelected && "bg-[var(--hover-bg)]",
         )}
+        style={isHeaderSelected ? { boxShadow: "var(--selection-ring)" } : undefined}
       >
         {/* Line 1: chevron + icon + repoName + notification actions */}
         <div className="flex items-center gap-2">

--- a/src/index.css
+++ b/src/index.css
@@ -35,6 +35,7 @@
   --badge-focus-text: #7c3aed;
 
   --new-highlight-bg: rgba(59, 130, 246, 0.08);
+  --selection-ring: inset 0 0 0 1.5px rgba(0, 0, 0, 0.15);
 }
 
 /* Dark mode */
@@ -73,6 +74,7 @@
     --badge-focus-text: #a78bfa;
 
     --new-highlight-bg: rgba(59, 130, 246, 0.12);
+    --selection-ring: inset 0 0 0 1.5px rgba(255, 255, 255, 0.2);
   }
 }
 


### PR DESCRIPTION
## Summary

- Add `--selection-ring` CSS custom property (inset box-shadow) for keyboard-selected items
- Apply the ring to PaneCard and RepoGroup header when selected via j/k navigation
- Improves cursor visibility when mouse hover overlaps with keyboard selection

## Changes

- **`src/index.css`**: Add `--selection-ring` variable for light (`rgba(0,0,0,0.15)`) and dark (`rgba(255,255,255,0.2)`) modes
- **`src/components/pane-card.tsx`**: Apply `boxShadow` style when `isSelected`
- **`src/components/repo-group.tsx`**: Apply `boxShadow` style when `isHeaderSelected`

