### PR TITLE
chore: add bun install pre-start hook

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,6 @@
+# Worktrunk project config (team-shared)
+# See: https://worktrunk.dev/reference/hook
+
+# Install frontend dependencies when creating a worktree.
+# Bun is required (bun.lock is checked in).
+pre-start = "bun install"


### PR DESCRIPTION
## Summary

- Add `.config/wt.toml` so Worktrunk runs `bun install` as a `pre-start` hook when creating a worktree.
- Keeps `node_modules/` in sync with `bun.lock` automatically — no manual install step after `wt switch --create`.

## Details

- Project-level Worktrunk config (team-shared, checked in).
- Rust-side builds are intentionally left out of `pre-start` to avoid slowing down worktree creation; `cargo make dev` / `build-app` compiles on first run as usual.
- Coexists with the user-level `set-upstream` `pre-start` hook (both fire).

## Test plan

- [ ] `wt switch --create test-bun-install` creates a worktree and `bun install` runs automatically.
- [ ] Resulting worktree has `node_modules/` populated.
- [ ] `cargo make dev` starts without needing a manual `bun install`.
- [ ] Remove the test worktree with `wt remove test-bun-install`.
