### PR TITLE
fix(panel): jump cursor to active tmux pane on Shift+T

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -59,6 +59,7 @@
     "unlisten",
     "untap",
     "wezterm",
+    "worktree",
     "xattr"
   ],
   "flagWords": []

--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -402,22 +402,29 @@ pub fn list_tmux_panes_grouped(
             .map(|p| (p.session_name.clone(), p.window_name.clone()))
             .collect();
         for group in &mut groups {
-            let any_agent_active = group
-                .panes
-                .iter()
-                .any(|p| p.is_active && p.agent_type.is_some());
-            if !any_agent_active {
-                if let Some(first_agent) = group.panes.iter_mut().find(|p| {
-                    p.agent_type.is_some()
-                        && active_windows.contains(&(p.session_name.clone(), p.window_name.clone()))
-                }) {
-                    log::debug!(
-                        "sessions: promoted is_active to agent pane {} (session={} window={})",
-                        first_agent.pane_id,
-                        first_agent.session_name,
-                        first_agent.window_name
-                    );
-                    first_agent.is_active = true;
+            // Only promote within the group that actually hosts the attached pane.
+            // The same tmux (session, window) can span multiple worktree groups;
+            // promoting across groups makes the UI cursor land on the wrong worktree.
+            let has_active_in_group = group.panes.iter().any(|p| p.is_active);
+            if has_active_in_group {
+                let any_agent_active = group
+                    .panes
+                    .iter()
+                    .any(|p| p.is_active && p.agent_type.is_some());
+                if !any_agent_active {
+                    if let Some(first_agent) = group.panes.iter_mut().find(|p| {
+                        p.agent_type.is_some()
+                            && active_windows
+                                .contains(&(p.session_name.clone(), p.window_name.clone()))
+                    }) {
+                        log::debug!(
+                            "sessions: promoted is_active to agent pane {} (session={} window={})",
+                            first_agent.pane_id,
+                            first_agent.session_name,
+                            first_agent.window_name
+                        );
+                        first_agent.is_active = true;
+                    }
                 }
             }
             group.panes.retain(|p| p.agent_type.is_some());

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ export function App() {
 
   const needFetchVersionRef = useRef(-1);
   const repositionCancelledRef = useRef(false);
+  const pendingJumpToActiveRef = useRef(false);
   const fetchVersionRef = useRef(fetchVersion);
   fetchVersionRef.current = fetchVersion;
 
@@ -352,6 +353,19 @@ export function App() {
     });
   }, [flatItems, filterNotifiedOnly, fetchVersion]);
 
+  // Shift+T: jump cursor to the currently active tmux pane once it appears in flatItems
+  useEffect(() => {
+    if (!pendingJumpToActiveRef.current) return;
+    const activeIdx = flatItems.findIndex(
+      (f) => f.type === "pane-item" && f.paneItem.pane.isActive,
+    );
+    if (activeIdx >= 0) {
+      pendingJumpToActiveRef.current = false;
+      repositionCancelledRef.current = true;
+      setSelectedIndex(activeIdx);
+    }
+  }, [flatItems]);
+
   // Scroll selected item into view
   useEffect(() => {
     const container = scrollContainerRef.current;
@@ -532,12 +546,12 @@ export function App() {
       case "T": {
         if (showHelp) break;
         e.preventDefault();
+        pendingJumpToActiveRef.current = true;
         setShowNonAgentPanes((prev) => {
           const next = !prev;
           void invoke("save_show_non_agent_panes", { value: next });
           return next;
         });
-        setSelectedIndex(0);
         break;
       }
       case "Tab": {

--- a/src/components/keybind-help.tsx
+++ b/src/components/keybind-help.tsx
@@ -11,7 +11,7 @@ const KEYBINDS = [
   { key: "C", action: "Collapse all" },
   { key: "E", action: "Expand all" },
   { key: "F", action: "Filter action needed" },
-  { key: "T", action: "Toggle non-agent panes" },
+  { key: "T", action: "Toggle non-agent panes / jump cursor to active pane" },
   { key: "Esc", action: "Close" },
   { key: "?", action: "Help" },
 ] as const;


### PR DESCRIPTION
## Summary

- Shift+T used to call `setSelectedIndex(0)`, which pinned the cursor to the first visible row regardless of the user's attached tmux pane.
- Replace the hard-coded reset with a pending-ref + effect that waits for the post-toggle `flatItems` update and then positions the cursor on the pane where `pane.isActive === true`.
- Update the keybind help text to reflect the new behavior ("Toggle non-agent panes / jump cursor to active pane").

## Why

When the user presses Shift+T, they expect to (1) toggle the non-agent pane visibility and (2) move the cursor to their actually-attached tmux pane. The previous implementation only satisfied (1) and silently reset the cursor to index 0, which looked like a bug ("cursor goes to the top").

## Implementation notes

- `pendingJumpToActiveRef` is set in the `T` handler before invoking `save_show_non_agent_panes`. The backend emits `sessions:updated`, `flatItems` rebuilds, and a dedicated effect consumes the pending flag to set the selection via `findIndex(pane.isActive)`.
- `repositionCancelledRef.current = true` is flipped alongside the jump so the existing clamp effect does not re-pick the latest notification and override the jump.
- If no active pane is visible after the toggle (e.g., the user is on a shell with no sibling agent and `showNonAgentPanes` is turning off), the pending flag stays set and resolves on the next `flatItems` update.

