### PR TITLE
perf(logging): gate sessions debug logs to debug builds only

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -414,6 +414,12 @@ pub fn run() {
 
     let file_logger = fern::log_file(&log_path).expect("Failed to create log file");
 
+    let sessions_level = if cfg!(debug_assertions) {
+        log::LevelFilter::Debug
+    } else {
+        log::LevelFilter::Info
+    };
+
     fern::Dispatch::new()
         .format(|out, message, record| {
             out.finish(format_args!(
@@ -424,7 +430,7 @@ pub fn run() {
             ))
         })
         .level(log::LevelFilter::Info)
-        .level_for("agentoast_app_lib::sessions", log::LevelFilter::Debug)
+        .level_for("agentoast_app_lib::sessions", sessions_level)
         .chain(std::io::stderr())
         .chain(file_logger)
         .apply()

--- a/src-tauri/src/sessions/agents/claude.rs
+++ b/src-tauri/src/sessions/agents/claude.rs
@@ -127,7 +127,7 @@ fn check_claude_pane_content(pane_id: &str, content: Option<&str>) -> ClaudePane
         .copied()
         .collect();
 
-    log::debug!(
+    log::trace!(
         "check_claude_pane_content({}): last lines (bottom→up, first 5): {:?}",
         pane_id,
         &last_lines[..last_lines.len().min(5)]


### PR DESCRIPTION
## Summary

- Gate the `agentoast_app_lib::sessions` Debug log level behind `cfg!(debug_assertions)` so release builds fall back to `Info`, eliminating the 43 per-pane `log::debug!` calls under `sessions/agents/` that fired on every `get_sessions` invocation.
- Demote the Claude `last_lines` dump (which serializes up to 5 captured pane lines with `{:?}`) from `debug!` to `trace!` so even debug builds stay readable.

## Why

Inspection of `~/.local/share/agentoast/agentoast.log` on a live install showed ~70,000 lines per 5 MB rotation, dominated by `sessions/agents/` debug output (e.g. `check_claude_pane_content(...) last lines ...` at 1,546 occurrences, `detect_claude_status(...)` at 1,632). These logs run in release builds on every panel open and tmux topology change, producing dozens of stderr + file writes plus `{:?}` formatting over captured pane contents per `get_sessions` call.

## Changes

- `src-tauri/src/lib.rs`: pick `LevelFilter::Debug` only under `cfg!(debug_assertions)`, otherwise `Info`, and pass that to `fern`'s `level_for("agentoast_app_lib::sessions", ...)`.
- `src-tauri/src/sessions/agents/claude.rs`: `log::debug!` → `log::trace!` for the `last lines (bottom→up, first 5)` dump.

