### PR TITLE
fix(panel): simplify T key help description

### DIFF
--- a/src/components/keybind-help.tsx
+++ b/src/components/keybind-help.tsx
@@ -11,7 +11,7 @@ const KEYBINDS = [
   { key: "C", action: "Collapse all" },
   { key: "E", action: "Expand all" },
   { key: "F", action: "Filter action needed" },
-  { key: "T", action: "Toggle non-agent panes / jump cursor to active pane" },
+  { key: "T", action: "Toggle non-agent panes" },
   { key: "Esc", action: "Close" },
   { key: "?", action: "Help" },
 ] as const;


### PR DESCRIPTION
## Summary
- Shorten the `T` key description in the keybind help overlay to `Toggle non-agent panes`.
- Drops the secondary "jump cursor to active pane" side-effect note for readability.

## Changes
- `src/components/keybind-help.tsx` — updated the `T` entry in the `KEYBINDS` array.


