### PR TITLE
feat: dismiss notifications via tmux hooks on pane focus

### DIFF
--- a/crates/agentoast-cli/src/lib.rs
+++ b/crates/agentoast-cli/src/lib.rs
@@ -85,6 +85,13 @@ enum Commands {
         limit: i64,
     },
 
+    /// Dismiss all notifications for a given tmux pane
+    Dismiss {
+        /// tmux pane ID (e.g. %5)
+        #[arg(short = 't', long)]
+        tmux_pane: String,
+    },
+
     /// Open config file in editor
     Config,
 }
@@ -123,6 +130,7 @@ pub fn try_run_cli() -> bool {
         "send",
         "hook",
         "list",
+        "dismiss",
         "config",
         "--version",
         "-V",
@@ -239,6 +247,24 @@ fn run(cli: Cli) {
             HookAgent::Copilot { event } => hooks::copilot::handle(&event),
             HookAgent::Opencode { json } => hooks::opencode::handle(&json),
         },
+        // Called by tmux hooks (`after-select-pane` et al.) to clear
+        // notifications when the user navigates to a pane directly. tmux can
+        // hand us an empty pane id in edge cases (hook fires before the pane
+        // is fully selected), so treat empty as a no-op rather than erroring.
+        Commands::Dismiss { tmux_pane } => {
+            if tmux_pane.is_empty() {
+                return;
+            }
+            let db_path = config::db_path();
+            let conn = db::open_reader(&db_path).unwrap_or_else(|e| {
+                eprintln!("Failed to open database: {}", e);
+                std::process::exit(1);
+            });
+            if let Err(e) = db::delete_notifications_by_pane(&conn, &tmux_pane) {
+                eprintln!("Failed to delete notifications: {}", e);
+                std::process::exit(1);
+            }
+        }
         Commands::Config => {
             let config_path = config::ensure_config_file().unwrap_or_else(|e| {
                 eprintln!("Failed to create config file: {}", e);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,8 @@ mod panel;
 mod sessions;
 #[cfg(target_os = "macos")]
 mod terminal;
+#[cfg(target_os = "macos")]
+mod tmux_hooks;
 mod tray;
 mod watcher;
 
@@ -86,6 +88,10 @@ fn refresh_and_emit(app_handle: &tauri::AppHandle) {
     let show_non_agent = read_show_non_agent_panes(app_handle);
     match sessions::list_tmux_panes_grouped(show_non_agent) {
         Ok(groups) => {
+            // Reaching here means the tmux server is alive and responsive —
+            // the right moment to attempt one-shot hook registration (retries
+            // on every refresh until success, idempotent thereafter).
+            tmux_hooks::install();
             if let Some(cache) = app_handle.try_state::<Mutex<SessionsCache>>() {
                 if let Ok(mut guard) = cache.lock() {
                     guard.groups = Some(groups.clone());

--- a/src-tauri/src/sessions/agents/mod.rs
+++ b/src-tauri/src/sessions/agents/mod.rs
@@ -48,57 +48,6 @@ pub(super) fn is_numbered_option(line: &str) -> bool {
     }
 }
 
-/// Lightweight running check: capture a pane and check for universal running signals.
-/// Does NOT require agent_type or process tree — uses patterns common to all agents.
-pub(crate) fn is_pane_agent_running(pane_id: &str) -> bool {
-    let content = match capture_pane(pane_id) {
-        Some(c) => c,
-        None => return false,
-    };
-
-    content
-        .lines()
-        .rev()
-        .filter(|l| !l.trim().is_empty())
-        .take(30)
-        .any(|line| {
-            let trimmed = line.trim();
-            is_universal_running_line(trimmed)
-        })
-}
-
-/// Running signals common across Claude Code, Codex, OpenCode, and Copilot CLI.
-fn is_universal_running_line(line: &str) -> bool {
-    // Claude Code: spinner chars (✢✽✶✳✻·) + "esc to interrupt" or "…"
-    if let Some(c) = line.chars().next() {
-        if ['✢', '✽', '✶', '✳', '✻', '·'].contains(&c)
-            && (line.contains("esc to interrupt") || line.contains('…'))
-        {
-            return true;
-        }
-    }
-    // Copilot CLI: spinner chars (◎○◉●) + "Esc to cancel"
-    if let Some(c) = line.chars().next() {
-        if ['◎', '○', '◉', '●'].contains(&c) && line.contains("Esc to cancel") {
-            return true;
-        }
-    }
-    // Claude Code: "· esc to interrupt" in status line
-    if line.contains("\u{00B7} esc to interrupt") {
-        return true;
-    }
-    // Claude Code: status bar "(running)" suffix
-    if line.ends_with("(running)") {
-        return true;
-    }
-    // Codex: "esc to interrupt" (covered by spinner check above)
-    // OpenCode: "esc interrupt" (without "to")
-    if line.contains("esc interrupt") {
-        return true;
-    }
-    false
-}
-
 /// Detect agent status using pre-captured pane content.
 /// This avoids redundant capture-pane calls when content is already available
 /// (e.g., captured in parallel by the caller).

--- a/src-tauri/src/tmux_hooks.rs
+++ b/src-tauri/src/tmux_hooks.rs
@@ -1,0 +1,96 @@
+//! Installs tmux global hooks that call `agentoast dismiss` so notifications
+//! clear when the user navigates to a pane via tmux directly. Runs lazily on
+//! the first successful session refresh — the tmux server may not be up when
+//! agentoast launches, so we retry until a hook registration attempt succeeds.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::terminal::find_tmux;
+
+static INSTALLED: AtomicBool = AtomicBool::new(false);
+
+// Marker matched against `tmux show-hooks -g` output to detect a prior install
+// and avoid appending duplicate hook entries across app restarts.
+const HOOK_MARKER: &str = "agentoast dismiss";
+
+const HOOK_EVENTS: &[&str] = &[
+    "after-select-pane",
+    "after-select-window",
+    "client-attached",
+];
+
+pub fn install() {
+    if INSTALLED.load(Ordering::Relaxed) {
+        return;
+    }
+
+    let Some(tmux) = find_tmux() else {
+        return;
+    };
+    let Ok(agentoast_bin) = std::env::current_exe() else {
+        log::debug!("tmux_hooks: current_exe unavailable, skipping install");
+        return;
+    };
+
+    let show = match Command::new(&tmux).args(["show-hooks", "-g"]).output() {
+        Ok(o) if o.status.success() => o,
+        _ => {
+            // tmux server not running yet / socket unreachable. Leave
+            // INSTALLED unset so the next refresh attempt retries.
+            return;
+        }
+    };
+    let existing = String::from_utf8_lossy(&show.stdout);
+
+    let bin_str = agentoast_bin.to_string_lossy();
+    if bin_str.contains('\'') {
+        // Path can't be safely single-quoted; mark as installed to stop
+        // retrying indefinitely. User can symlink to a cleaner path.
+        log::warn!(
+            "tmux_hooks: agentoast path contains single quote, skipping install: {}",
+            bin_str
+        );
+        INSTALLED.store(true, Ordering::Relaxed);
+        return;
+    }
+    let payload = format!("run-shell -b '{} dismiss -t \"#{{pane_id}}\"'", bin_str);
+
+    let mut all_ok = true;
+    for event in HOOK_EVENTS {
+        // Per-event idempotency: only skip if THIS specific event already has
+        // an agentoast hook. A whole-output marker check breaks when one
+        // event was wiped (e.g. `set-hook -gu`) but others remain.
+        let prefix = format!("{}[", event);
+        let already = existing
+            .lines()
+            .any(|line| line.starts_with(&prefix) && line.contains(HOOK_MARKER));
+        if already {
+            continue;
+        }
+        match Command::new(&tmux)
+            .args(["set-hook", "-ag", event, &payload])
+            .output()
+        {
+            Ok(o) if o.status.success() => {
+                log::info!("tmux_hooks: installed {} hook", event);
+            }
+            Ok(o) => {
+                log::warn!(
+                    "tmux_hooks: set-hook {} failed: {}",
+                    event,
+                    String::from_utf8_lossy(&o.stderr).trim()
+                );
+                all_ok = false;
+            }
+            Err(e) => {
+                log::warn!("tmux_hooks: set-hook {} spawn failed: {}", event, e);
+                all_ok = false;
+            }
+        }
+    }
+
+    if all_ok {
+        INSTALLED.store(true, Ordering::Relaxed);
+    }
+}

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -131,7 +131,6 @@ pub fn start(app_handle: AppHandle, db_path: PathBuf) {
         loop {
             std::thread::sleep(Duration::from_secs(5));
             check_new_notifications(&handle_for_poll, &conn, "polling");
-            cleanup_running_agent_notifications(&handle_for_poll, &conn);
         }
     });
 }
@@ -351,44 +350,6 @@ fn check_new_notifications(app_handle: &AppHandle, conn: &Connection, source: &s
     if let Ok(count) = db::get_unread_count(conn) {
         let _ = app_handle.emit("notifications:unread-count", count);
         update_tray_icon(app_handle, count);
-    }
-}
-
-/// Auto-delete notifications for panes where the agent has resumed running.
-/// Only runs capture-pane on panes that have pending notifications (no ps/process tree).
-fn cleanup_running_agent_notifications(app_handle: &AppHandle, conn: &Connection) {
-    let pane_ids = match db::get_notified_pane_ids(conn) {
-        Ok(ids) => ids,
-        Err(e) => {
-            log::debug!("cleanup_running: failed to get notified panes: {}", e);
-            return;
-        }
-    };
-    if pane_ids.is_empty() {
-        return;
-    }
-
-    let mut deleted_any = false;
-    for pane_id in &pane_ids {
-        if crate::sessions::agents::is_pane_agent_running(pane_id) {
-            log::info!(
-                "cleanup_running: pane {} is running, deleting notifications",
-                pane_id
-            );
-            if let Err(e) = db::delete_notifications_by_pane(conn, pane_id) {
-                log::error!("cleanup_running: delete failed for {}: {}", pane_id, e);
-            } else {
-                deleted_any = true;
-            }
-        }
-    }
-
-    if deleted_any {
-        if let Ok(count) = db::get_unread_count(conn) {
-            let _ = app_handle.emit("notifications:unread-count", count);
-            update_tray_icon(app_handle, count);
-        }
-        let _ = app_handle.emit("notifications:refresh", ());
     }
 }
 


### PR DESCRIPTION
## Summary

- Clear tmux-pane notifications automatically when the user focuses the pane through tmux, without requiring a click in the agentoast panel
- Drop the 5-second running-spinner polling cleanup; the signal is replaced by tmux hooks which also removes a false-positive case (a teammate agent running in another pane used to wipe unrelated notifications)
- Agentoast installs the required tmux hooks at startup, so no user-side tmux.conf changes are needed

## Details

- **New CLI** `agentoast dismiss --tmux-pane <pane>` — deletes every notification matching the given pane. Empty input is a no-op so hooks that fire before a pane is fully selected cannot wipe the whole table.
- **New module** `src-tauri/src/tmux_hooks.rs` — on each successful session refresh, registers three global hooks that invoke `agentoast dismiss` with `#{pane_id}` expansion:
  - `after-select-pane`, `after-select-window`, `client-attached`
  - Idempotency is per-event (checks `<event>[...]` lines in `tmux show-hooks -g` for the `agentoast dismiss` marker) so wiping one event with `set-hook -gu` does not prevent the others from re-registering.
  - `INSTALLED` only flips to `true` when every event succeeds; otherwise the next refresh retries. If tmux is not running yet, `show-hooks` fails and we simply wait for the next tick.
  - Hook target uses the absolute path from `std::env::current_exe()` so it survives Launch Services launches that do not inherit the shell `PATH`.
  - `run-shell -b` keeps pane switching non-blocking.
- **Removed** `cleanup_running_agent_notifications` and the `is_pane_agent_running` / `is_universal_running_line` helpers. The insert-time `is_pane_visible_to_user` suppression (event-driven) is kept as a complementary path for notifications that arrive while the pane is already active.
