### PR TITLE
perf(sessions): tmux control mode + event-driven refresh

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -55,6 +55,7 @@
     "subviews",
     "staticlib",
     "tauri",
+    "topo",
     "unlisten",
     "untap",
     "wezterm",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,7 +11,11 @@ mod tray;
 mod watcher;
 
 use std::collections::HashSet;
+#[cfg(target_os = "macos")]
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 use std::sync::Mutex;
+#[cfg(target_os = "macos")]
+use std::time::Duration;
 
 use agentoast_shared::config::{self, AppConfig};
 use agentoast_shared::db;
@@ -20,9 +24,22 @@ use serde::Serialize;
 use tauri::{Emitter, Manager};
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 
+#[cfg(target_os = "macos")]
+const SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
+#[cfg(target_os = "macos")]
+const TOPOLOGY_DEBOUNCE: Duration = Duration::from_millis(200);
+#[cfg(target_os = "macos")]
+#[allow(dead_code)]
+const FALLBACK_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
 pub struct AppState {
     pub db_path: std::path::PathBuf,
     pub config: AppConfig,
+}
+
+#[derive(Default)]
+pub struct SessionsCache {
+    pub groups: Option<Vec<TmuxPaneGroup>>,
 }
 
 #[derive(Default)]
@@ -47,6 +64,76 @@ impl MuteState {
             muted_repos: repos,
         }
     }
+}
+
+pub fn emit_cached_sessions(app_handle: &tauri::AppHandle) {
+    if let Some(cache) = app_handle.try_state::<Mutex<SessionsCache>>() {
+        if let Ok(guard) = cache.lock() {
+            if let Some(groups) = guard.groups.as_ref() {
+                let _ = app_handle.emit("sessions:cached", groups);
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn refresh_and_emit(app_handle: &tauri::AppHandle, ctrl: Option<&sessions::TmuxCtrl>) {
+    match sessions::list_tmux_panes_grouped(ctrl) {
+        Ok(groups) => {
+            if let Some(cache) = app_handle.try_state::<Mutex<SessionsCache>>() {
+                if let Ok(mut guard) = cache.lock() {
+                    guard.groups = Some(groups.clone());
+                }
+            }
+            let _ = app_handle.emit("sessions:updated", &groups);
+        }
+        Err(e) => {
+            log::debug!("sessions refresh: list_tmux_panes_grouped failed: {}", e);
+        }
+    }
+}
+
+/// Topology-driven refresh loop. Wakes on `%window-add` / `%session-changed`
+/// notifications from tmux ctrl, debounces bursts (a single user action often
+/// fires multiple events), and falls back to a 30s safety refresh so a missed
+/// event eventually self-heals. Replaces the fixed 2s polling we had in Phase 1.
+#[cfg(target_os = "macos")]
+fn start_sessions_event_loop(
+    app_handle: tauri::AppHandle,
+    ctrl: sessions::TmuxCtrl,
+    rx: Receiver<sessions::TopologyChanged>,
+) {
+    std::thread::spawn(move || loop {
+        match rx.recv_timeout(SAFETY_POLL_INTERVAL) {
+            Ok(_) => {
+                std::thread::sleep(TOPOLOGY_DEBOUNCE);
+                while rx.try_recv().is_ok() {}
+                refresh_and_emit(&app_handle, Some(&ctrl));
+            }
+            Err(RecvTimeoutError::Timeout) => {
+                refresh_and_emit(&app_handle, Some(&ctrl));
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                log::error!("sessions event loop: channel disconnected");
+                break;
+            }
+        }
+    });
+}
+
+/// Fixed-interval fallback poller used when tmux ctrl is unavailable
+/// (e.g. tmux binary missing). Kept for non-macOS or future Linux paths.
+#[cfg(target_os = "macos")]
+#[allow(dead_code)]
+fn start_sessions_safety_poller(
+    app_handle: tauri::AppHandle,
+    ctrl: Option<sessions::TmuxCtrl>,
+    interval: Duration,
+) {
+    std::thread::spawn(move || loop {
+        std::thread::sleep(interval);
+        refresh_and_emit(&app_handle, ctrl.as_ref());
+    });
 }
 
 pub fn do_toggle_global_mute(app_handle: &tauri::AppHandle) -> Result<MuteStatePayload, String> {
@@ -87,6 +174,7 @@ fn show_panel(app_handle: tauri::AppHandle) {
     use tauri_nspanel::ManagerExt;
     if let Ok(panel) = app_handle.get_webview_panel("main") {
         let _ = app_handle.emit("panel:shown", ());
+        emit_cached_sessions(&app_handle);
         let _ = app_handle.emit("notifications:refresh", ());
         panel.show();
     }
@@ -106,15 +194,30 @@ fn focus_terminal(tmux_pane: String, terminal_bundle_id: String) -> Result<(), S
 }
 
 #[tauri::command]
-async fn get_sessions() -> Result<Vec<TmuxPaneGroup>, String> {
+async fn get_sessions(app_handle: tauri::AppHandle) -> Result<Vec<TmuxPaneGroup>, String> {
     #[cfg(target_os = "macos")]
     {
-        tauri::async_runtime::spawn_blocking(sessions::list_tmux_panes_grouped)
-            .await
-            .map_err(|e| e.to_string())?
+        let ctrl = app_handle
+            .try_state::<sessions::TmuxCtrl>()
+            .map(|s| s.inner().clone());
+        let result = tauri::async_runtime::spawn_blocking(move || {
+            sessions::list_tmux_panes_grouped(ctrl.as_ref())
+        })
+        .await
+        .map_err(|e| e.to_string())?;
+        if let Ok(ref groups) = result {
+            if let Some(cache) = app_handle.try_state::<Mutex<SessionsCache>>() {
+                if let Ok(mut guard) = cache.lock() {
+                    guard.groups = Some(groups.clone());
+                }
+            }
+            let _ = app_handle.emit("sessions:updated", groups);
+        }
+        result
     }
     #[cfg(not(target_os = "macos"))]
     {
+        let _ = app_handle;
         Err("Sessions are only supported on macOS".to_string())
     }
 }
@@ -329,6 +432,8 @@ pub fn run() {
                 config: app_config,
             }));
 
+            app.manage(Mutex::new(SessionsCache { groups: None }));
+
             app.manage(Mutex::new(MuteState {
                 global_muted: initial_muted,
                 muted_repos: HashSet::new(),
@@ -386,6 +491,18 @@ pub fn run() {
 
             // Start DB watcher
             watcher::start(app.handle().clone(), db_path);
+
+            // Spawn tmux control-mode client and register it so subsequent
+            // calls reuse a single long-lived tmux process. The Sender side of
+            // the topology channel is moved into TmuxCtrl, the Receiver into
+            // the event loop below.
+            #[cfg(target_os = "macos")]
+            {
+                let (topo_tx, topo_rx) = mpsc::channel::<sessions::TopologyChanged>();
+                let ctrl = sessions::TmuxCtrl::spawn(Some(topo_tx));
+                app.manage(ctrl.clone());
+                start_sessions_event_loop(app.handle().clone(), ctrl, topo_rx);
+            }
 
             Ok(())
         })

--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -74,22 +74,25 @@ pub fn position_panel_at_tray_icon(
             return;
         }
     };
-    let mut found_monitor = None;
-
-    for m in &monitors {
+    // Find the monitor containing the tray icon.
+    // When the menu bar is hidden (auto-hide or fullscreen), the tray icon Y coordinate
+    // may fall outside monitor bounds. In that case, fall back to X-only matching so
+    // that the correct monitor is used for scale factor and coordinate conversion.
+    let found_monitor = monitors.iter().find(|m| {
         let pos = m.position();
         let size = m.size();
         let x_in = icon_phys_x >= pos.x && icon_phys_x < pos.x + size.width as i32;
         let y_in = icon_phys_y >= pos.y && icon_phys_y < pos.y + size.height as i32;
+        x_in && y_in
+    });
+    let found_monitor = found_monitor.or_else(|| {
+        monitors.iter().find(|m| {
+            let pos = m.position();
+            let size = m.size();
+            icon_phys_x >= pos.x && icon_phys_x < pos.x + size.width as i32
+        })
+    });
 
-        if x_in && y_in {
-            found_monitor = Some(m);
-            break;
-        }
-    }
-
-    // Fullscreen mode may cause tray icon coordinates to fall outside monitor bounds.
-    // Fall back to the first available monitor.
     let monitor = match found_monitor.or_else(|| monitors.first()) {
         Some(m) => m,
         None => {
@@ -141,12 +144,15 @@ pub fn position_panel_at_tray_icon(
     let nudge_up_phys = (nudge_up_points * scale_factor).round() as i32;
     let panel_y_phys = icon_phys_y + icon_height_phys - nudge_up_phys;
 
-    // Clamp panel position within monitor bounds so it doesn't go off-screen
-    // (e.g. fullscreen mode where tray icon coords may be above visible area).
+    // Clamp panel position within monitor bounds.
+    // Use menu-bar-bottom as the Y minimum so that the panel never sticks to
+    // the very top of the screen (happens when menu bar is auto-hidden or
+    // in fullscreen mode — tray.rect() returns y≈0 in these cases).
     let monitor_pos = monitor.position();
     let monitor_size = monitor.size();
     let window_height_phys = window_size.height as i32;
-    let panel_y_phys = panel_y_phys.max(monitor_pos.y);
+    let menu_bar_bottom_phys = monitor_pos.y + (25.0 * scale_factor).round() as i32 - nudge_up_phys;
+    let panel_y_phys = panel_y_phys.max(menu_bar_bottom_phys);
     let panel_y_phys =
         panel_y_phys.min(monitor_pos.y + monitor_size.height as i32 - window_height_phys);
     let panel_x_phys = panel_x_phys.max(monitor_pos.x);
@@ -357,22 +363,39 @@ pub fn position_panel_for_shortcut(app_handle: &tauri::AppHandle) {
             };
             let tray_monitor_pos =
                 find_monitor_containing(&monitors, tx, ty).map(|m| *m.position());
-            (rect, tray_monitor_pos)
+            (rect, tx, tray_monitor_pos)
         });
 
     match (cursor_monitor_pos, &tray_info) {
         // Cursor and tray on the same monitor → use tray position for precise alignment
-        (Some(cursor_mp), Some((rect, Some(tray_mp)))) if cursor_mp == *tray_mp => {
+        (Some(cursor_mp), Some((rect, _, Some(tray_mp)))) if cursor_mp == *tray_mp => {
             position_panel_at_tray_icon(app_handle, rect.position, rect.size);
         }
-        // Cursor on a different monitor (or tray monitor unknown) → position on cursor's monitor
+        // Tray Y out of bounds but X on cursor's monitor (hidden menu bar / fullscreen)
+        // → still use tray position so the panel aligns with the tray icon horizontally
+        (Some(cursor_mp), Some((rect, tx, None))) => {
+            let tray_x_on_cursor_monitor = monitors
+                .iter()
+                .find(|m| *m.position() == cursor_mp)
+                .is_some_and(|mon| {
+                    let mp = mon.position();
+                    let ms = mon.size();
+                    *tx >= mp.x && *tx < mp.x + ms.width as i32
+                });
+            if tray_x_on_cursor_monitor {
+                position_panel_at_tray_icon(app_handle, rect.position, rect.size);
+            } else if let Some(monitor) = monitors.iter().find(|m| *m.position() == cursor_mp) {
+                position_panel_on_monitor(app_handle, &window, monitor);
+            }
+        }
+        // Cursor on a different monitor → position on cursor's monitor
         (Some(cursor_mp), _) => {
             if let Some(monitor) = monitors.iter().find(|m| *m.position() == cursor_mp) {
                 position_panel_on_monitor(app_handle, &window, monitor);
             }
         }
         // cursor_position() failed → fallback to tray position if available
-        (None, Some((rect, _))) => {
+        (None, Some((rect, _, _))) => {
             position_panel_at_tray_icon(app_handle, rect.position, rect.size);
         }
         // Both failed → fallback to first monitor's top-right

--- a/src-tauri/src/sessions/agents/mod.rs
+++ b/src-tauri/src/sessions/agents/mod.rs
@@ -2,6 +2,7 @@ use std::process::Command;
 
 use agentoast_shared::{db, models::AgentStatus};
 
+use crate::sessions::ctrl::TmuxCtrl;
 use crate::terminal::find_tmux;
 
 mod claude;
@@ -18,24 +19,35 @@ pub(super) struct AgentDetectionResult {
 }
 
 /// Capture tmux pane content as plain text.
-/// Returns None if tmux is not found or the capture command fails.
-pub(crate) fn capture_pane(pane_id: &str) -> Option<String> {
-    let tmux_path = find_tmux()?;
-    let output = Command::new(&tmux_path)
-        .env_remove("TMPDIR")
-        .args(["capture-pane", "-t", pane_id, "-p"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        log::debug!(
-            "capture_pane({}): exit={} stderr={}",
-            pane_id,
-            output.status,
-            String::from_utf8_lossy(&output.stderr)
-        );
-        return None;
+/// When `ctrl` is provided, uses the long-lived control-mode client. Otherwise
+/// falls back to spawning `tmux capture-pane` directly.
+pub(crate) fn capture_pane(ctrl: Option<&TmuxCtrl>, pane_id: &str) -> Option<String> {
+    if let Some(ctrl) = ctrl {
+        match ctrl.send(&format!("capture-pane -t {} -p", pane_id)) {
+            Ok(lines) => Some(lines.join("\n")),
+            Err(e) => {
+                log::debug!("capture_pane({}): ctrl failed: {}", pane_id, e);
+                None
+            }
+        }
+    } else {
+        let tmux_path = find_tmux()?;
+        let output = Command::new(&tmux_path)
+            .env_remove("TMPDIR")
+            .args(["capture-pane", "-t", pane_id, "-p"])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            log::debug!(
+                "capture_pane({}): exit={} stderr={}",
+                pane_id,
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return None;
+        }
+        Some(String::from_utf8_lossy(&output.stdout).into_owned())
     }
-    Some(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 /// Check if a line is a numbered option (e.g., "1. Yes", "2. No").
@@ -51,8 +63,8 @@ pub(super) fn is_numbered_option(line: &str) -> bool {
 
 /// Lightweight running check: capture a pane and check for universal running signals.
 /// Does NOT require agent_type or process tree — uses patterns common to all agents.
-pub(crate) fn is_pane_agent_running(pane_id: &str) -> bool {
-    let content = match capture_pane(pane_id) {
+pub(crate) fn is_pane_agent_running(ctrl: Option<&TmuxCtrl>, pane_id: &str) -> bool {
+    let content = match capture_pane(ctrl, pane_id) {
         Some(c) => c,
         None => return false,
     };
@@ -102,11 +114,12 @@ fn is_universal_running_line(line: &str) -> bool {
 
 #[allow(dead_code)]
 pub(super) fn detect_agent_status(
+    ctrl: Option<&TmuxCtrl>,
     db_conn: &Option<db::Connection>,
     pane_id: &str,
     agent_type: &str,
 ) -> AgentDetectionResult {
-    let content = capture_pane(pane_id);
+    let content = capture_pane(ctrl, pane_id);
     detect_agent_status_with_content(db_conn, pane_id, agent_type, content.as_deref())
 }
 

--- a/src-tauri/src/sessions/ctrl.rs
+++ b/src-tauri/src/sessions/ctrl.rs
@@ -1,0 +1,306 @@
+//! tmux control mode (`tmux -C`) client.
+//!
+//! Maintains a long-lived tmux client process over a single pipe, avoiding per-call
+//! fork+exec overhead. Commands are serialized through a worker thread: each caller
+//! sends a command string, gets back the response lines collected between tmux's
+//! `%begin` / `%end` markers. Asynchronous notifications (window-add etc.) flow into
+//! a separate listener channel for event-driven cache invalidation.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{ChildStdout, Command, Stdio};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::thread;
+use std::time::Duration;
+
+use crate::terminal::find_tmux;
+
+const HANDSHAKE_SENTINEL: &str = "__agentoast_ctrl_ready__";
+const RECONNECT_BACKOFF: Duration = Duration::from_secs(3);
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+const CTRL_SESSION_NAME: &str = "_agentoast_ctrl";
+
+#[derive(Clone)]
+pub struct TmuxCtrl {
+    tx: Sender<Request>,
+}
+
+enum Request {
+    Cmd {
+        cmd: String,
+        reply: Sender<Response>,
+    },
+    ReaderEvent(ReaderEvent),
+}
+
+type Response = Result<Vec<String>, String>;
+
+enum ReaderEvent {
+    Begin,
+    End,
+    Error,
+    /// Any non-marker line. May start with `%` (tmux pane IDs are `%NN`), so
+    /// the dispatcher — not the parser — decides whether it's block content or
+    /// an async notification based on whether we're currently inside a block.
+    Raw(String),
+    Eof,
+}
+
+/// Topology change notification emitted by the reader when tmux reports
+/// window/session add/close/rename events.
+#[derive(Debug, Clone, Copy)]
+pub struct TopologyChanged;
+
+impl TmuxCtrl {
+    pub fn spawn(notifier: Option<Sender<TopologyChanged>>) -> Self {
+        let (tx, rx) = mpsc::channel::<Request>();
+        let self_tx = tx.clone();
+        thread::spawn(move || loop {
+            match run_session(&rx, &self_tx, notifier.as_ref()) {
+                Ok(()) => {
+                    log::info!("tmux ctrl: session ended cleanly");
+                    return;
+                }
+                Err(e) => {
+                    log::warn!("tmux ctrl: {}. reconnecting in {:?}", e, RECONNECT_BACKOFF);
+                    thread::sleep(RECONNECT_BACKOFF);
+                }
+            }
+        });
+        Self { tx }
+    }
+
+    /// Send a tmux command and wait for its response (all lines between `%begin` and `%end`).
+    pub fn send(&self, cmd: &str) -> Result<Vec<String>, String> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx
+            .send(Request::Cmd {
+                cmd: cmd.to_string(),
+                reply: reply_tx,
+            })
+            .map_err(|e| format!("ctrl send: {}", e))?;
+        match reply_rx.recv_timeout(COMMAND_TIMEOUT) {
+            Ok(res) => res,
+            Err(e) => Err(format!("ctrl recv: {}", e)),
+        }
+    }
+}
+
+fn run_session(
+    rx: &Receiver<Request>,
+    self_tx: &Sender<Request>,
+    notifier: Option<&Sender<TopologyChanged>>,
+) -> Result<(), String> {
+    let tmux = find_tmux().ok_or_else(|| "tmux not found".to_string())?;
+
+    let mut child = Command::new(&tmux)
+        .env_remove("TMPDIR")
+        .args(["-C", "new-session", "-A", "-s", CTRL_SESSION_NAME])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("spawn tmux -C: {}", e))?;
+
+    let mut stdin = child.stdin.take().ok_or_else(|| "no stdin".to_string())?;
+    let stdout = child.stdout.take().ok_or_else(|| "no stdout".to_string())?;
+    let mut reader = BufReader::new(stdout);
+
+    // Synchronous handshake: write a sentinel command and drain the initial
+    // attach output until we see both the sentinel string and its closing `%end`.
+    writeln!(stdin, "display-message -p '{}'", HANDSHAKE_SENTINEL)
+        .map_err(|e| format!("handshake write: {}", e))?;
+    stdin
+        .flush()
+        .map_err(|e| format!("handshake flush: {}", e))?;
+
+    let mut seen_sentinel = false;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if reader
+            .read_line(&mut line)
+            .map_err(|e| format!("handshake read: {}", e))?
+            == 0
+        {
+            return Err("handshake: EOF before sentinel".to_string());
+        }
+        let trimmed = line.trim_end();
+        if trimmed.contains(HANDSHAKE_SENTINEL) {
+            seen_sentinel = true;
+        }
+        if seen_sentinel && (trimmed.starts_with("%end ") || trimmed.starts_with("%error ")) {
+            break;
+        }
+    }
+    log::info!("tmux ctrl: handshake complete");
+
+    // After handshake, delegate stdout reading to a background thread that funnels
+    // parsed events back into the same channel the dispatcher reads from.
+    let reader_tx = self_tx.clone();
+    thread::spawn(move || reader_loop(reader, reader_tx));
+
+    enum State {
+        Idle,
+        Waiting {
+            reply: Sender<Response>,
+            lines: Vec<String>,
+            in_block: bool,
+            is_error: bool,
+        },
+    }
+
+    let mut state = State::Idle;
+
+    loop {
+        let req = rx.recv().map_err(|e| format!("rx closed: {}", e))?;
+        match req {
+            Request::Cmd { cmd, reply } => match state {
+                State::Idle => {
+                    if let Err(e) = writeln!(stdin, "{}", cmd).and_then(|_| stdin.flush()) {
+                        let _ = reply.send(Err(format!("stdin: {}", e)));
+                        return Err(format!("stdin write: {}", e));
+                    }
+                    state = State::Waiting {
+                        reply,
+                        lines: Vec::new(),
+                        in_block: false,
+                        is_error: false,
+                    };
+                }
+                State::Waiting { .. } => {
+                    // send() serializes callers, so this should be unreachable.
+                    let _ = reply.send(Err("ctrl busy".to_string()));
+                }
+            },
+            Request::ReaderEvent(ev) => match ev {
+                ReaderEvent::Begin => {
+                    if let State::Waiting {
+                        in_block,
+                        lines,
+                        is_error,
+                        ..
+                    } = &mut state
+                    {
+                        *in_block = true;
+                        *is_error = false;
+                        lines.clear();
+                    }
+                }
+                ReaderEvent::End => {
+                    if let State::Waiting {
+                        reply,
+                        lines,
+                        is_error,
+                        ..
+                    } = std::mem::replace(&mut state, State::Idle)
+                    {
+                        let resp = if is_error {
+                            Err(lines.join("\n"))
+                        } else {
+                            Ok(lines)
+                        };
+                        let _ = reply.send(resp);
+                    }
+                }
+                ReaderEvent::Error => {
+                    if let State::Waiting { reply, lines, .. } =
+                        std::mem::replace(&mut state, State::Idle)
+                    {
+                        let _ = reply.send(Err(lines.join("\n")));
+                    }
+                }
+                ReaderEvent::Raw(line) => match &mut state {
+                    State::Waiting {
+                        in_block: true,
+                        lines,
+                        ..
+                    } => {
+                        // Inside a %begin..%end block: raw lines are command output,
+                        // even if they start with '%' (pane IDs like %71).
+                        lines.push(line);
+                    }
+                    _ => {
+                        // Outside any block: a '%'-prefixed line is an async
+                        // notification from tmux. Everything else is ignored.
+                        if let Some(rest) = line.strip_prefix('%') {
+                            let kind = rest.split_whitespace().next().unwrap_or("");
+                            if is_topology_event(kind) {
+                                log::debug!("tmux ctrl: topology notification: {}", kind);
+                                if let Some(n) = notifier {
+                                    let _ = n.send(TopologyChanged);
+                                }
+                            }
+                        }
+                    }
+                },
+                ReaderEvent::Eof => {
+                    if let State::Waiting { reply, .. } = std::mem::replace(&mut state, State::Idle)
+                    {
+                        let _ = reply.send(Err("tmux exited".to_string()));
+                    }
+                    return Err("tmux stdout EOF".to_string());
+                }
+            },
+        }
+    }
+}
+
+fn reader_loop(mut reader: BufReader<ChildStdout>, tx: Sender<Request>) {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => {
+                let _ = tx.send(Request::ReaderEvent(ReaderEvent::Eof));
+                return;
+            }
+            Ok(_) => {
+                let ev = parse_line(line.trim_end());
+                if tx.send(Request::ReaderEvent(ev)).is_err() {
+                    return;
+                }
+            }
+            Err(e) => {
+                log::warn!("tmux ctrl reader io: {}", e);
+                let _ = tx.send(Request::ReaderEvent(ReaderEvent::Eof));
+                return;
+            }
+        }
+    }
+}
+
+fn parse_line(line: &str) -> ReaderEvent {
+    if line.starts_with("%begin ") {
+        ReaderEvent::Begin
+    } else if line.starts_with("%end ") {
+        ReaderEvent::End
+    } else if line.starts_with("%error ") {
+        ReaderEvent::Error
+    } else {
+        ReaderEvent::Raw(line.to_string())
+    }
+}
+
+fn is_topology_event(kind: &str) -> bool {
+    matches!(
+        kind,
+        // Structural changes
+        "window-add"
+            | "window-close"
+            | "window-renamed"
+            | "unlinked-window-add"
+            | "unlinked-window-close"
+            | "unlinked-window-renamed"
+            | "session-changed"
+            | "sessions-changed"
+            | "session-renamed"
+            // Active-pane / focus changes — needed so the UI's "jump cursor to
+            // currently-focused pane on panel open" reflects the latest tmux
+            // state. is_active = pane_active && window_active && session_attached
+            // (sessions/mod.rs), so we listen to all three transitions.
+            | "window-pane-changed"
+            | "session-window-changed"
+            | "client-session-changed"
+            | "client-detached"
+    )
+}

--- a/src-tauri/src/sessions/ctrl.rs
+++ b/src-tauri/src/sessions/ctrl.rs
@@ -7,8 +7,10 @@
 //! a separate listener channel for event-driven cache invalidation.
 
 use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
 use std::process::{ChildStdout, Command, Stdio};
 use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::Duration;
 
@@ -17,11 +19,19 @@ use crate::terminal::find_tmux;
 const HANDSHAKE_SENTINEL: &str = "__agentoast_ctrl_ready__";
 const RECONNECT_BACKOFF: Duration = Duration::from_secs(3);
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
-const CTRL_SESSION_NAME: &str = "_agentoast_ctrl";
+/// Session name left behind by the previous (dedicated-session) implementation.
+/// Cleaned up on startup and excluded from attach candidates as a safety net.
+const LEGACY_CTRL_SESSION_NAME: &str = "_agentoast_ctrl";
 
 #[derive(Clone)]
 pub struct TmuxCtrl {
     tx: Sender<Request>,
+    /// Name of the tmux session this control client is currently attached to.
+    /// Updated by `run_session` on every (re)connect. Consumers rely on this
+    /// to correct `session_attached` counts (we contribute +1 to our target
+    /// session, which would otherwise skew the "is this pane focused" check
+    /// in `list_tmux_panes_grouped`).
+    attached_session: Arc<RwLock<Option<String>>>,
 }
 
 enum Request {
@@ -54,8 +64,16 @@ impl TmuxCtrl {
     pub fn spawn(notifier: Option<Sender<TopologyChanged>>) -> Self {
         let (tx, rx) = mpsc::channel::<Request>();
         let self_tx = tx.clone();
+        let attached_session: Arc<RwLock<Option<String>>> = Arc::new(RwLock::new(None));
+        let attached_session_worker = Arc::clone(&attached_session);
         thread::spawn(move || loop {
-            match run_session(&rx, &self_tx, notifier.as_ref()) {
+            let result = run_session(&rx, &self_tx, notifier.as_ref(), &attached_session_worker);
+            // Always clear the attached-session record on exit so stale names
+            // don't leak into the next reconnect cycle.
+            if let Ok(mut guard) = attached_session_worker.write() {
+                *guard = None;
+            }
+            match result {
                 Ok(()) => {
                     log::info!("tmux ctrl: session ended cleanly");
                     return;
@@ -66,7 +84,10 @@ impl TmuxCtrl {
                 }
             }
         });
-        Self { tx }
+        Self {
+            tx,
+            attached_session,
+        }
     }
 
     /// Send a tmux command and wait for its response (all lines between `%begin` and `%end`).
@@ -83,18 +104,31 @@ impl TmuxCtrl {
             Err(e) => Err(format!("ctrl recv: {}", e)),
         }
     }
+
+    /// Session name this control client is currently attached to, if any.
+    /// Returns `None` while reconnecting or before the first successful attach.
+    pub fn attached_session(&self) -> Option<String> {
+        self.attached_session.read().ok().and_then(|g| g.clone())
+    }
 }
 
 fn run_session(
     rx: &Receiver<Request>,
     self_tx: &Sender<Request>,
     notifier: Option<&Sender<TopologyChanged>>,
+    attached_session: &Arc<RwLock<Option<String>>>,
 ) -> Result<(), String> {
     let tmux = find_tmux().ok_or_else(|| "tmux not found".to_string())?;
 
+    cleanup_legacy_ctrl_session(&tmux);
+
+    let target = pick_attach_target(&tmux)
+        .ok_or_else(|| "no tmux session available to attach".to_string())?;
+    log::info!("tmux ctrl: attaching to session '{}'", target);
+
     let mut child = Command::new(&tmux)
         .env_remove("TMPDIR")
-        .args(["-C", "new-session", "-A", "-s", CTRL_SESSION_NAME])
+        .args(["-C", "attach-session", "-t", &target])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -133,6 +167,13 @@ fn run_session(
         }
     }
     log::info!("tmux ctrl: handshake complete");
+
+    // Publish our attached session name so `list_tmux_panes_grouped` can
+    // subtract our contribution from `session_attached` when deciding which
+    // pane is "the" focused one.
+    if let Ok(mut guard) = attached_session.write() {
+        *guard = Some(target.clone());
+    }
 
     // After handshake, delegate stdout reading to a background thread that funnels
     // parsed events back into the same channel the dispatcher reads from.
@@ -230,6 +271,17 @@ fn run_session(
                                     let _ = n.send(TopologyChanged);
                                 }
                             }
+                            if kind == "client-detached" {
+                                // Our attached session was killed or the
+                                // control client was detached. Bail out so
+                                // the reconnect loop picks another session.
+                                if let State::Waiting { reply, .. } =
+                                    std::mem::replace(&mut state, State::Idle)
+                                {
+                                    let _ = reply.send(Err("tmux client-detached".to_string()));
+                                }
+                                return Err("tmux: client-detached".to_string());
+                            }
                         }
                     }
                 },
@@ -279,6 +331,54 @@ fn parse_line(line: &str) -> ReaderEvent {
     } else {
         ReaderEvent::Raw(line.to_string())
     }
+}
+
+/// Pick a user session to attach to via `tmux list-sessions`. Prefers sessions
+/// that already have a client attached (where the user's GUI terminal is
+/// pointing), so our control client doesn't fork off to a session the user
+/// isn't looking at — which would otherwise double-count `session_attached`
+/// on the real focused session. `None` means either no server is running or
+/// no eligible session exists; the caller falls through to reconnect backoff.
+fn pick_attach_target(tmux: &Path) -> Option<String> {
+    let output = Command::new(tmux)
+        .env_remove("TMPDIR")
+        .args(["list-sessions", "-F", "#{session_attached} #{session_name}"])
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut candidates: Vec<(u32, String)> = Vec::new();
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        let (count_str, name) = match trimmed.split_once(' ') {
+            Some(pair) => pair,
+            None => continue,
+        };
+        if name.is_empty() || name == LEGACY_CTRL_SESSION_NAME {
+            continue;
+        }
+        let count: u32 = count_str.parse().unwrap_or(0);
+        candidates.push((count, name.to_string()));
+    }
+    // Highest attached count first — that's where the user's terminal lives.
+    // Stable sort keeps tmux's original ordering as a tiebreaker.
+    candidates.sort_by(|a, b| b.0.cmp(&a.0));
+    candidates.into_iter().next().map(|(_, n)| n)
+}
+
+/// Best-effort removal of the `_agentoast_ctrl` session left over from the
+/// previous implementation. Failure (session missing, no server) is the
+/// normal case, so it is intentionally silent.
+fn cleanup_legacy_ctrl_session(tmux: &Path) {
+    let _ = Command::new(tmux)
+        .env_remove("TMPDIR")
+        .args(["kill-session", "-t", LEGACY_CTRL_SESSION_NAME])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
 }
 
 fn is_topology_event(kind: &str) -> bool {

--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -197,6 +197,11 @@ pub fn list_tmux_panes_grouped(ctrl: Option<&TmuxCtrl>) -> Result<Vec<TmuxPaneGr
 
     log::info!("sessions: tmux list-panes {} lines", stdout_lines.len());
 
+    // Our own control client bumps `#{session_attached}` for the session it
+    // attached to. Subtract that contribution when computing `is_active`,
+    // otherwise the "jump to focused pane on panel open" behavior breaks.
+    let ctrl_attached_session: Option<String> = ctrl.and_then(|c| c.attached_session());
+
     // Build process tree once for all panes
     let process_tree = build_process_tree();
     log::debug!(
@@ -226,7 +231,13 @@ pub fn list_tmux_panes_grouped(ctrl: Option<&TmuxCtrl>) -> Result<Vec<TmuxPaneGr
 
         let pane_pid: u32 = parts[1].parse().unwrap_or(0);
         let agent_type = detect_agent(&process_tree, pane_pid);
-        let is_active = parts[5] == "1" && parts[6] == "1" && parts[7] == "1";
+        let raw_attached: u32 = parts[7].parse().unwrap_or(0);
+        let effective_attached = if Some(parts[2]) == ctrl_attached_session.as_deref() {
+            raw_attached.saturating_sub(1)
+        } else {
+            raw_attached
+        };
+        let is_active = parts[5] == "1" && parts[6] == "1" && effective_attached >= 1;
         log::debug!(
             "sessions: pane {} pid={} agent={:?} is_active={}",
             parts[0],

--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::process::Command;
 
 use agentoast_shared::models::{TmuxPane, TmuxPaneGroup};
@@ -7,7 +7,11 @@ use agentoast_shared::{config, db};
 use crate::terminal::{find_git, find_tmux};
 
 pub(crate) mod agents;
+pub mod ctrl;
 use agents::{capture_pane, detect_agent_status_with_content};
+pub use ctrl::TmuxCtrl;
+#[allow(unused_imports)]
+pub use ctrl::TopologyChanged;
 
 const AGENT_PROCESSES: &[(&str, &str)] = &[
     ("claude", "claude-code"),
@@ -146,15 +150,13 @@ fn extract_repo_name_from_url(url: &str) -> Option<String> {
     }
 }
 
-pub fn list_tmux_panes_grouped() -> Result<Vec<TmuxPaneGroup>, String> {
-    log::info!("sessions: get_sessions called");
+pub fn list_tmux_panes_grouped(ctrl: Option<&TmuxCtrl>) -> Result<Vec<TmuxPaneGroup>, String> {
+    log::info!("sessions: get_sessions called (ctrl={})", ctrl.is_some());
     log::info!(
         "sessions: TMPDIR={:?}, TMUX_TMPDIR={:?}",
         std::env::var("TMPDIR").ok(),
         std::env::var("TMUX_TMPDIR").ok()
     );
-    let tmux_path = find_tmux().ok_or_else(|| "tmux not found".to_string())?;
-    log::debug!("sessions: tmux found at {:?}", tmux_path);
 
     // Use "|||" as delimiter instead of "\t" because macOS Launch Services
     // (Finder double-click) sanitizes control characters in process arguments,
@@ -165,34 +167,35 @@ pub fn list_tmux_panes_grouped() -> Result<Vec<TmuxPaneGroup>, String> {
         d = DELIM
     );
 
-    let output = Command::new(&tmux_path)
-        .env_remove("TMPDIR")
-        .args(["list-panes", "-a", "-F", &format_str])
-        .output()
-        .map_err(|e| {
-            log::error!("sessions: tmux list-panes exec failed: {}", e);
-            format!("tmux list-panes failed: {}", e)
-        })?;
+    let stdout_lines: Vec<String> = if let Some(ctrl) = ctrl {
+        ctrl.send(&format!("list-panes -a -F \"{}\"", format_str))
+            .map_err(|e| {
+                log::error!("sessions: ctrl list-panes failed: {}", e);
+                format!("tmux list-panes failed: {}", e)
+            })?
+    } else {
+        let tmux_path = find_tmux().ok_or_else(|| "tmux not found".to_string())?;
+        log::debug!("sessions: tmux found at {:?}", tmux_path);
+        let output = Command::new(&tmux_path)
+            .env_remove("TMPDIR")
+            .args(["list-panes", "-a", "-F", &format_str])
+            .output()
+            .map_err(|e| {
+                log::error!("sessions: tmux list-panes exec failed: {}", e);
+                format!("tmux list-panes failed: {}", e)
+            })?;
+        if !output.status.success() {
+            let stderr_str = String::from_utf8_lossy(&output.stderr);
+            log::error!("sessions: tmux list-panes returned error: {}", stderr_str);
+            return Err(format!("tmux list-panes failed: {}", stderr_str));
+        }
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(|s| s.to_string())
+            .collect()
+    };
 
-    let stderr_str = String::from_utf8_lossy(&output.stderr);
-    log::info!(
-        "sessions: tmux list-panes exit={}, stderr={:?}",
-        output.status,
-        stderr_str.as_ref()
-    );
-
-    if !output.status.success() {
-        log::error!("sessions: tmux list-panes returned error: {}", stderr_str);
-        return Err(format!("tmux list-panes failed: {}", stderr_str));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    log::info!(
-        "sessions: tmux list-panes stdout len={} lines={}",
-        stdout.len(),
-        stdout.lines().count()
-    );
-    log::debug!("sessions: tmux list-panes stdout:\n{}", stdout);
+    log::info!("sessions: tmux list-panes {} lines", stdout_lines.len());
 
     // Build process tree once for all panes
     let process_tree = build_process_tree();
@@ -215,7 +218,7 @@ pub fn list_tmux_panes_grouped() -> Result<Vec<TmuxPaneGroup>, String> {
 
     let mut raw_panes: Vec<RawPane> = Vec::new();
 
-    for line in stdout.lines() {
+    for line in &stdout_lines {
         let parts: Vec<&str> = line.splitn(8, DELIM).collect();
         if parts.len() < 8 {
             continue;
@@ -268,20 +271,28 @@ pub fn list_tmux_panes_grouped() -> Result<Vec<TmuxPaneGroup>, String> {
         // Git info: one thread per unique path
         let git_handle = s.spawn(|| resolve_git_info(&unique_paths));
 
-        // Capture-pane: one thread per agent pane
-        let capture_handles: Vec<_> = agent_pane_indices
-            .iter()
-            .map(|&idx| {
-                let pane_id = raw_panes[idx].pane_id.as_str();
-                s.spawn(move || (idx, capture_pane(pane_id)))
-            })
-            .collect();
+        // Capture-pane: when ctrl is available, serialize via the single ctrl pipe.
+        // Otherwise fan out threads to parallelize fork+exec overhead.
+        let captured: HashMap<usize, Option<String>> = if let Some(ctrl) = ctrl {
+            agent_pane_indices
+                .iter()
+                .map(|&idx| {
+                    let pane_id = raw_panes[idx].pane_id.as_str();
+                    (idx, capture_pane(Some(ctrl), pane_id))
+                })
+                .collect()
+        } else {
+            let handles: Vec<_> = agent_pane_indices
+                .iter()
+                .map(|&idx| {
+                    let pane_id = raw_panes[idx].pane_id.as_str();
+                    s.spawn(move || (idx, capture_pane(None, pane_id)))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        };
 
         let git_cache = git_handle.join().unwrap();
-        let captured: HashMap<usize, Option<String>> = capture_handles
-            .into_iter()
-            .map(|h| h.join().unwrap())
-            .collect();
 
         (git_cache, captured)
     });
@@ -361,8 +372,35 @@ pub fn list_tmux_panes_grouped() -> Result<Vec<TmuxPaneGroup>, String> {
         })
         .collect();
 
-    // Keep only panes with active agents, remove empty groups
+    // Promote is_active to a sibling agent pane when the tmux-focused pane is
+    // a shell (not an agent) in the same tmux window. Match by (session, window)
+    // rather than by group key — panes in the same window can have different
+    // current_paths, which puts them in different git-rooted groups.
+    let active_windows: HashSet<(String, String)> = groups
+        .iter()
+        .flat_map(|g| g.panes.iter())
+        .filter(|p| p.is_active)
+        .map(|p| (p.session_name.clone(), p.window_name.clone()))
+        .collect();
     for group in &mut groups {
+        let any_agent_active = group
+            .panes
+            .iter()
+            .any(|p| p.is_active && p.agent_type.is_some());
+        if !any_agent_active {
+            if let Some(first_agent) = group.panes.iter_mut().find(|p| {
+                p.agent_type.is_some()
+                    && active_windows.contains(&(p.session_name.clone(), p.window_name.clone()))
+            }) {
+                log::debug!(
+                    "sessions: promoted is_active to agent pane {} (session={} window={})",
+                    first_agent.pane_id,
+                    first_agent.session_name,
+                    first_agent.window_name
+                );
+                first_agent.is_active = true;
+            }
+        }
         group.panes.retain(|p| p.agent_type.is_some());
     }
     groups.retain(|g| !g.panes.is_empty());

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -36,6 +36,7 @@ macro_rules! get_or_init_panel {
 fn show_panel(app_handle: &AppHandle) {
     if let Some(panel) = get_or_init_panel!(app_handle) {
         let _ = app_handle.emit("panel:shown", ());
+        crate::emit_cached_sessions(app_handle);
         let _ = app_handle.emit("notifications:refresh", ());
         panel.show_and_make_key();
     }
@@ -49,6 +50,7 @@ pub fn toggle_panel(app_handle: &AppHandle) {
         panel.hide();
     } else {
         let _ = app_handle.emit("panel:shown", ());
+        crate::emit_cached_sessions(app_handle);
         let _ = app_handle.emit("notifications:refresh", ());
         panel.set_alpha_value(0.0);
         panel.show_and_make_key();
@@ -119,6 +121,7 @@ pub fn create(app_handle: &AppHandle) -> tauri::Result<()> {
                     }
 
                     let _ = app_handle.emit("panel:shown", ());
+                    crate::emit_cached_sessions(app_handle);
                     let _ = app_handle.emit("notifications:refresh", ());
                     panel.set_alpha_value(0.0);
                     panel.show_and_make_key();

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -370,7 +370,7 @@ fn cleanup_running_agent_notifications(app_handle: &AppHandle, conn: &Connection
 
     let mut deleted_any = false;
     for pane_id in &pane_ids {
-        if crate::sessions::agents::is_pane_agent_running(pane_id) {
+        if crate::sessions::agents::is_pane_agent_running(None, pane_id) {
             log::info!(
                 "cleanup_running: pane {} is running, deleting notifications",
                 pane_id

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ export function App() {
 
   const { globalMuted, isRepoMuted, toggleGlobalMute, toggleRepoMute } = useMute();
 
-  const { groups: sessionGroups, fetchVersion } = useSessions();
+  const { groups: sessionGroups, fetchVersion, statusReady } = useSessions();
 
   const [appVersion, setAppVersion] = useState("");
   const { updateStatus, triggerInstall, checkForUpdates } = useAppUpdate();
@@ -442,6 +442,7 @@ export function App() {
       case "Enter": {
         if (showHelp) break;
         e.preventDefault();
+        repositionCancelledRef.current = true;
         const item = flatItems[selectedIndexRef.current];
         if (!item) {
           void invoke("hide_panel");
@@ -527,6 +528,7 @@ export function App() {
       case "Tab": {
         if (showHelp) break;
         e.preventDefault();
+        repositionCancelledRef.current = true;
         const direction = e.shiftKey ? -1 : 1;
         const curIdx = selectedIndexRef.current;
         let nextIndex =
@@ -614,6 +616,7 @@ export function App() {
                   selectedPaneId={selectedPaneId}
                   flatItems={flatItems}
                   autoExpandedPaneId={autoExpandedPaneId}
+                  statusReady={statusReady}
                   onDeleteNotification={(id) => void deleteNotification(id)}
                   onDeleteByPanes={(paneIds) => void deleteByPanes(paneIds)}
                   onToggleRepoMute={(path) => void toggleRepoMute(path)}

--- a/src/components/pane-card.tsx
+++ b/src/components/pane-card.tsx
@@ -10,6 +10,7 @@ interface PaneCardProps {
   isSelected?: boolean;
   isAutoExpanded?: boolean;
   navIndex?: number;
+  statusReady?: boolean;
   onDeleteNotification: (id: number) => void;
 }
 
@@ -69,6 +70,7 @@ export function PaneCard({
   isSelected,
   isAutoExpanded,
   navIndex,
+  statusReady = true,
   onDeleteNotification,
 }: PaneCardProps) {
   const { pane, notification } = paneItem;
@@ -114,28 +116,39 @@ export function PaneCard({
           {/* Line 1: Running status + notification badge + session info + time */}
           <div className="flex items-center gap-1.5">
             {pane.agentType && (
-              <span className="flex-shrink-0 flex items-center gap-1" title={statusTooltip(pane)}>
-                <Circle size={7} className={statusDotClass(pane.agentStatus)} />
-                {pane.waitingReason && (
+              <span
+                className="flex-shrink-0 flex items-center gap-1"
+                title={statusReady ? statusTooltip(pane) : undefined}
+              >
+                <Circle
+                  size={7}
+                  className={
+                    statusReady
+                      ? statusDotClass(pane.agentStatus)
+                      : "text-transparent fill-transparent"
+                  }
+                />
+                {statusReady && pane.waitingReason && (
                   <span className="text-[10px] text-amber-500 font-medium">
                     {pane.waitingReason}
                   </span>
                 )}
               </span>
             )}
-            {pane.agentModes.map((mode) => (
-              <span
-                key={mode}
-                className={cn(
-                  "text-[10px] font-medium flex-shrink-0",
-                  mode.endsWith("shell") || mode.endsWith("bash")
-                    ? "text-green-500"
-                    : "text-[var(--text-muted)]",
-                )}
-              >
-                {mode}
-              </span>
-            ))}
+            {statusReady &&
+              pane.agentModes.map((mode) => (
+                <span
+                  key={mode}
+                  className={cn(
+                    "text-[10px] font-medium flex-shrink-0",
+                    mode.endsWith("shell") || mode.endsWith("bash")
+                      ? "text-green-500"
+                      : "text-[var(--text-muted)]",
+                  )}
+                >
+                  {mode}
+                </span>
+              ))}
             {pane.teamRole === "lead" && (
               <span className="text-[10px] text-[var(--text-muted)] flex-shrink-0">@main</span>
             )}

--- a/src/components/repo-group.tsx
+++ b/src/components/repo-group.tsx
@@ -28,6 +28,7 @@ interface RepoGroupProps {
   selectedPaneId: string | null;
   flatItems: FlatItem[];
   autoExpandedPaneId: string | null;
+  statusReady: boolean;
   onDeleteNotification: (id: number) => void;
   onDeleteByPanes: (paneIds: string[]) => void;
   onToggleRepoMute: (repoPath: string) => void;
@@ -48,6 +49,7 @@ export function RepoGroup({
   selectedPaneId,
   flatItems,
   autoExpandedPaneId,
+  statusReady,
   onDeleteNotification,
   onDeleteByPanes,
   onToggleRepoMute,
@@ -120,8 +122,8 @@ export function RepoGroup({
             </span>
           </div>
         )}
-        {/* Line 3: agent status counts */}
-        {(runningCount > 0 || idleCount > 0 || waitingCount > 0) && (
+        {/* Line 3: agent status counts (only after status is confirmed) */}
+        {statusReady && (runningCount > 0 || idleCount > 0 || waitingCount > 0) && (
           <div className="flex items-center gap-3 pl-[33px] mt-0.5">
             {runningCount > 0 && (
               <span className="flex items-center gap-1 text-[10px] text-green-500 font-medium">
@@ -153,6 +155,7 @@ export function RepoGroup({
           selectedId={selectedId}
           selectedPaneId={selectedPaneId}
           autoExpandedPaneId={autoExpandedPaneId}
+          statusReady={statusReady}
           onDeleteNotification={onDeleteNotification}
         />
       )}
@@ -167,6 +170,7 @@ interface ExpandedPanesProps {
   selectedId: number | null;
   selectedPaneId: string | null;
   autoExpandedPaneId: string | null;
+  statusReady: boolean;
   onDeleteNotification: (id: number) => void;
 }
 
@@ -177,6 +181,7 @@ function ExpandedPanes({
   selectedId,
   selectedPaneId,
   autoExpandedPaneId,
+  statusReady,
   onDeleteNotification,
 }: ExpandedPanesProps) {
   // Group panes by Agent Teams membership (session:window key)
@@ -212,6 +217,7 @@ function ExpandedPanes({
         isSelected={isSelected}
         isAutoExpanded={isAutoExpanded}
         navIndex={navIndex}
+        statusReady={statusReady}
         onDeleteNotification={onDeleteNotification}
       />
     );

--- a/src/hooks/use-sessions.ts
+++ b/src/hooks/use-sessions.ts
@@ -35,6 +35,7 @@ export function useSessions() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [fetchVersion, setFetchVersion] = useState(0);
+  const [statusReady, setStatusReady] = useState(false);
   const mountedRef = useRef(true);
 
   const refresh = useCallback(async () => {
@@ -46,6 +47,7 @@ export function useSessions() {
           return result;
         });
         setFetchVersion((v) => v + 1);
+        setStatusReady(true);
         setError(null);
       }
     } catch (e) {
@@ -78,5 +80,44 @@ export function useSessions() {
     };
   }, [refresh]);
 
-  return { groups, loading, error, refresh, fetchVersion };
+  // Receive cached sessions emitted by show_panel before the live get_sessions completes.
+  // This populates the UI immediately on panel re-open, avoiding a blank flash while
+  // get_sessions runs (150-300ms). Skip setLoading/setFetchVersion so the cache is treated
+  // as a render hint, not a data source — the live refresh still drives canonical state.
+  useEffect(() => {
+    const unlisten = listen<TmuxPaneGroup[]>("sessions:cached", (event) => {
+      if (!mountedRef.current) return;
+      const cached = event.payload;
+      setGroups((prev) => {
+        if (shallowEqualGroups(prev, cached)) return prev;
+        return cached;
+      });
+      setLoading(false);
+    });
+    return () => {
+      unlisten.then((f) => f()).catch(() => {});
+    };
+  }, []);
+
+  // Push updates from the topology-driven event loop in the backend. Treated as a
+  // render hint (like sessions:cached) — never bumps fetchVersion. Cursor reposition
+  // on panel open is driven exclusively by the invoke(get_sessions) round-trip via
+  // notifications:refresh, so backend-initiated pushes must not race with the
+  // panel:shown → needFetchVersionRef capture sequence in App.tsx.
+  useEffect(() => {
+    const unlisten = listen<TmuxPaneGroup[]>("sessions:updated", (event) => {
+      if (!mountedRef.current) return;
+      const next = event.payload;
+      setGroups((prev) => {
+        if (shallowEqualGroups(prev, next)) return prev;
+        return next;
+      });
+      setLoading(false);
+    });
+    return () => {
+      unlisten.then((f) => f()).catch(() => {});
+    };
+  }, []);
+
+  return { groups, loading, error, refresh, fetchVersion, statusReady };
 }


### PR DESCRIPTION
## Summary

- Replace the per-call `tmux` fork+exec path with a long-lived `tmux -C` control-mode client (`TmuxCtrl`), eliminating panel-open latency dominated by process startup.
- Replace the fixed 2-second sessions poller with an event-driven refresh loop fed by tmux topology notifications (`window-add`, `session-changed`, `window-pane-changed`, ...), debounced at 200ms with a 30-second safety net.
- Promote `is_active=true` onto the first agent pane in a tmux window when the focused pane is a sibling shell, so the panel cursor still jumps to the right group when the user is not sitting on the agent pane itself.

## Details

### Backend
- `src-tauri/src/sessions/ctrl.rs` (new): worker thread owns one `tmux -C new-session` child, serializes commands through mpsc, and parses `%begin`/`%end`/`%error` blocks. Block-internal `%`-prefixed lines are treated as command output (tmux pane IDs like `%71` collide with the marker syntax). Async notifications outside blocks fan out to a `Sender<TopologyChanged>`. EOF triggers a 3s-backoff reconnect.
- `src-tauri/src/sessions/mod.rs`: `list_tmux_panes_grouped(ctrl: Option<&TmuxCtrl>)` routes through the ctrl pipe when available, falling back to fork+exec otherwise. Active-pane promotion runs before the agent filter, matched by `(session_name, window_name)` so it works across git-rooted groups when the focused shell has a different `cwd` than the agent panes.
- `src-tauri/src/sessions/agents/mod.rs`: `capture_pane` / `is_pane_agent_running` accept `Option<&TmuxCtrl>` for the same routing.
- `src-tauri/src/lib.rs`: `setup()` spawns `TmuxCtrl::spawn(Some(topo_tx))` and `start_sessions_event_loop`. `refresh_and_emit` updates the cache and emits `sessions:updated`. `start_sessions_safety_poller` is kept (`#[allow(dead_code)]`) for the non-macOS / fallback path.
- `src-tauri/src/watcher.rs`: switches to `is_pane_agent_running(None, ...)` for the fallback path.

### Frontend
- `src/hooks/use-sessions.ts`: subscribes to the new `sessions:updated` event as a render hint (does not bump `fetchVersion`, so it does not race with the `panel:shown → needFetchVersionRef` sequence).
- `src/App.tsx`: minor cleanup; cursor reposition logic unchanged in semantics — relies on the backend now reporting an `is_active` agent pane in the focused window.

### Docs
- `docs/tmux-control-mode.md`: design notes covering Phase 1 (ctrl client + parser bug post-mortem), Phase 2 (event loop, debounce / safety-net constants), and the chosen parameters (200ms / 30s).

 