### PR TITLE
fix(panel): track selection by stable key and harden tmux switch

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -51,6 +51,7 @@
     "rusqlite",
     "shuntaka",
     "splitn",
+    "subcmd",
     "subview",
     "subviews",
     "staticlib",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -194,14 +194,45 @@ fn show_panel(app_handle: tauri::AppHandle) {
 }
 
 #[tauri::command]
-fn focus_terminal(tmux_pane: String, terminal_bundle_id: String) -> Result<(), String> {
+fn focus_terminal(
+    app_handle: tauri::AppHandle,
+    tmux_pane: String,
+    terminal_bundle_id: String,
+) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
-        terminal::focus_terminal(&tmux_pane, &terminal_bundle_id)
+        // Split out the tmux switch from the terminal activation so we can
+        // react when the pane id is stale: if tmux errors, refresh sessions
+        // immediately so the frontend's next keypress uses fresh ids instead
+        // of waiting for the user to nudge tmux manually.
+        let mut tmux_failed = false;
+        if !tmux_pane.is_empty() {
+            if let Err(e) = terminal::switch_tmux_pane(&tmux_pane) {
+                log::warn!(
+                    "focus_terminal: switch_tmux_pane failed pane={}: {}",
+                    tmux_pane,
+                    e
+                );
+                tmux_failed = true;
+            }
+        }
+
+        if tmux_failed {
+            let ctrl = app_handle
+                .try_state::<sessions::TmuxCtrl>()
+                .map(|s| s.inner().clone());
+            refresh_and_emit(&app_handle, ctrl.as_ref());
+        }
+
+        if terminal_bundle_id.is_empty() {
+            terminal::activate_any_terminal()
+        } else {
+            terminal::activate_terminal(&terminal_bundle_id)
+        }
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = (tmux_pane, terminal_bundle_id);
+        let _ = (app_handle, tmux_pane, terminal_bundle_id);
         Err("focus_terminal is only supported on macOS".to_string())
     }
 }

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -111,32 +111,91 @@ pub(crate) fn find_git() -> Option<PathBuf> {
     None
 }
 
-fn switch_tmux_pane(tmux_pane: &str) -> Result<(), String> {
-    let tmux_path = find_tmux().ok_or_else(|| "tmux not found".to_string())?;
-
-    // Switch the attached session to the one containing the target pane
-    Command::new(&tmux_path)
+/// Resolve a pane id (%NN) to a concrete `session:window.pane` target by
+/// asking tmux. Returns `None` when the pane no longer exists, which lets the
+/// caller decide to fall back to the raw pane id or report failure upstream.
+fn resolve_pane_target(tmux_path: &std::path::Path, pane_id: &str) -> Option<(String, String)> {
+    let output = Command::new(tmux_path)
         .env_remove("TMPDIR")
-        .args(["switch-client", "-t", tmux_pane])
+        .args([
+            "display-message",
+            "-t",
+            pane_id,
+            "-p",
+            "#{session_name}\t#{session_name}:#{window_index}.#{pane_index}",
+        ])
         .output()
-        .map_err(|e| format!("tmux switch-client failed: {}", e))?;
+        .ok()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        log::warn!(
+            "switch_tmux_pane: display-message failed for pane={} exit={:?} stderr={}",
+            pane_id,
+            output.status.code(),
+            stderr.trim()
+        );
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let line = stdout.lines().next()?;
+    let mut parts = line.splitn(2, '\t');
+    let session = parts.next()?.trim().to_string();
+    let target = parts.next()?.trim().to_string();
+    if session.is_empty() || target.is_empty() {
+        return None;
+    }
+    Some((session, target))
+}
 
-    Command::new(&tmux_path)
+fn run_tmux_subcmd(tmux_path: &std::path::Path, subcmd: &str, target: &str) -> Result<(), String> {
+    let output = Command::new(tmux_path)
         .env_remove("TMPDIR")
-        .args(["select-window", "-t", tmux_pane])
+        .args([subcmd, "-t", target])
         .output()
-        .map_err(|e| format!("tmux select-window failed: {}", e))?;
-
-    Command::new(&tmux_path)
-        .env_remove("TMPDIR")
-        .args(["select-pane", "-t", tmux_pane])
-        .output()
-        .map_err(|e| format!("tmux select-pane failed: {}", e))?;
-
+        .map_err(|e| format!("tmux {} failed to spawn: {}", subcmd, e))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let msg = format!(
+            "tmux {} -t {} exit={:?} stderr={}",
+            subcmd,
+            target,
+            output.status.code(),
+            stderr.trim()
+        );
+        log::warn!("switch_tmux_pane: {}", msg);
+        return Err(msg);
+    }
     Ok(())
 }
 
-fn activate_terminal(bundle_id: &str) -> Result<(), String> {
+pub(crate) fn switch_tmux_pane(tmux_pane: &str) -> Result<(), String> {
+    let tmux_path = find_tmux().ok_or_else(|| "tmux not found".to_string())?;
+
+    // Resolve pane-id to session+window+pane so switch-client gets a valid
+    // target-session (its -t flag expects a session, not a pane id).
+    let (session_target, full_target) = match resolve_pane_target(&tmux_path, tmux_pane) {
+        Some(pair) => pair,
+        None => {
+            // Pane likely vanished; fall back to the raw id so at least
+            // select-pane has a chance to succeed. The three sub-calls
+            // below will surface real errors via their exit status.
+            (tmux_pane.to_string(), tmux_pane.to_string())
+        }
+    };
+
+    run_tmux_subcmd(&tmux_path, "switch-client", &session_target)?;
+    run_tmux_subcmd(&tmux_path, "select-window", &full_target)?;
+    run_tmux_subcmd(&tmux_path, "select-pane", &full_target)?;
+
+    log::info!(
+        "switch_tmux_pane ok pane={} target={}",
+        tmux_pane,
+        full_target
+    );
+    Ok(())
+}
+
+pub(crate) fn activate_terminal(bundle_id: &str) -> Result<(), String> {
     if bundle_id.is_empty() {
         return Err("No terminal bundle ID specified".to_string());
     }
@@ -289,7 +348,7 @@ pub fn is_pane_visible_to_user(terminal_bundle_id: &str, tmux_pane: &str) -> boo
     pane_active
 }
 
-fn activate_any_terminal() -> Result<(), String> {
+pub(crate) fn activate_any_terminal() -> Result<(), String> {
     for &bid in KNOWN_TERMINAL_BUNDLE_IDS {
         if activate_terminal(bid).is_ok() {
             return Ok(());

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ export function App() {
       .catch(() => {});
   }, []);
 
-  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [selectedKey, setSelectedKey] = useState<SelectedKey | null>(null);
   const [showHelp, setShowHelp] = useState(false);
   const [filterNotifiedOnly, setFilterNotifiedOnly] = useState(false);
   const [showNonAgentPanes, setShowNonAgentPanes] = useState(false);
@@ -53,8 +53,9 @@ export function App() {
       .catch(() => {});
   }, []);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const selectedIndexRef = useRef(selectedIndex);
-  selectedIndexRef.current = selectedIndex;
+  const selectedKeyRef = useRef(selectedKey);
+  selectedKeyRef.current = selectedKey;
+  const lastIndexRef = useRef(-1);
 
   const toggleGroupExpanded = useCallback((groupKey: string) => {
     setManuallyToggledGroups((prev) => {
@@ -301,10 +302,31 @@ export function App() {
     return result;
   }, [displayGroups, collapsedGroups]);
 
+  // Resolve the numeric index of the currently-selected key. Falls back to the
+  // last known index (clamped) when the key disappears so the cursor stays near
+  // its old position instead of snapping to the top or activating a random item.
+  const selectedIndex = useMemo(() => {
+    if (flatItems.length === 0) {
+      lastIndexRef.current = -1;
+      return -1;
+    }
+    const hit = indexOfKey(flatItems, selectedKey);
+    if (hit >= 0) {
+      lastIndexRef.current = hit;
+      return hit;
+    }
+    if (selectedKey === null) {
+      return -1;
+    }
+    const clamped = Math.min(Math.max(lastIndexRef.current, 0), flatItems.length - 1);
+    return clamped;
+  }, [flatItems, selectedKey]);
+
   // Reset selection when panel is shown
   useEffect(() => {
     const unlisten = listen("panel:shown", () => {
-      setSelectedIndex(-1);
+      setSelectedKey(null);
+      lastIndexRef.current = -1;
       repositionCancelledRef.current = false;
       needFetchVersionRef.current = fetchVersionRef.current;
     });
@@ -313,66 +335,70 @@ export function App() {
     };
   }, []);
 
-  // Clamp selectedIndex when items change; reposition cursor when fresh data arrives
+  // Pick the initial cursor position when fresh data arrives and no selection
+  // exists yet. Once a key is set, we never overwrite it here — the derived
+  // selectedIndex memo handles "item disappeared" via nearest-index fallback.
   useEffect(() => {
-    setSelectedIndex((prev) => {
-      if (flatItems.length === 0) return -1;
-      if (prev < 0 && !repositionCancelledRef.current) {
-        // Wait until sessions data is fresh after panel show
-        if (needFetchVersionRef.current >= 0 && fetchVersion <= needFetchVersionRef.current) {
-          return -1;
-        }
+    if (flatItems.length === 0) {
+      if (selectedKey !== null) setSelectedKey(null);
+      return;
+    }
+    if (selectedKey !== null) return;
+    if (repositionCancelledRef.current) return;
+    // Wait until sessions data is fresh after panel show
+    if (needFetchVersionRef.current >= 0 && fetchVersion <= needFetchVersionRef.current) {
+      return;
+    }
 
-        // Hold selection if the active pane's group is manually collapsed.
-        // The auto-expand useEffect will remove it from manuallyToggledGroups,
-        // re-render will include the active pane in flatItems, and this effect
-        // will re-run and pick the active pane below.
-        if (!filterNotifiedOnly) {
-          const activeGroup = displayGroups.find((ug) =>
-            ug.paneItems.some((pi) => pi.pane.isActive),
-          );
-          if (
-            activeGroup &&
-            manuallyToggledGroups.has(activeGroup.groupKey) &&
-            collapsedGroups.has(activeGroup.groupKey)
-          ) {
-            return -1;
-          }
-        }
-
-        needFetchVersionRef.current = -1;
-
-        // If notifications exist, focus the pane with the most recent notification
-        let latestNotifIdx = -1;
-        let latestCreatedAt = "";
-        for (let i = 0; i < flatItems.length; i++) {
-          const f = flatItems[i];
-          if (f.type === "pane-item" && f.paneItem.notification) {
-            if (f.paneItem.notification.createdAt > latestCreatedAt) {
-              latestCreatedAt = f.paneItem.notification.createdAt;
-              latestNotifIdx = i;
-            }
-          }
-        }
-        if (latestNotifIdx >= 0) return latestNotifIdx;
-
-        if (!filterNotifiedOnly) {
-          // No notifications: focus the active tmux pane
-          const activeIdx = flatItems.findIndex(
-            (f) => f.type === "pane-item" && f.paneItem.pane.isActive,
-          );
-          if (activeIdx >= 0) return activeIdx;
-        }
-        // No notifications and no active pane: focus first non-header item
-        const idx = flatItems.findIndex((f) => f.type !== "group-header");
-        return idx >= 0 ? idx : 0;
+    // Hold selection if the active pane's group is manually collapsed.
+    // The auto-expand useEffect will remove it from manuallyToggledGroups,
+    // re-render will include the active pane in flatItems, and this effect
+    // will re-run and pick the active pane below.
+    if (!filterNotifiedOnly) {
+      const activeGroup = displayGroups.find((ug) => ug.paneItems.some((pi) => pi.pane.isActive));
+      if (
+        activeGroup &&
+        manuallyToggledGroups.has(activeGroup.groupKey) &&
+        collapsedGroups.has(activeGroup.groupKey)
+      ) {
+        return;
       }
-      return Math.min(prev, flatItems.length - 1);
-    });
+    }
+
+    needFetchVersionRef.current = -1;
+
+    // If notifications exist, focus the pane with the most recent notification
+    let latest: { idx: number; at: string } | null = null;
+    for (let i = 0; i < flatItems.length; i++) {
+      const f = flatItems[i];
+      if (f.type === "pane-item" && f.paneItem.notification) {
+        if (!latest || f.paneItem.notification.createdAt > latest.at) {
+          latest = { idx: i, at: f.paneItem.notification.createdAt };
+        }
+      }
+    }
+    if (latest) {
+      setSelectedKey(keyFromItem(flatItems[latest.idx]));
+      return;
+    }
+
+    if (!filterNotifiedOnly) {
+      const activeIdx = flatItems.findIndex(
+        (f) => f.type === "pane-item" && f.paneItem.pane.isActive,
+      );
+      if (activeIdx >= 0) {
+        setSelectedKey(keyFromItem(flatItems[activeIdx]));
+        return;
+      }
+    }
+    const idx = flatItems.findIndex((f) => f.type !== "group-header");
+    const fallback = idx >= 0 ? idx : 0;
+    setSelectedKey(keyFromItem(flatItems[fallback]));
   }, [
     flatItems,
     filterNotifiedOnly,
     fetchVersion,
+    selectedKey,
     displayGroups,
     manuallyToggledGroups,
     collapsedGroups,
@@ -380,9 +406,9 @@ export function App() {
 
   // On panel show, auto-expand the active pane's group if it was manually
   // collapsed, so the cursor can reach the active pane. Runs only while the
-  // initial cursor positioning is pending (selectedIndex < 0, no user interaction).
+  // initial cursor positioning is pending (no selection, no user interaction).
   useEffect(() => {
-    if (selectedIndexRef.current >= 0) return;
+    if (selectedKeyRef.current !== null) return;
     if (repositionCancelledRef.current) return;
     if (filterNotifiedOnly) return;
     if (needFetchVersionRef.current >= 0 && fetchVersion <= needFetchVersionRef.current) {
@@ -409,7 +435,7 @@ export function App() {
     if (activeIdx >= 0) {
       pendingJumpToActiveRef.current = false;
       repositionCancelledRef.current = true;
-      setSelectedIndex(activeIdx);
+      setSelectedKey(keyFromItem(flatItems[activeIdx]));
     }
   }, [flatItems]);
 
@@ -493,7 +519,10 @@ export function App() {
         e.preventDefault();
         repositionCancelledRef.current = true;
         if (flatItems.length > 0) {
-          setSelectedIndex((prev) => Math.min(prev + 1, flatItems.length - 1));
+          const cur = indexOfKey(flatItems, selectedKeyRef.current);
+          const base = cur >= 0 ? cur : lastIndexRef.current;
+          const nextIdx = Math.min(base + 1, flatItems.length - 1);
+          setSelectedKey(keyFromItem(flatItems[nextIdx]));
         }
         break;
       case "k":
@@ -501,14 +530,20 @@ export function App() {
         e.preventDefault();
         repositionCancelledRef.current = true;
         if (flatItems.length > 0) {
-          setSelectedIndex((prev) => Math.max(prev - 1, 0));
+          const cur = indexOfKey(flatItems, selectedKeyRef.current);
+          const base = cur >= 0 ? cur : lastIndexRef.current;
+          const nextIdx = Math.max(base - 1, 0);
+          setSelectedKey(keyFromItem(flatItems[nextIdx]));
         }
         break;
       case "Enter": {
         if (showHelp) break;
         e.preventDefault();
         repositionCancelledRef.current = true;
-        const item = flatItems[selectedIndexRef.current];
+        // Resolve by key at keypress time — protects against flatItems having
+        // been re-sorted (e.g. a new notification) between last render and now.
+        const resolvedIdx = indexOfKey(flatItems, selectedKeyRef.current);
+        const item = resolvedIdx >= 0 ? flatItems[resolvedIdx] : undefined;
         if (!item) {
           void invoke("hide_panel");
           break;
@@ -524,7 +559,8 @@ export function App() {
       case "d": {
         if (showHelp || e.shiftKey) break;
         e.preventDefault();
-        const item = flatItems[selectedIndexRef.current];
+        const resolvedIdx = indexOfKey(flatItems, selectedKeyRef.current);
+        const item = resolvedIdx >= 0 ? flatItems[resolvedIdx] : undefined;
         if (!item) break;
         if (item.type === "group-header") {
           const ug = unifiedGroups.find((g) => g.groupKey === item.groupKey);
@@ -558,7 +594,11 @@ export function App() {
           }
           return next;
         });
-        setSelectedIndex(0);
+        if (flatItems.length > 0) {
+          setSelectedKey(keyFromItem(flatItems[0]));
+        } else {
+          setSelectedKey(null);
+        }
         break;
       }
       case "E": {
@@ -587,7 +627,10 @@ export function App() {
           void invoke("save_filter_notified_only", { value: next });
           return next;
         });
-        setSelectedIndex(0);
+        // flatItems will be rebuilt on the next render; clear key so the
+        // reposition effect picks the new cursor the same way it does on open.
+        setSelectedKey(null);
+        repositionCancelledRef.current = false;
         break;
       }
       case "T": {
@@ -606,14 +649,14 @@ export function App() {
         e.preventDefault();
         repositionCancelledRef.current = true;
         const direction = e.shiftKey ? -1 : 1;
-        const curIdx = selectedIndexRef.current;
+        const curIdx = indexOfKey(flatItems, selectedKeyRef.current);
         let nextIndex =
           curIdx < 0 ? (direction === 1 ? 0 : flatItems.length - 1) : curIdx + direction;
         while (nextIndex >= 0 && nextIndex < flatItems.length) {
           const fi = flatItems[nextIndex];
           const hasNotif = fi.type === "pane-item" && fi.paneItem.notification !== null;
           if (hasNotif) {
-            setSelectedIndex(nextIndex);
+            setSelectedKey(keyFromItem(fi));
             break;
           }
           nextIndex += direction;
@@ -629,7 +672,7 @@ export function App() {
   }, []);
 
   // Derive selected IDs for highlighting
-  const currentItem = flatItems[selectedIndexRef.current];
+  const currentItem = selectedIndex >= 0 ? flatItems[selectedIndex] : undefined;
   const selectedNotificationId =
     currentItem?.type === "pane-item" && currentItem.paneItem.notification
       ? currentItem.paneItem.notification.id
@@ -725,6 +768,23 @@ export function App() {
       </div>
     </div>
   );
+}
+
+type SelectedKey = { kind: "pane"; paneId: string } | { kind: "group"; groupKey: string };
+
+function keyFromItem(f: FlatItem): SelectedKey {
+  if (f.type === "group-header") {
+    return { kind: "group", groupKey: f.groupKey };
+  }
+  return { kind: "pane", paneId: f.paneItem.pane.paneId };
+}
+
+function indexOfKey(items: FlatItem[], key: SelectedKey | null): number {
+  if (key === null) return -1;
+  if (key.kind === "pane") {
+    return items.findIndex((f) => f.type === "pane-item" && f.paneItem.pane.paneId === key.paneId);
+  }
+  return items.findIndex((f) => f.type === "group-header" && f.groupKey === key.groupKey);
 }
 
 function groupHasNotifications(ug: UnifiedGroup): boolean {


### PR DESCRIPTION
## Summary

- Fix intermittent bug where pressing Enter on a selected pane failed to transition and left the UI unchanged.
- Root causes were independent: frontend cursor drift during `flatItems` resort bursts, and backend `switch_tmux_pane` silently ignoring tmux errors on stale pane ids.
- Hardens both sides so the regression can be diagnosed from logs next time.

## Details

### Frontend: stable-key selection (`src/App.tsx`)

Cursor was stored as `selectedIndex: number` into `flatItems`, which is regenerated whenever notifications or sessions update. When a notification arrived for another pane, `unifiedGroups` got re-sorted by `createdAt` desc, and the same numeric index would end up on a different item — often a `group-header`. Pressing Enter then ran `toggleGroupExpanded` instead of `focus_terminal`, so the UI stayed as-is.

- Replace `selectedIndex` state with `selectedKey: { kind: "pane"; paneId } | { kind: "group"; groupKey } | null`.
- Derive `selectedIndex` via `useMemo` that resolves the key against the current `flatItems`, with a `lastIndexRef` nearest-index fallback when the key disappears.
- Enter/`d` resolve the item by key at keypress time (via `indexOfKey(flatItems, selectedKeyRef.current)`) so a mid-flight resort can't hand Enter a group-header that wasn't selected.
- `j`/`k`/`Tab`/`C`/`E`/Shift+T all write the new key via `keyFromItem(...)`.

### Backend: tmux switch hardening (`src-tauri/src/terminal.rs`, `src-tauri/src/lib.rs`)

`switch_tmux_pane` passed the raw pane id (`%NN`) as `switch-client -t`, which expects a session name. It also ignored each sub-command's exit status, so after a tmux ctrl reconnect or a pane re-layout the call would silently no-op and leave the user on the wrong pane. "Touching tmux fixes it" matched exactly: a `%window-pane-changed` from the control channel refreshed the cached pane id and the next Enter succeeded.

- Resolve the target first via `display-message -t <paneId> -p '#{session_name}\t#{session_name}:#{window_index}.#{pane_index}'`.
- `switch-client -t <sessionName>` → `select-window -t session:win.pane` → `select-pane -t target`, with a raw-id fallback when resolution fails.
- Each sub-command now checks `status.success()`, logs stderr on failure via `log::warn!`, and returns `Err`.
- `focus_terminal` in `lib.rs` now splits the tmux switch from terminal activation; on tmux failure it calls `refresh_and_emit(&app_handle, ctrl.as_ref())` so the frontend gets a fresh `sessions:updated` and the next Enter uses a live pane id.

## Verification

- `cargo check`, `cargo clippy -- -D warnings`, `cargo fmt --check`, `bunx tsc --noEmit`, `vp fmt --check`, `vp lint --deny-warnings`, `cspell lint` all pass locally (pre-push hook).
- Manual: new log lines (`switch_tmux_pane ok pane=%X` / `tmux <subcmd> -t ... exit=...`) appear in `~/.local/share/agentoast/agentoast.log` so future occurrences leave evidence.

