### PR TITLE
feat(sessions): detect local agent count and auto mode

### DIFF
--- a/src-tauri/src/sessions/agents/claude.rs
+++ b/src-tauri/src/sessions/agents/claude.rs
@@ -9,6 +9,7 @@ struct ClaudePaneContentInfo {
     has_question_dialog: bool, // "Enter to select" navigation hint (AskUserQuestion dialog)
     has_plan_approval: bool,   // ❯ N. selection cursor + 2+ numbered options (plan approval etc.)
     shell_count: Option<u32>, // Background shell task count from "· N shell" (or "· N bash") in mode line
+    local_agent_count: Option<u32>, // Background local agent count from "· N local agent(s)" in mode line
     agent_modes: Vec<String>,
     team_role: Option<String>, // "lead" or "teammate" (Agent Teams feature)
     team_name: Option<String>, // "@agent-alpha" for teammates
@@ -50,7 +51,8 @@ pub(super) fn detect_claude_status(
         (AgentStatus::Waiting, Some("respond".to_string()))
     } else if info.at_prompt {
         // Background shell tasks mean work is still in progress — treat as Running
-        if info.shell_count.is_some_and(|c| c > 0) {
+        if info.shell_count.is_some_and(|c| c > 0) || info.local_agent_count.is_some_and(|c| c > 0)
+        {
             (AgentStatus::Running, None)
         } else if let Some(conn) = db_conn {
             if let Ok(Some(_)) = db::get_latest_notification_by_pane(conn, pane_id) {
@@ -83,6 +85,7 @@ const MODE_PATTERNS: &[(&str, &str)] = &[
     ("plan mode on", "plan"),
     ("bypass permissions on", "bypass"),
     ("accept edits on", "accept"),
+    ("auto mode on", "auto"),
 ];
 
 fn check_claude_pane_content(pane_id: &str, content: Option<&str>) -> ClaudePaneContentInfo {
@@ -93,6 +96,7 @@ fn check_claude_pane_content(pane_id: &str, content: Option<&str>) -> ClaudePane
         has_question_dialog: false,
         has_plan_approval: false,
         shell_count: None,
+        local_agent_count: None,
         agent_modes: Vec::new(),
         team_role: None,
         team_name: None,
@@ -136,6 +140,7 @@ fn check_claude_pane_content(pane_id: &str, content: Option<&str>) -> ClaudePane
     let mut numbered_option_count: usize = 0;
     let mut agent_modes: Vec<String> = Vec::new();
     let mut shell_count: Option<u32> = None; // set in status_area scan below
+    let mut local_agent_count: Option<u32> = None; // set in status_area scan below
 
     for line in &last_lines {
         let trimmed = line.trim();
@@ -210,6 +215,13 @@ fn check_claude_pane_content(pane_id: &str, content: Option<&str>) -> ClaudePane
         // or as a standalone status line ("1 shell · PR #1381").
         if shell_count.is_none() {
             shell_count = extract_shell_count(trimmed);
+        }
+
+        // Background local agent detection: "· N local agent(s)" pattern.
+        // Can appear on the mode line ("⏸ plan mode on · 1 local agent")
+        // or as a standalone status line ("1 local agent · ...").
+        if local_agent_count.is_none() {
+            local_agent_count = extract_local_agent_count(trimmed);
         }
 
         // Lead: mode line (⏵/⏸) containing "teammate"
@@ -288,6 +300,18 @@ fn check_claude_pane_content(pane_id: &str, content: Option<&str>) -> ClaudePane
         }
     }
 
+    // Add local agent count to agent_modes if detected
+    if let Some(count) = local_agent_count {
+        if count > 0 {
+            log::debug!(
+                "check_claude_pane_content({}): {} local agent(s) detected",
+                pane_id,
+                count
+            );
+            agent_modes.push(format!("{} local agent", count));
+        }
+    }
+
     ClaudePaneContentInfo {
         has_spinner,
         has_status_running,
@@ -295,6 +319,7 @@ fn check_claude_pane_content(pane_id: &str, content: Option<&str>) -> ClaudePane
         has_question_dialog,
         has_plan_approval,
         shell_count,
+        local_agent_count,
         agent_modes,
         team_role,
         team_name,
@@ -351,6 +376,52 @@ fn extract_shell_count(line: &str) -> Option<u32> {
             let next = parts.next();
             if next.is_none() || next == Some("\u{00B7}") {
                 return Some(count);
+            }
+        }
+    }
+
+    None
+}
+
+/// Extract background local agent count from a status bar line.
+/// Pattern 1 (mode line suffix): "⏸ plan mode on · 1 local agent" → Some(1)
+/// Pattern 2 (standalone line):  "1 local agent · ..." → Some(1)
+fn extract_local_agent_count(line: &str) -> Option<u32> {
+    let trimmed = line.trim();
+
+    // Pattern 1: "· N local agent(s)" suffix (· = U+00B7 MIDDLE DOT)
+    // The next token after "agent"/"agents" must be absent or "·" to avoid matching
+    // conversation text like "· 2 local agent configurations".
+    let marker = "\u{00B7} ";
+    if let Some(pos) = trimmed.rfind(marker) {
+        let after = trimmed[pos + marker.len()..].trim();
+        let mut parts = after.split_whitespace();
+        if let Some(count) = parts.next().and_then(|s| s.parse::<u32>().ok()) {
+            if parts.next() == Some("local") {
+                if let Some(kw) = parts.next() {
+                    if kw == "agent" || kw == "agents" {
+                        let next = parts.next();
+                        if next.is_none() || next == Some("\u{00B7}") {
+                            return Some(count);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Pattern 2: "N local agent(s)" at line start
+    // The next token after "agent"/"agents" must be absent or "·" (middle dot).
+    let mut parts = trimmed.split_whitespace();
+    if let Some(count) = parts.next().and_then(|s| s.parse::<u32>().ok()) {
+        if parts.next() == Some("local") {
+            if let Some(kw) = parts.next() {
+                if kw == "agent" || kw == "agents" {
+                    let next = parts.next();
+                    if next.is_none() || next == Some("\u{00B7}") {
+                        return Some(count);
+                    }
+                }
             }
         }
     }

--- a/src/components/pane-card.tsx
+++ b/src/components/pane-card.tsx
@@ -145,7 +145,7 @@ export function PaneCard({
                   key={mode}
                   className={cn(
                     "text-[10px] font-medium flex-shrink-0",
-                    mode.endsWith("shell") || mode.endsWith("bash")
+                    mode.endsWith("shell") || mode.endsWith("bash") || mode.endsWith("local agent")
                       ? "text-green-500"
                       : "text-[var(--text-muted)]",
                   )}


### PR DESCRIPTION
## Summary

- Port #173: detect `· N local agent(s)` in the Claude Code status bar and treat it the same as `shell_count` (agent mode badge + Running status override).
- Detect `⏵⏵ auto mode on` via `MODE_PATTERNS` so the PaneCard renders a muted `auto` badge alongside `plan` / `bypass` / `accept`.
- Render background-activity modes (`shell` / `bash` / `local agent`) in green on the PaneCard to visually separate them from user-selected UI modes.

## Changes

### `src-tauri/src/sessions/agents/claude.rs`
- Add `local_agent_count: Option<u32>` field to `ClaudePaneContentInfo`.
- New `extract_local_agent_count()` — matches both the `· N local agent(s)` mode-line suffix and a standalone `N local agent(s) · …` line, mirroring `extract_shell_count()`.
- Call the extractor in the status-area scan (bottom 7 lines) and include `local_agent_count > 0` in the `at_prompt` Running override.
- Push `N local agent` to `agent_modes` so the frontend can render it.
- Add `(\"auto mode on\", \"auto\")` to `MODE_PATTERNS`. Existing `shift+tab to cycle` skip in `is_prompt_line()` already prevents the auto mode line from being misclassified as a prompt.

### `src/components/pane-card.tsx`
- Extend the green badge condition to `mode.endsWith(\"local agent\")` so local-agent activity renders green like `shell` / `bash`. `auto` keeps the muted color (consistent with `plan` / `bypass` / `accept`).

