### PR TITLE
feat(panes): add toggle to show non-agent tmux panes

### DIFF
--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -71,6 +71,8 @@ pub struct NotificationConfig {
     pub muted: bool,
     #[serde(default = "default_filter_notified_only")]
     pub filter_notified_only: bool,
+    #[serde(default = "default_show_non_agent_panes")]
+    pub show_non_agent_panes: bool,
     #[serde(default)]
     pub agents: AgentsConfig,
 }
@@ -80,12 +82,17 @@ impl Default for NotificationConfig {
         Self {
             muted: false,
             filter_notified_only: default_filter_notified_only(),
+            show_non_agent_panes: default_show_non_agent_panes(),
             agents: AgentsConfig::default(),
         }
     }
 }
 
 fn default_filter_notified_only() -> bool {
+    false
+}
+
+fn default_show_non_agent_panes() -> bool {
     false
 }
 
@@ -282,6 +289,15 @@ pub fn save_notification_filter_notified_only(value: bool) -> io::Result<()> {
     std::fs::write(&path, doc.to_string())
 }
 
+/// Update [notification] show_non_agent_panes in config.toml, preserving existing comments and formatting.
+pub fn save_notification_show_non_agent_panes(value: bool) -> io::Result<()> {
+    let path = config_path();
+    let content = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut doc: DocumentMut = content.parse().unwrap_or_default();
+    doc["notification"]["show_non_agent_panes"] = toml_edit::value(value);
+    std::fs::write(&path, doc.to_string())
+}
+
 /// Default config.toml template.
 fn default_config_template() -> &'static str {
     r#"# agentoast configuration
@@ -305,6 +321,9 @@ fn default_config_template() -> &'static str {
 
 # Show only groups with notifications (default: false)
 # filter_notified_only = false
+
+# Show tmux panes without an AI coding agent (default: false)
+# show_non_agent_panes = false
 
 # Claude Code agent settings
 [notification.agents.claude_code]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -77,8 +77,21 @@ pub fn emit_cached_sessions(app_handle: &tauri::AppHandle) {
 }
 
 #[cfg(target_os = "macos")]
+fn read_show_non_agent_panes(app_handle: &tauri::AppHandle) -> bool {
+    app_handle
+        .try_state::<Mutex<AppState>>()
+        .and_then(|s| {
+            s.lock()
+                .ok()
+                .map(|g| g.config.notification.show_non_agent_panes)
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "macos")]
 fn refresh_and_emit(app_handle: &tauri::AppHandle, ctrl: Option<&sessions::TmuxCtrl>) {
-    match sessions::list_tmux_panes_grouped(ctrl) {
+    let show_non_agent = read_show_non_agent_panes(app_handle);
+    match sessions::list_tmux_panes_grouped(ctrl, show_non_agent) {
         Ok(groups) => {
             if let Some(cache) = app_handle.try_state::<Mutex<SessionsCache>>() {
                 if let Ok(mut guard) = cache.lock() {
@@ -200,8 +213,9 @@ async fn get_sessions(app_handle: tauri::AppHandle) -> Result<Vec<TmuxPaneGroup>
         let ctrl = app_handle
             .try_state::<sessions::TmuxCtrl>()
             .map(|s| s.inner().clone());
+        let show_non_agent = read_show_non_agent_panes(&app_handle);
         let result = tauri::async_runtime::spawn_blocking(move || {
-            sessions::list_tmux_panes_grouped(ctrl.as_ref())
+            sessions::list_tmux_panes_grouped(ctrl.as_ref(), show_non_agent)
         })
         .await
         .map_err(|e| e.to_string())?;
@@ -334,6 +348,39 @@ fn save_filter_notified_only(
 }
 
 #[tauri::command]
+fn get_show_non_agent_panes(state: tauri::State<'_, Mutex<AppState>>) -> Result<bool, String> {
+    let state = state.lock().map_err(|e| e.to_string())?;
+    Ok(state.config.notification.show_non_agent_panes)
+}
+
+#[tauri::command]
+fn save_show_non_agent_panes(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, Mutex<AppState>>,
+    value: bool,
+) -> Result<(), String> {
+    {
+        let mut state = state.lock().map_err(|e| e.to_string())?;
+        state.config.notification.show_non_agent_panes = value;
+    }
+    if let Err(e) = config::save_notification_show_non_agent_panes(value) {
+        log::warn!("Failed to save show_non_agent_panes to config.toml: {}", e);
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let ctrl = app_handle
+            .try_state::<sessions::TmuxCtrl>()
+            .map(|s| s.inner().clone());
+        refresh_and_emit(&app_handle, ctrl.as_ref());
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app_handle;
+    }
+    Ok(())
+}
+
+#[tauri::command]
 fn get_update_enabled(state: tauri::State<'_, Mutex<AppState>>) -> Result<bool, String> {
     let state = state.lock().map_err(|e| e.to_string())?;
     Ok(state.config.update.enabled)
@@ -403,6 +450,8 @@ pub fn run() {
             get_update_enabled,
             get_filter_notified_only,
             save_filter_notified_only,
+            get_show_non_agent_panes,
+            save_show_non_agent_panes,
             get_mute_state,
             toggle_global_mute,
             toggle_repo_mute,

--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -150,8 +150,15 @@ fn extract_repo_name_from_url(url: &str) -> Option<String> {
     }
 }
 
-pub fn list_tmux_panes_grouped(ctrl: Option<&TmuxCtrl>) -> Result<Vec<TmuxPaneGroup>, String> {
-    log::info!("sessions: get_sessions called (ctrl={})", ctrl.is_some());
+pub fn list_tmux_panes_grouped(
+    ctrl: Option<&TmuxCtrl>,
+    show_non_agent: bool,
+) -> Result<Vec<TmuxPaneGroup>, String> {
+    log::info!(
+        "sessions: get_sessions called (ctrl={}, show_non_agent={})",
+        ctrl.is_some(),
+        show_non_agent
+    );
     log::info!(
         "sessions: TMPDIR={:?}, TMUX_TMPDIR={:?}",
         std::env::var("TMPDIR").ok(),
@@ -383,36 +390,38 @@ pub fn list_tmux_panes_grouped(ctrl: Option<&TmuxCtrl>) -> Result<Vec<TmuxPaneGr
         })
         .collect();
 
-    // Promote is_active to a sibling agent pane when the tmux-focused pane is
-    // a shell (not an agent) in the same tmux window. Match by (session, window)
-    // rather than by group key — panes in the same window can have different
-    // current_paths, which puts them in different git-rooted groups.
-    let active_windows: HashSet<(String, String)> = groups
-        .iter()
-        .flat_map(|g| g.panes.iter())
-        .filter(|p| p.is_active)
-        .map(|p| (p.session_name.clone(), p.window_name.clone()))
-        .collect();
-    for group in &mut groups {
-        let any_agent_active = group
-            .panes
+    if !show_non_agent {
+        // Promote is_active to a sibling agent pane when the tmux-focused pane is
+        // a shell (not an agent) in the same tmux window. Match by (session, window)
+        // rather than by group key — panes in the same window can have different
+        // current_paths, which puts them in different git-rooted groups.
+        let active_windows: HashSet<(String, String)> = groups
             .iter()
-            .any(|p| p.is_active && p.agent_type.is_some());
-        if !any_agent_active {
-            if let Some(first_agent) = group.panes.iter_mut().find(|p| {
-                p.agent_type.is_some()
-                    && active_windows.contains(&(p.session_name.clone(), p.window_name.clone()))
-            }) {
-                log::debug!(
-                    "sessions: promoted is_active to agent pane {} (session={} window={})",
-                    first_agent.pane_id,
-                    first_agent.session_name,
-                    first_agent.window_name
-                );
-                first_agent.is_active = true;
+            .flat_map(|g| g.panes.iter())
+            .filter(|p| p.is_active)
+            .map(|p| (p.session_name.clone(), p.window_name.clone()))
+            .collect();
+        for group in &mut groups {
+            let any_agent_active = group
+                .panes
+                .iter()
+                .any(|p| p.is_active && p.agent_type.is_some());
+            if !any_agent_active {
+                if let Some(first_agent) = group.panes.iter_mut().find(|p| {
+                    p.agent_type.is_some()
+                        && active_windows.contains(&(p.session_name.clone(), p.window_name.clone()))
+                }) {
+                    log::debug!(
+                        "sessions: promoted is_active to agent pane {} (session={} window={})",
+                        first_agent.pane_id,
+                        first_agent.session_name,
+                        first_agent.window_name
+                    );
+                    first_agent.is_active = true;
+                }
             }
+            group.panes.retain(|p| p.agent_type.is_some());
         }
-        group.panes.retain(|p| p.agent_type.is_some());
     }
     groups.retain(|g| !g.panes.is_empty());
     log::debug!(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ export function App() {
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [showHelp, setShowHelp] = useState(false);
   const [filterNotifiedOnly, setFilterNotifiedOnly] = useState(false);
+  const [showNonAgentPanes, setShowNonAgentPanes] = useState(false);
   const [manuallyToggledGroups, setManuallyToggledGroups] = useState<Set<string>>(new Set());
   const [autoExpandedPaneId, setAutoExpandedPaneId] = useState<string | null>(null);
   const autoExpandTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -45,6 +46,9 @@ export function App() {
   useEffect(() => {
     invoke<boolean>("get_filter_notified_only")
       .then((v) => setFilterNotifiedOnly(v))
+      .catch(() => {});
+    invoke<boolean>("get_show_non_agent_panes")
+      .then((v) => setShowNonAgentPanes(v))
       .catch(() => {});
   }, []);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -525,6 +529,17 @@ export function App() {
         setSelectedIndex(0);
         break;
       }
+      case "T": {
+        if (showHelp) break;
+        e.preventDefault();
+        setShowNonAgentPanes((prev) => {
+          const next = !prev;
+          void invoke("save_show_non_agent_panes", { value: next });
+          return next;
+        });
+        setSelectedIndex(0);
+        break;
+      }
       case "Tab": {
         if (showHelp) break;
         e.preventDefault();
@@ -571,10 +586,18 @@ export function App() {
         <PanelHeader
           globalMuted={globalMuted}
           filterNotifiedOnly={filterNotifiedOnly}
+          showNonAgentPanes={showNonAgentPanes}
           onToggleFilter={() => {
             setFilterNotifiedOnly((prev) => {
               const next = !prev;
               void invoke("save_filter_notified_only", { value: next });
+              return next;
+            });
+          }}
+          onToggleShowNonAgentPanes={() => {
+            setShowNonAgentPanes((prev) => {
+              const next = !prev;
+              void invoke("save_show_non_agent_panes", { value: next });
               return next;
             });
           }}

--- a/src/components/keybind-help.tsx
+++ b/src/components/keybind-help.tsx
@@ -11,6 +11,7 @@ const KEYBINDS = [
   { key: "C", action: "Collapse all" },
   { key: "E", action: "Expand all" },
   { key: "F", action: "Filter action needed" },
+  { key: "T", action: "Toggle non-agent panes" },
   { key: "Esc", action: "Close" },
   { key: "?", action: "Help" },
 ] as const;

--- a/src/components/pane-card.tsx
+++ b/src/components/pane-card.tsx
@@ -109,7 +109,11 @@ export function PaneCard({
     >
       <div className="flex items-start gap-2.5">
         <div className="flex-shrink-0 mt-0.5">
-          <IconPreset icon={icon} size={14} className="text-[var(--text-tertiary)]" />
+          {pane.agentType || notification ? (
+            <IconPreset icon={icon} size={14} className="text-[var(--text-tertiary)]" />
+          ) : (
+            <TmuxIcon size={14} className="text-[var(--text-tertiary)]" />
+          )}
         </div>
 
         <div className="flex-1 min-w-0">

--- a/src/components/panel-header.tsx
+++ b/src/components/panel-header.tsx
@@ -1,11 +1,14 @@
 import { useState, useRef, useEffect } from "react";
 import { Bell, BellOff, Filter, Trash2, Loader2, RefreshCw } from "lucide-react";
+import { TmuxIcon } from "@/components/icons/source-icon";
 import type { UpdateStatus } from "@/lib/types";
 
 interface PanelHeaderProps {
   globalMuted: boolean;
   filterNotifiedOnly: boolean;
+  showNonAgentPanes: boolean;
   onToggleFilter: () => void;
+  onToggleShowNonAgentPanes: () => void;
   onDeleteAll: () => void;
   onToggleGlobalMute: () => void;
   appVersion: string;
@@ -37,7 +40,9 @@ function getUpdateTitle(status: UpdateStatus, version: string): string {
 export function PanelHeader({
   globalMuted,
   filterNotifiedOnly,
+  showNonAgentPanes,
   onToggleFilter,
+  onToggleShowNonAgentPanes,
   onDeleteAll,
   onToggleGlobalMute,
   appVersion,
@@ -80,18 +85,32 @@ export function PanelHeader({
 
   return (
     <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border-primary)]">
-      <button
-        tabIndex={-1}
-        onClick={onToggleFilter}
-        className={`p-1.5 rounded-md hover:bg-[var(--hover-bg-strong)] transition-colors ${
-          filterNotifiedOnly
-            ? "text-[var(--text-primary)]"
-            : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
-        }`}
-        title={filterNotifiedOnly ? "Show all" : "Show notified only"}
-      >
-        <Filter size={14} fill={filterNotifiedOnly ? "currentColor" : "none"} />
-      </button>
+      <div className="flex items-center gap-1">
+        <button
+          tabIndex={-1}
+          onClick={onToggleFilter}
+          className={`p-1.5 rounded-md hover:bg-[var(--hover-bg-strong)] transition-colors ${
+            filterNotifiedOnly
+              ? "text-[var(--text-primary)]"
+              : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
+          }`}
+          title={filterNotifiedOnly ? "Show all" : "Show notified only"}
+        >
+          <Filter size={14} fill={filterNotifiedOnly ? "currentColor" : "none"} />
+        </button>
+        <button
+          tabIndex={-1}
+          onClick={onToggleShowNonAgentPanes}
+          className={`p-1.5 rounded-md hover:bg-[var(--hover-bg-strong)] transition-colors ${
+            showNonAgentPanes
+              ? "text-[var(--text-primary)]"
+              : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
+          }`}
+          title={showNonAgentPanes ? "Hide non-agent panes" : "Show non-agent panes"}
+        >
+          <TmuxIcon size={14} />
+        </button>
+      </div>
       <div className="flex items-center gap-1">
         {showUpdateIcon && (
           <div className="relative" ref={dropdownRef}>


### PR DESCRIPTION
## Summary
- Add a toggle to display tmux panes that don't have an AI coding agent, so users can see shell-only panes when needed.
- Persist the toggle state in `config.toml` under `notification.show_non_agent_panes` (default: `false`).
- Bind the new toggle to the `T` key and add a tmux-icon button in the panel header.

## Changes
### Backend (Rust)
- `crates/agentoast-shared/src/config.rs`: Add `show_non_agent_panes` field to `NotificationConfig` with a `save_notification_show_non_agent_panes` helper that preserves comments/formatting.
- `src-tauri/src/sessions/mod.rs`: Make `list_tmux_panes_grouped` accept a `show_non_agent` flag; when `true`, skip the "promote active agent" step and skip the filter that drops non-agent panes.
- `src-tauri/src/lib.rs`: Add `get_show_non_agent_panes` / `save_show_non_agent_panes` commands, propagate the setting through `refresh_and_emit` / `get_sessions`, and register the new commands.

### Frontend (React)
- `src/App.tsx`: Load the current value on startup, handle the `T` keybinding, and wire `onToggleShowNonAgentPanes` to the panel header.
- `src/components/panel-header.tsx`: Add a tmux-icon toggle button next to the existing filter button.
- `src/components/pane-card.tsx`: Render the tmux icon for panes without an agent type or notification.
- `src/components/keybind-help.tsx`: Document the new `T` shortcut.


