### PR TITLE
feat(panel): show fg process name on non-agent panes

### DIFF
--- a/crates/agentoast-shared/src/models.rs
+++ b/crates/agentoast-shared/src/models.rs
@@ -87,6 +87,7 @@ pub struct TmuxPane {
     pub team_name: Option<String>, // "@agent-alpha" (teammate only)
     pub git_repo_root: Option<String>,
     pub git_branch: Option<String>,
+    pub current_command: Option<String>, // tmux #{pane_current_command}
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -162,7 +162,7 @@ pub fn list_tmux_panes_grouped(show_non_agent: bool) -> Result<Vec<TmuxPaneGroup
     // converting tabs to underscores.
     const DELIM: &str = "|||";
     let format_str = format!(
-        "#{{pane_id}}{d}#{{pane_pid}}{d}#{{session_name}}{d}#{{window_name}}{d}#{{pane_current_path}}{d}#{{pane_active}}{d}#{{window_active}}{d}#{{session_attached}}",
+        "#{{pane_id}}{d}#{{pane_pid}}{d}#{{session_name}}{d}#{{window_name}}{d}#{{pane_current_path}}{d}#{{pane_active}}{d}#{{window_active}}{d}#{{session_attached}}{d}#{{pane_current_command}}",
         d = DELIM
     );
 
@@ -207,13 +207,14 @@ pub fn list_tmux_panes_grouped(show_non_agent: bool) -> Result<Vec<TmuxPaneGroup
         current_path: String,
         is_active: bool,
         agent_type: Option<String>,
+        current_command: Option<String>,
     }
 
     let mut raw_panes: Vec<RawPane> = Vec::new();
 
     for line in &stdout_lines {
-        let parts: Vec<&str> = line.splitn(8, DELIM).collect();
-        if parts.len() < 8 {
+        let parts: Vec<&str> = line.splitn(9, DELIM).collect();
+        if parts.len() < 9 {
             continue;
         }
 
@@ -229,6 +230,12 @@ pub fn list_tmux_panes_grouped(show_non_agent: bool) -> Result<Vec<TmuxPaneGroup
             is_active
         );
 
+        let current_command = if parts[8].is_empty() {
+            None
+        } else {
+            Some(parts[8].to_string())
+        };
+
         raw_panes.push(RawPane {
             pane_id: parts[0].to_string(),
             pane_pid,
@@ -237,6 +244,7 @@ pub fn list_tmux_panes_grouped(show_non_agent: bool) -> Result<Vec<TmuxPaneGroup
             current_path: parts[4].to_string(),
             is_active,
             agent_type,
+            current_command,
         });
     }
     log::debug!("sessions: parsed {} panes total", raw_panes.len());
@@ -317,6 +325,7 @@ pub fn list_tmux_panes_grouped(show_non_agent: bool) -> Result<Vec<TmuxPaneGroup
                 team_name,
                 git_repo_root: git_info.map(|g| g.repo_root.clone()),
                 git_branch: git_info.and_then(|g| g.branch.clone()),
+                current_command: rp.current_command,
             }
         })
         .collect();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -160,6 +160,7 @@ export function App() {
           teamName: null,
           gitRepoRoot: null,
           gitBranch: null,
+          currentCommand: null,
         },
         notification: n,
       });

--- a/src/components/pane-card.tsx
+++ b/src/components/pane-card.tsx
@@ -209,6 +209,11 @@ export function PaneCard({
                   className={cn("flex items-center gap-0.5", metaEntries.length > 0 ? "ml-1" : "")}
                 >
                   <TmuxIcon size={10} className="flex-shrink-0" /> {pane.paneId}
+                  {pane.currentCommand && !pane.agentType && (
+                    <span className="ml-1 text-[var(--text-tertiary)]">
+                      · {pane.currentCommand}
+                    </span>
+                  )}
                 </span>
               )}
             </div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,6 +45,7 @@ export interface TmuxPane {
   teamName: string | null; // "@agent-alpha" for teammates
   gitRepoRoot: string | null;
   gitBranch: string | null;
+  currentCommand: string | null;
 }
 
 export interface TmuxPaneGroup {


### PR DESCRIPTION
## Summary

- Show the foreground process name (`tmux #{pane_current_command}`) next to the pane id on `PaneCard` for non-agent panes
- Helps identify what is running in panes shown via the `T` (`show_non_agent_panes`) toggle, where the card was previously near-empty
- Suppressed for agent panes to avoid duplicating the icon/mode badges (and to hide noisy values like Claude Code's versioned binary path)

## Changes

| File | Change |
|---|---|
| `crates/agentoast-shared/src/models.rs` | Add `current_command: Option<String>` to `TmuxPane` |
| `src-tauri/src/sessions/mod.rs` | Append `#{pane_current_command}` to the `list-panes -F` format and parse it (`splitn(8)` → `splitn(9)`) |
| `src/lib/types.ts` | Add `currentCommand: string \| null` |
| `src/components/pane-card.tsx` | Render `· <command>` next to pane id when `agentType` is null |
| `src/App.tsx` | Default `currentCommand: null` on the synthetic pane built for orphan notifications |

## Performance Notes

No additional process spawns. `#{pane_current_command}` is an existing tmux format variable evaluated in the same `list-panes` call already issued by `list_tmux_panes_grouped`.


