### PR TITLE
feat: onboarding flow, CLI installer, and tmux hook hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-nspanel",
+ "tauri-plugin-autostart",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-opener",
  "tauri-plugin-process",
@@ -317,6 +318,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
 
 [[package]]
 name = "autocfg"
@@ -840,11 +852,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -855,7 +887,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -956,7 +988,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.11+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -3257,6 +3289,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -4091,7 +4134,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4142,7 +4185,7 @@ checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4227,6 +4270,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-global-shortcut"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4280,7 +4337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -4764,7 +4821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -5634,6 +5691,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -5664,7 +5730,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dpi",
  "dunce",
  "gdkx11",

--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -23,6 +23,25 @@ pub fn db_path() -> PathBuf {
     data_dir().join("notifications.db")
 }
 
+/// Marker file written when onboarding has been completed.
+pub fn onboarded_marker_path() -> PathBuf {
+    data_dir().join(".onboarded")
+}
+
+/// Whether the user has completed the onboarding flow.
+pub fn is_onboarded() -> bool {
+    onboarded_marker_path().exists()
+}
+
+/// Persist the "onboarding complete" flag by creating the marker file.
+pub fn mark_onboarded() -> io::Result<()> {
+    let path = onboarded_marker_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&path, b"")
+}
+
 /// Return XDG_CONFIG_HOME/agentoast.
 pub fn config_dir() -> PathBuf {
     if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {

--- a/cspell.json
+++ b/cspell.json
@@ -17,6 +17,7 @@
   "words": [
     "agentoast",
     "appdir",
+    "autolaunch",
     "Backquote",
     "bezeled",
     "cdylib",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ tauri-plugin-opener = "2.5.3"
 tauri-plugin-global-shortcut = "2.3.1"
 tauri-plugin-updater = "2.10.1"
 tauri-plugin-process = "2.3.1"
+tauri-plugin-autostart = "2.5.0"
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
 log = "0.4.29"
 fern = "0.7.1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main", "settings"],
+  "windows": ["main", "settings", "onboarding"],
   "permissions": [
     "core:default",
     "core:tray:default",
@@ -11,9 +11,11 @@
     "core:window:allow-outer-size",
     "core:window:allow-inner-size",
     "core:window:allow-scale-factor",
+    "core:window:allow-start-dragging",
     "opener:default",
     "global-shortcut:default",
     "updater:default",
-    "process:allow-restart"
+    "process:allow-restart",
+    "autostart:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,7 +24,11 @@ use agentoast_shared::db;
 use agentoast_shared::models::{Notification, TmuxPaneGroup};
 use serde::{Deserialize, Serialize};
 use tauri::{Emitter, Manager};
+use tauri_plugin_autostart::ManagerExt as AutostartManagerExt;
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
+use tauri_plugin_opener::OpenerExt;
+
+const README_BASE: &str = "https://github.com/shuntaka9576/agentoast";
 
 #[cfg(target_os = "macos")]
 const FALLBACK_POLL_INTERVAL: Duration = Duration::from_secs(2);
@@ -224,6 +228,21 @@ pub fn apply_toggle_panel_shortcut(
     Ok(())
 }
 
+/// Switch the macOS Dock presence on the fly. Used to bring agentoast forward
+/// during onboarding (so the user can find it via Dock / Cmd+Tab) and then
+/// hide it again once onboarding is complete to keep the menu-bar-only feel.
+#[cfg(target_os = "macos")]
+fn set_dock_visible(app_handle: &tauri::AppHandle, visible: bool) {
+    let policy = if visible {
+        tauri::ActivationPolicy::Regular
+    } else {
+        tauri::ActivationPolicy::Accessory
+    };
+    if let Err(e) = app_handle.set_activation_policy(policy) {
+        log::warn!("Failed to set activation policy: {}", e);
+    }
+}
+
 pub fn do_toggle_global_mute(app_handle: &tauri::AppHandle) -> Result<MuteStatePayload, String> {
     let mute_state = app_handle.state::<Mutex<MuteState>>();
     let mut state = mute_state.lock().map_err(|e| e.to_string())?;
@@ -263,7 +282,12 @@ fn show_panel(app_handle: tauri::AppHandle) {
         let _ = app_handle.emit("panel:shown", ());
         emit_cached_sessions(&app_handle);
         let _ = app_handle.emit("notifications:refresh", ());
-        panel.show();
+        // Re-anchor at the tray icon every show so the panel never opens at
+        // its last position (e.g. screen center on a fresh launch).
+        panel.set_alpha_value(0.0);
+        panel.show_and_make_key();
+        panel::position_panel_for_shortcut(&app_handle);
+        panel.set_alpha_value(1.0);
     }
 }
 
@@ -489,6 +513,7 @@ pub struct SettingsPayload {
     pub toast_persistent: bool,
     pub toggle_panel_shortcut: String,
     pub editor: String,
+    pub autostart_enabled: bool,
 }
 
 #[derive(Clone, Serialize)]
@@ -498,13 +523,18 @@ pub struct SaveSettingsResult {
 }
 
 #[tauri::command]
-fn get_settings(state: tauri::State<'_, Mutex<AppState>>) -> Result<SettingsPayload, String> {
+fn get_settings(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, Mutex<AppState>>,
+) -> Result<SettingsPayload, String> {
     let state = state.lock().map_err(|e| e.to_string())?;
+    let autostart_enabled = app_handle.autolaunch().is_enabled().unwrap_or(false);
     Ok(SettingsPayload {
         toast_duration_ms: state.config.toast.duration_ms,
         toast_persistent: state.config.toast.persistent,
         toggle_panel_shortcut: state.config.keybinding.toggle_panel.clone(),
         editor: state.config.editor.clone().unwrap_or_default(),
+        autostart_enabled,
     })
 }
 
@@ -633,6 +663,21 @@ fn save_settings(
     #[cfg(target_os = "macos")]
     native_toast::update_settings(payload.toast_duration_ms, payload.toast_persistent);
 
+    // --- Phase 5: autostart (LaunchAgent). Not mirrored in config.toml, so a
+    // failure here is surfaced but does not need a toml rollback. ---
+    let old_autostart = app_handle.autolaunch().is_enabled().unwrap_or(false);
+    if old_autostart != payload.autostart_enabled {
+        let manager = app_handle.autolaunch();
+        let result = if payload.autostart_enabled {
+            manager.enable()
+        } else {
+            manager.disable()
+        };
+        if let Err(e) = result {
+            return Err(format!("Failed to update autostart: {}", e));
+        }
+    }
+
     Ok(SaveSettingsResult {
         restart_required: false,
     })
@@ -672,6 +717,166 @@ fn get_reserved_shortcuts() -> Vec<String> {
     {
         Vec::new()
     }
+}
+
+#[tauri::command]
+fn open_hook_readme(app_handle: tauri::AppHandle, agent: String) -> Result<(), String> {
+    let anchor = match agent.as_str() {
+        "claude-code" => "#claude-code",
+        "codex" => "#codex",
+        "copilot-cli" => "#copilot-cli",
+        "opencode" => "#opencode",
+        other => return Err(format!("unknown agent: {}", other)),
+    };
+    app_handle
+        .opener()
+        .open_url(format!("{}{}", README_BASE, anchor), None::<&str>)
+        .map_err(|e| e.to_string())
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CliInstallStatus {
+    installed: bool,
+    points_to_current_exe: bool,
+    on_path: bool,
+    target_path: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CliInstallResult {
+    target_path: String,
+    on_path: bool,
+    replaced_existing: bool,
+}
+
+fn cli_symlink_target() -> Result<std::path::PathBuf, String> {
+    let home = std::env::var("HOME").map_err(|_| "HOME not set".to_string())?;
+    Ok(std::path::PathBuf::from(home).join(".local/bin/agentoast"))
+}
+
+fn local_bin_on_path() -> bool {
+    let Ok(home) = std::env::var("HOME") else {
+        return false;
+    };
+    let local_bin = std::path::PathBuf::from(&home).join(".local/bin");
+    let canonical_local_bin = std::fs::canonicalize(&local_bin).ok();
+    let path = std::env::var("PATH").unwrap_or_default();
+    path.split(':').filter(|s| !s.is_empty()).any(|entry| {
+        let expanded = if let Some(stripped) = entry.strip_prefix("~/") {
+            std::path::PathBuf::from(&home).join(stripped)
+        } else if entry == "~" {
+            std::path::PathBuf::from(&home)
+        } else {
+            std::path::PathBuf::from(entry)
+        };
+        if expanded == local_bin {
+            return true;
+        }
+        match (
+            std::fs::canonicalize(&expanded).ok(),
+            canonical_local_bin.as_ref(),
+        ) {
+            (Some(a), Some(b)) => &a == b,
+            _ => false,
+        }
+    })
+}
+
+fn read_symlink_target(path: &std::path::Path) -> Option<std::path::PathBuf> {
+    let target = std::fs::read_link(path).ok()?;
+    if target.is_absolute() {
+        Some(target)
+    } else {
+        path.parent().map(|p| p.join(&target))
+    }
+}
+
+#[tauri::command]
+fn get_cli_install_status() -> Result<CliInstallStatus, String> {
+    let target = cli_symlink_target()?;
+    let target_str = target.to_string_lossy().to_string();
+    let symlink_meta = target.symlink_metadata();
+    let installed = symlink_meta.is_ok();
+
+    let points_to_current_exe = match (
+        symlink_meta
+            .as_ref()
+            .ok()
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false),
+        std::env::current_exe().ok(),
+    ) {
+        (true, Some(current_exe)) => match (
+            read_symlink_target(&target).and_then(|p| std::fs::canonicalize(p).ok()),
+            std::fs::canonicalize(&current_exe).ok(),
+        ) {
+            (Some(a), Some(b)) => a == b,
+            _ => false,
+        },
+        _ => false,
+    };
+
+    Ok(CliInstallStatus {
+        installed,
+        points_to_current_exe,
+        on_path: local_bin_on_path(),
+        target_path: target_str,
+    })
+}
+
+#[tauri::command]
+fn install_cli_symlink() -> Result<CliInstallResult, String> {
+    #[cfg(not(unix))]
+    {
+        return Err("CLI symlink installation is only supported on Unix platforms".to_string());
+    }
+    #[cfg(unix)]
+    {
+        let current_exe = std::env::current_exe().map_err(|e| format!("current_exe: {}", e))?;
+        let target = cli_symlink_target()?;
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("create_dir_all {}: {}", parent.display(), e))?;
+        }
+
+        let mut replaced_existing = false;
+        if let Ok(meta) = target.symlink_metadata() {
+            if meta.file_type().is_symlink() {
+                std::fs::remove_file(&target)
+                    .map_err(|e| format!("remove existing symlink: {}", e))?;
+                replaced_existing = true;
+            } else {
+                return Err(format!(
+                    "{} already exists and is not a symlink. Remove it manually before retrying.",
+                    target.display()
+                ));
+            }
+        }
+
+        std::os::unix::fs::symlink(&current_exe, &target)
+            .map_err(|e| format!("create symlink: {}", e))?;
+
+        Ok(CliInstallResult {
+            target_path: target.to_string_lossy().to_string(),
+            on_path: local_bin_on_path(),
+            replaced_existing,
+        })
+    }
+}
+
+#[tauri::command]
+fn complete_onboarding(app_handle: tauri::AppHandle) -> Result<(), String> {
+    if let Err(e) = config::mark_onboarded() {
+        log::warn!("Failed to write onboarded marker: {}", e);
+    }
+    if let Some(window) = app_handle.get_webview_window("onboarding") {
+        let _ = window.hide();
+    }
+    #[cfg(target_os = "macos")]
+    set_dock_visible(&app_handle, false);
+    Ok(())
 }
 
 #[tauri::command]
@@ -728,6 +933,10 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_nspanel::init())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            None,
+        ))
         .invoke_handler(tauri::generate_handler![
             init_panel,
             hide_panel,
@@ -755,10 +964,24 @@ pub fn run() {
             hide_settings,
             restart_app,
             get_reserved_shortcuts,
+            complete_onboarding,
+            open_hook_readme,
+            get_cli_install_status,
+            install_cli_symlink,
         ])
         .setup(|app| {
             #[cfg(target_os = "macos")]
-            app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+            {
+                // Default to menu-bar-only (Accessory). If onboarding is still
+                // pending we promote to Regular so the Welcome window shows up
+                // in the Dock / Cmd+Tab; complete_onboarding flips it back.
+                let policy = if config::is_onboarded() {
+                    tauri::ActivationPolicy::Accessory
+                } else {
+                    tauri::ActivationPolicy::Regular
+                };
+                app.set_activation_policy(policy);
+            }
 
             #[cfg(target_os = "macos")]
             {
@@ -823,6 +1046,29 @@ pub fn run() {
                         let _ = window_clone.hide();
                     }
                 });
+            }
+
+            // Show the onboarding window on first launch. Treat the close button
+            // as a "complete onboarding" gesture so users aren't shown the flow
+            // again next launch.
+            if let Some(onboarding_window) = app.handle().get_webview_window("onboarding") {
+                let window_clone = onboarding_window.clone();
+                onboarding_window.on_window_event(move |event| {
+                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                        api.prevent_close();
+                        if let Err(e) = config::mark_onboarded() {
+                            log::warn!("Failed to write onboarded marker on close: {}", e);
+                        }
+                        let _ = window_clone.hide();
+                        #[cfg(target_os = "macos")]
+                        set_dock_visible(window_clone.app_handle(), false);
+                    }
+                });
+
+                if !config::is_onboarded() {
+                    let _ = onboarding_window.show();
+                    let _ = onboarding_window.set_focus();
+                }
             }
 
             // Initialize native toast panel

--- a/src-tauri/src/tmux_hooks.rs
+++ b/src-tauri/src/tmux_hooks.rs
@@ -2,6 +2,16 @@
 //! clear when the user navigates to a pane via tmux directly. Runs lazily on
 //! the first successful session refresh — the tmux server may not be up when
 //! agentoast launches, so we retry until a hook registration attempt succeeds.
+//!
+//! Self-healing: if the user moves or replaces `Agentoast.app`, an old hook
+//! pointing at the previous binary path stays registered with the tmux server
+//! and produces `exit 127` on every pane switch. On install we detect such
+//! stale entries (path differs from the current binary) and remove them via
+//! `set-hook -gu '<event>[<idx>]'`. The hook payload also wraps the call in
+//! `[ -x "<bin>" ] && ... || true` so a stale path or a transient dismiss
+//! failure (SQLite WAL contention with the running app) silently no-ops
+//! instead of producing `'... dismiss -t ...' returned N` lines in the tmux
+//! status bar. dismiss is best-effort, so swallowing exit codes here is safe.
 
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -10,8 +20,6 @@ use crate::terminal::find_tmux;
 
 static INSTALLED: AtomicBool = AtomicBool::new(false);
 
-// Marker matched against `tmux show-hooks -g` output to detect a prior install
-// and avoid appending duplicate hook entries across app restarts.
 const HOOK_MARKER: &str = "agentoast dismiss";
 
 const HOOK_EVENTS: &[&str] = &[
@@ -33,6 +41,18 @@ pub fn install() {
         return;
     };
 
+    let bin_str = agentoast_bin.to_string_lossy().to_string();
+    if bin_str.contains('\'') || bin_str.contains('"') {
+        // Path can't be safely shell-quoted; mark as installed to stop
+        // retrying indefinitely. User can symlink to a cleaner path.
+        log::warn!(
+            "tmux_hooks: agentoast path contains quote chars, skipping install: {}",
+            bin_str
+        );
+        INSTALLED.store(true, Ordering::Relaxed);
+        return;
+    }
+
     let show = match Command::new(&tmux).args(["show-hooks", "-g"]).output() {
         Ok(o) if o.status.success() => o,
         _ => {
@@ -43,29 +63,73 @@ pub fn install() {
     };
     let existing = String::from_utf8_lossy(&show.stdout);
 
-    let bin_str = agentoast_bin.to_string_lossy();
-    if bin_str.contains('\'') {
-        // Path can't be safely single-quoted; mark as installed to stop
-        // retrying indefinitely. User can symlink to a cleaner path.
-        log::warn!(
-            "tmux_hooks: agentoast path contains single quote, skipping install: {}",
-            bin_str
-        );
-        INSTALLED.store(true, Ordering::Relaxed);
-        return;
+    // First pass: collect stale entries (matching marker but pointing at a
+    // different binary path) and detect events that already have a correct
+    // hook so we can skip the re-add.
+    let mut stale: Vec<(String, u32)> = Vec::new(); // (event, idx) to unset
+    let mut already_correct: std::collections::HashSet<&'static str> =
+        std::collections::HashSet::new();
+
+    for line in existing.lines() {
+        if !line.contains(HOOK_MARKER) {
+            continue;
+        }
+        let Some(parsed) = parse_hook_line(line, HOOK_EVENTS) else {
+            continue;
+        };
+        if parsed.bin == bin_str && parsed.has_or_true {
+            already_correct.insert(parsed.event);
+        } else {
+            log::info!(
+                "tmux_hooks: stale {}[{}] -> {} (current: {}, has_or_true: {})",
+                parsed.event,
+                parsed.idx,
+                parsed.bin,
+                bin_str,
+                parsed.has_or_true,
+            );
+            stale.push((parsed.event.to_string(), parsed.idx));
+        }
     }
-    let payload = format!("run-shell -b '{} dismiss -t \"#{{pane_id}}\"'", bin_str);
+
+    // Remove stale entries highest-index-first per event so the indices of
+    // the remaining hooks don't shift under us.
+    stale.sort_by(|a, b| a.0.cmp(&b.0).then(b.1.cmp(&a.1)));
+    for (event, idx) in &stale {
+        let target = format!("{}[{}]", event, idx);
+        match Command::new(&tmux)
+            .args(["set-hook", "-gu", &target])
+            .output()
+        {
+            Ok(o) if o.status.success() => {
+                log::info!("tmux_hooks: removed stale {}", target);
+            }
+            Ok(o) => {
+                log::warn!(
+                    "tmux_hooks: unset {} failed: {}",
+                    target,
+                    String::from_utf8_lossy(&o.stderr).trim()
+                );
+            }
+            Err(e) => {
+                log::warn!("tmux_hooks: unset {} spawn failed: {}", target, e);
+            }
+        }
+    }
+
+    // Self-healing payload: if the bin disappears (uninstall, .app moved),
+    // the `[ -x ... ]` test fails and the `|| true` tail keeps the overall
+    // exit at 0 so tmux doesn't print `... returned 1` in the status bar.
+    // Same suppression covers transient dismiss failures (e.g. SQLITE_BUSY
+    // when the app's watcher holds a reader).
+    let payload = format!(
+        "run-shell -b '[ -x \"{0}\" ] && \"{0}\" dismiss -t \"#{{pane_id}}\" || true'",
+        bin_str
+    );
 
     let mut all_ok = true;
     for event in HOOK_EVENTS {
-        // Per-event idempotency: only skip if THIS specific event already has
-        // an agentoast hook. A whole-output marker check breaks when one
-        // event was wiped (e.g. `set-hook -gu`) but others remain.
-        let prefix = format!("{}[", event);
-        let already = existing
-            .lines()
-            .any(|line| line.starts_with(&prefix) && line.contains(HOOK_MARKER));
-        if already {
+        if already_correct.contains(event) {
             continue;
         }
         match Command::new(&tmux)
@@ -92,5 +156,104 @@ pub fn install() {
 
     if all_ok {
         INSTALLED.store(true, Ordering::Relaxed);
+    }
+}
+
+struct ParsedHook {
+    event: &'static str,
+    idx: u32,
+    bin: String,
+    has_or_true: bool,
+}
+
+/// Parse a single `tmux show-hooks -g` line that looks like an `agentoast
+/// dismiss` invocation. Returns `None` if the line doesn't target one of the
+/// given events or can't be parsed.
+///
+/// Handles three payload shapes (oldest first):
+///   v1: `run-shell -b "<bin> dismiss -t ..."`
+///   v2: `run-shell -b "[ -x \"<bin>\" ] && \"<bin>\" dismiss -t ..."`
+///   v3: `run-shell -b "[ -x \"<bin>\" ] && \"<bin>\" dismiss -t ... || true"`
+///
+/// `has_or_true` is true only for v3. v1/v2 are flagged so the caller can
+/// re-install with the current payload format.
+fn parse_hook_line(line: &str, events: &[&'static str]) -> Option<ParsedHook> {
+    let event = events
+        .iter()
+        .copied()
+        .find(|e| line.starts_with(&format!("{}[", e)))?;
+    let after_event = &line[event.len() + 1..]; // skip `<event>[`
+    let bracket_end = after_event.find(']')?;
+    let idx: u32 = after_event[..bracket_end].parse().ok()?;
+
+    // Bin path lives just before " dismiss". In v2/v3 it is the second
+    // occurrence of \" ... \"; in v1 the path is bare between `-b "` and
+    // ` dismiss`.
+    let dismiss_idx = line.find(" dismiss")?;
+    let prefix = &line[..dismiss_idx];
+    let bin = if let Some(trimmed) = prefix.strip_suffix("\\\"") {
+        let start = trimmed.rfind("\\\"")?;
+        trimmed[start + 2..].to_string()
+    } else {
+        let payload_start = prefix.rfind("-b \"")?;
+        prefix[payload_start + "-b \"".len()..].to_string()
+    };
+
+    // v3 marker: trailing ` || true` inside the run-shell payload. tmux
+    // doesn't escape `|` or whitespace so a substring check is sufficient.
+    let has_or_true = line[dismiss_idx..].contains("|| true");
+
+    Some(ParsedHook {
+        event,
+        idx,
+        bin,
+        has_or_true,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EVENTS: &[&str] = &[
+        "after-select-pane",
+        "after-select-window",
+        "client-attached",
+    ];
+
+    #[test]
+    fn parses_v1_bare_bin_payload() {
+        let line = "after-select-pane[0] run-shell -b \"/old/path/agentoast dismiss -t \\\"#{pane_id}\\\"\"";
+        let p = parse_hook_line(line, EVENTS).expect("parse");
+        assert_eq!(p.event, "after-select-pane");
+        assert_eq!(p.idx, 0);
+        assert_eq!(p.bin, "/old/path/agentoast");
+        assert!(!p.has_or_true);
+    }
+
+    #[test]
+    fn parses_v2_existence_check_without_or_true() {
+        let line = "client-attached[2] run-shell -b \"[ -x \\\"/new/path/agentoast\\\" ] && \\\"/new/path/agentoast\\\" dismiss -t \\\"#{pane_id}\\\"\"";
+        let p = parse_hook_line(line, EVENTS).expect("parse");
+        assert_eq!(p.event, "client-attached");
+        assert_eq!(p.idx, 2);
+        assert_eq!(p.bin, "/new/path/agentoast");
+        assert!(!p.has_or_true);
+    }
+
+    #[test]
+    fn parses_v3_existence_check_with_or_true() {
+        let line = "after-select-window[1] run-shell -b \"[ -x \\\"/p/agentoast\\\" ] && \\\"/p/agentoast\\\" dismiss -t \\\"#{pane_id}\\\" || true\"";
+        let p = parse_hook_line(line, EVENTS).expect("parse");
+        assert_eq!(p.event, "after-select-window");
+        assert_eq!(p.idx, 1);
+        assert_eq!(p.bin, "/p/agentoast");
+        assert!(p.has_or_true);
+    }
+
+    #[test]
+    fn ignores_unrelated_events() {
+        let line = "after-bind-key[0] run-shell -b \"/x/agentoast dismiss -t \\\"#{pane_id}\\\"\"";
+        assert!(parse_hook_line(line, EVENTS).is_none());
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,6 +32,18 @@
         "transparent": false,
         "visible": false,
         "center": true
+      },
+      {
+        "label": "onboarding",
+        "title": "Agentoast",
+        "url": "index.html?window=onboarding",
+        "width": 480,
+        "height": 620,
+        "resizable": false,
+        "decorations": false,
+        "transparent": true,
+        "visible": false,
+        "center": true
       }
     ],
     "security": {

--- a/src/OnboardingApp.tsx
+++ b/src/OnboardingApp.tsx
@@ -1,0 +1,347 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { ArrowRight } from "lucide-react";
+import { IconPreset } from "@/components/icons/source-icon";
+import { ShortcutRecorder } from "@/components/shortcut-recorder";
+import { Toggle } from "@/components/toggle";
+import type { Icon } from "@/lib/types";
+import type { CliInstallStatus, SettingsPayload } from "@/lib/settings-types";
+
+type Step = 0 | 1 | 2;
+
+interface AgentEntry {
+  id: string;
+  label: string;
+  icon: Icon;
+}
+
+const AGENTS: AgentEntry[] = [
+  { id: "claude-code", label: "Claude Code", icon: "claude-code" },
+  { id: "codex", label: "Codex", icon: "codex" },
+  { id: "copilot-cli", label: "Copilot CLI", icon: "copilot-cli" },
+  { id: "opencode", label: "opencode", icon: "opencode" },
+];
+
+export function OnboardingApp() {
+  const [step, setStep] = useState<Step>(0);
+  const [shortcut, setShortcut] = useState<string>("");
+  const [autostart, setAutostart] = useState<boolean>(false);
+  const [reservedShortcuts, setReservedShortcuts] = useState<string[]>([]);
+  const [installCli, setInstallCli] = useState<boolean>(true);
+  const [cliStatus, setCliStatus] = useState<CliInstallStatus | null>(null);
+  const [saving, setSaving] = useState(false);
+  // Block "Get Started" until initial state is fetched. Without this, a user
+  // can finish before `shortcut` is hydrated, persisting an empty string and
+  // wiping their existing shortcut.
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    Promise.all([
+      invoke<SettingsPayload>("get_settings").then((payload) => {
+        setShortcut(payload.togglePanelShortcut);
+        setAutostart(payload.autostartEnabled);
+      }),
+      invoke<string[]>("get_reserved_shortcuts").then((list) => {
+        setReservedShortcuts(list);
+      }),
+      invoke<CliInstallStatus>("get_cli_install_status").then((status) => {
+        setCliStatus(status);
+      }),
+    ])
+      .catch((err) => console.warn("Onboarding hydrate failed:", err))
+      .finally(() => setHydrated(true));
+  }, []);
+
+  // `cli` lets Skip force CLI install off without waiting for setState to
+  // settle (avoids a stale-state race when calling finish from Skip handler).
+  const finish = async (cli: boolean) => {
+    if (saving || !hydrated) return;
+    setSaving(true);
+    try {
+      const current = await invoke<SettingsPayload>("get_settings");
+      await invoke("save_settings", {
+        payload: {
+          ...current,
+          togglePanelShortcut: shortcut,
+          autostartEnabled: autostart,
+        },
+      });
+      if (cli && !cliStatus?.pointsToCurrentExe) {
+        try {
+          await invoke("install_cli_symlink");
+        } catch (cliErr) {
+          // Non-fatal: GUI works without CLI on PATH. Log so users can debug
+          // via the Settings → "Install CLI" button later.
+          console.warn("Failed to install CLI symlink:", cliErr);
+        }
+      }
+      await invoke("complete_onboarding");
+      // Reveal the main panel right after the onboarding window hides so the
+      // user notices where agentoast lives in the menu bar.
+      await invoke("show_panel");
+    } catch (err) {
+      console.error("Failed to complete onboarding:", err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const busy = !hydrated || saving;
+
+  return (
+    <div className="flex h-screen flex-col overflow-hidden rounded-2xl border border-[var(--border-primary)] bg-[var(--panel-bg)] text-[var(--text-primary)] shadow-2xl">
+      <div data-tauri-drag-region className="h-8 shrink-0" />
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {step === 0 && <WelcomeStep onContinue={() => setStep(1)} />}
+        {step === 1 && (
+          <ShortcutStep
+            shortcut={shortcut}
+            onShortcutChange={setShortcut}
+            reservedShortcuts={reservedShortcuts}
+            autostart={autostart}
+            onAutostartChange={setAutostart}
+            onContinue={() => setStep(2)}
+            disabled={busy}
+          />
+        )}
+        {step === 2 && (
+          <HooksStep
+            installCli={installCli}
+            onInstallCliChange={setInstallCli}
+            cliStatus={cliStatus}
+            onSkip={() => {
+              void finish(false);
+            }}
+            onFinish={() => {
+              void finish(installCli);
+            }}
+            disabled={busy}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function WelcomeStep({ onContinue }: { onContinue: () => void }) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-6 px-8 text-center">
+      <div className="flex h-24 w-24 items-center justify-center rounded-3xl bg-[var(--accent)] text-white shadow-md">
+        <IconPreset icon="agentoast" size={64} className="text-white" />
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <h1 className="text-3xl font-bold tracking-tight">agentoast</h1>
+        <p className="max-w-xs text-sm text-[var(--text-tertiary)]">
+          Manage notifications from your AI coding agents right in the menu bar.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onContinue}
+        className="mt-2 inline-flex h-11 items-center gap-2 rounded-full bg-[var(--accent)] px-12 text-sm font-medium text-white shadow-sm transition-colors hover:bg-[var(--accent-hover)]"
+      >
+        Get Started
+        <ArrowRight size={16} />
+      </button>
+    </div>
+  );
+}
+
+interface ShortcutStepProps {
+  shortcut: string;
+  onShortcutChange: (value: string) => void;
+  reservedShortcuts: string[];
+  autostart: boolean;
+  onAutostartChange: (value: boolean) => void;
+  onContinue: () => void;
+  disabled: boolean;
+}
+
+function ShortcutStep({
+  shortcut,
+  onShortcutChange,
+  reservedShortcuts,
+  autostart,
+  onAutostartChange,
+  onContinue,
+  disabled,
+}: ShortcutStepProps) {
+  return (
+    <div className="flex h-full flex-col px-6 pt-3 pb-6">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-xl font-bold">Set up your shortcut</h1>
+        <p className="text-sm text-[var(--text-tertiary)]">
+          Pick a keyboard shortcut to quickly open the panel from the menu bar.
+        </p>
+      </div>
+
+      <div className="mt-6 flex flex-col items-center gap-3 rounded-2xl bg-[var(--hover-bg)] px-6 py-8">
+        <ShortcutRecorder
+          value={shortcut}
+          onChange={onShortcutChange}
+          reservedShortcuts={reservedShortcuts}
+          variant="large"
+        />
+        <p className="text-xs text-[var(--text-tertiary)]">
+          You can change this anytime in Settings
+        </p>
+      </div>
+
+      <div className="mt-auto flex items-center justify-between gap-3 pt-6">
+        <div className="flex items-center gap-2">
+          <Toggle checked={autostart} onChange={onAutostartChange} ariaLabel="Launch at login" />
+          <span className="text-sm text-[var(--text-primary)]">Launch at login</span>
+          <span className="rounded-full bg-[rgba(59,130,246,0.15)] px-2 py-0.5 text-[10px] font-medium text-[#3b82f6]">
+            Recommended
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onContinue}
+          disabled={disabled}
+          className="inline-flex h-10 items-center gap-1.5 rounded-full bg-[var(--text-primary)] px-6 text-sm font-medium text-[var(--panel-bg)] shadow-sm transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          Continue
+          <ArrowRight size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface HooksStepProps {
+  installCli: boolean;
+  onInstallCliChange: (value: boolean) => void;
+  cliStatus: CliInstallStatus | null;
+  onSkip: () => void;
+  onFinish: () => void;
+  disabled: boolean;
+}
+
+function HooksStep({
+  installCli,
+  onInstallCliChange,
+  cliStatus,
+  onSkip,
+  onFinish,
+  disabled,
+}: HooksStepProps) {
+  const showPathWarning = installCli && cliStatus !== null && !cliStatus.onPath;
+
+  return (
+    <div className="flex h-full flex-col px-6 pt-3 pb-6">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-xl font-bold">Enable notifications</h1>
+        <p className="text-sm text-[var(--text-tertiary)]">
+          Connect your AI coding agent so it can send notifications to agentoast. You can skip this
+          and set it up later.
+        </p>
+      </div>
+
+      <div className="mt-5 flex flex-col gap-2 rounded-xl border border-[var(--border-subtle)] p-4">
+        <div className="flex items-start gap-3">
+          <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[var(--accent)] text-[10px] font-bold text-white">
+            1
+          </span>
+          <div className="flex flex-1 flex-col gap-2">
+            <div className="flex flex-col gap-0.5">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-semibold text-[var(--text-primary)]">
+                  Install <code className="font-mono text-xs">agentoast</code> CLI
+                </span>
+                {cliStatus?.pointsToCurrentExe ? (
+                  <span className="rounded-full bg-[rgba(34,197,94,0.15)] px-2 py-0.5 text-[10px] font-medium text-[#22c55e]">
+                    Already installed
+                  </span>
+                ) : (
+                  <span className="rounded-full bg-[rgba(239,68,68,0.15)] px-2 py-0.5 text-[10px] font-medium text-[var(--delete-hover-text)]">
+                    Required for hooks
+                  </span>
+                )}
+              </div>
+              <span className="text-[11px] text-[var(--text-tertiary)]">
+                Hook scripts call <code className="font-mono">agentoast hook</code>, so the CLI must
+                be on your <code className="font-mono">PATH</code>.
+              </span>
+            </div>
+            {!cliStatus?.pointsToCurrentExe && (
+              <div className="flex items-center gap-2">
+                <Toggle
+                  checked={installCli}
+                  onChange={onInstallCliChange}
+                  ariaLabel="Install CLI symlink"
+                />
+                <span className="text-[12px] text-[var(--text-secondary)]">
+                  Symlink to <code className="font-mono text-[11px]">~/.local/bin/agentoast</code>
+                </span>
+              </div>
+            )}
+            {showPathWarning && (
+              <p className="rounded-md bg-[var(--hover-bg)] px-3 py-2 text-[11px] leading-relaxed text-[var(--text-tertiary)]">
+                <span className="text-[var(--text-secondary)]">
+                  ⚠ <code className="font-mono">~/.local/bin</code> is not in your{" "}
+                  <code className="font-mono">PATH</code>.
+                </span>{" "}
+                Add <code className="font-mono">{`export PATH="$HOME/.local/bin:$PATH"`}</code> to
+                your shell rc.
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-col gap-2 rounded-xl border border-[var(--border-subtle)] p-4">
+        <div className="flex items-start gap-3">
+          <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[var(--accent)] text-[10px] font-bold text-white">
+            2
+          </span>
+          <div className="flex flex-1 flex-col gap-2">
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm font-semibold text-[var(--text-primary)]">
+                Configure your agent
+              </span>
+              <span className="text-[11px] text-[var(--text-tertiary)]">
+                Open the README for the agent you use and follow the hook setup steps.
+              </span>
+            </div>
+            <div className="grid grid-cols-4 gap-2">
+              {AGENTS.map((a) => (
+                <button
+                  key={a.id}
+                  type="button"
+                  onClick={() => {
+                    void invoke("open_hook_readme", { agent: a.id });
+                  }}
+                  className="flex flex-col items-center gap-1.5 rounded-xl border border-[var(--border-subtle)] bg-[var(--panel-bg)] py-3 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--hover-bg)] hover:text-[var(--text-primary)]"
+                >
+                  <IconPreset icon={a.icon} size={22} className="text-[var(--text-primary)]" />
+                  {a.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-auto flex items-center justify-between gap-3 pt-6">
+        <button
+          type="button"
+          onClick={onSkip}
+          disabled={disabled}
+          className="rounded-full px-4 py-2 text-sm text-[var(--text-secondary)] transition-colors hover:bg-[var(--hover-bg)] hover:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          Skip
+        </button>
+        <button
+          type="button"
+          onClick={onFinish}
+          disabled={disabled}
+          className="inline-flex h-10 items-center gap-1.5 rounded-full bg-[var(--text-primary)] px-6 text-sm font-medium text-[var(--panel-bg)] shadow-sm transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          Finish
+          <ArrowRight size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/SettingsApp.tsx
+++ b/src/SettingsApp.tsx
@@ -5,7 +5,12 @@ import { RestartBanner } from "@/components/restart-banner";
 import { SettingsRow, SettingsSection } from "@/components/settings-section";
 import { ShortcutRecorder } from "@/components/shortcut-recorder";
 import { Toggle } from "@/components/toggle";
-import type { SaveSettingsResult, SettingsPayload } from "@/lib/settings-types";
+import type {
+  CliInstallResult,
+  CliInstallStatus,
+  SaveSettingsResult,
+  SettingsPayload,
+} from "@/lib/settings-types";
 import { RESTART_REQUIRED_FIELDS } from "@/lib/settings-types";
 
 type Status = { kind: "loading" } | { kind: "error"; message: string } | { kind: "ready" };
@@ -16,6 +21,12 @@ type SaveState =
   | { kind: "saved"; restartRequired: boolean }
   | { kind: "error"; message: string };
 
+type CliInstallState =
+  | { kind: "idle" }
+  | { kind: "installing" }
+  | { kind: "installed"; replaced: boolean }
+  | { kind: "error"; message: string };
+
 const MIN_TOAST_DURATION_MS = 500;
 
 export function SettingsApp() {
@@ -24,6 +35,16 @@ export function SettingsApp() {
   const [draft, setDraft] = useState<SettingsPayload | null>(null);
   const [saveState, setSaveState] = useState<SaveState>({ kind: "idle" });
   const [reservedShortcuts, setReservedShortcuts] = useState<string[]>([]);
+  const [cliStatus, setCliStatus] = useState<CliInstallStatus | null>(null);
+  const [cliInstallState, setCliInstallState] = useState<CliInstallState>({ kind: "idle" });
+
+  const refreshCliStatus = useCallback(() => {
+    invoke<CliInstallStatus>("get_cli_install_status")
+      .then(setCliStatus)
+      .catch((err) => {
+        console.warn("get_cli_install_status failed:", err);
+      });
+  }, []);
 
   useEffect(() => {
     invoke<SettingsPayload>("get_settings")
@@ -41,7 +62,20 @@ export function SettingsApp() {
       .catch((err) => {
         console.warn("get_reserved_shortcuts failed:", err);
       });
-  }, []);
+
+    refreshCliStatus();
+  }, [refreshCliStatus]);
+
+  const handleInstallCli = async () => {
+    setCliInstallState({ kind: "installing" });
+    try {
+      const result = await invoke<CliInstallResult>("install_cli_symlink");
+      setCliInstallState({ kind: "installed", replaced: result.replacedExisting });
+      refreshCliStatus();
+    } catch (err) {
+      setCliInstallState({ kind: "error", message: String(err) });
+    }
+  };
 
   const dirty = useMemo(() => {
     if (!original || !draft) return false;
@@ -156,6 +190,72 @@ export function SettingsApp() {
               ariaLabel="Keep toast until clicked"
             />
           </SettingsRow>
+        </SettingsSection>
+
+        <SettingsSection title="Startup" description="Control how agentoast launches on this Mac.">
+          <SettingsRow
+            label="Launch at login"
+            hint="Start agentoast automatically when you log in to macOS."
+            htmlFor="autostart-enabled"
+          >
+            <Toggle
+              id="autostart-enabled"
+              checked={draft.autostartEnabled}
+              onChange={(v) => updateField("autostartEnabled", v)}
+              ariaLabel="Launch at login"
+            />
+          </SettingsRow>
+        </SettingsSection>
+
+        <SettingsSection
+          title="CLI"
+          description="Symlink the agentoast CLI into ~/.local/bin so hook scripts can invoke `agentoast`."
+        >
+          <SettingsRow
+            label="Install agentoast CLI"
+            hint={
+              cliStatus
+                ? cliStatus.pointsToCurrentExe
+                  ? `Linked at ${cliStatus.targetPath}`
+                  : cliStatus.installed
+                    ? `${cliStatus.targetPath} exists but points elsewhere — reinstall to update.`
+                    : `Not installed (will create ${cliStatus.targetPath})`
+                : "Checking…"
+            }
+          >
+            <button
+              type="button"
+              onClick={() => {
+                void handleInstallCli();
+              }}
+              disabled={cliInstallState.kind === "installing" || cliStatus === null}
+              className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-xs font-medium text-white shadow-sm transition-colors hover:bg-[var(--accent-hover)] disabled:cursor-not-allowed disabled:bg-[var(--text-faint)] disabled:text-[var(--text-tertiary)] disabled:shadow-none"
+            >
+              {cliInstallState.kind === "installing"
+                ? "Installing…"
+                : cliStatus?.pointsToCurrentExe
+                  ? "Reinstall"
+                  : "Install"}
+            </button>
+          </SettingsRow>
+          {cliInstallState.kind === "installed" && (
+            <div className="px-3.5 py-2 text-[11px] text-[var(--text-tertiary)]">
+              {cliInstallState.replaced ? "Symlink replaced." : "Symlink created."}
+            </div>
+          )}
+          {cliInstallState.kind === "error" && (
+            <div className="px-3.5 py-2 text-[11px] text-[var(--delete-hover-text)]">
+              Install failed: {cliInstallState.message}
+            </div>
+          )}
+          {cliStatus && !cliStatus.onPath && (
+            <div className="px-3.5 py-2 text-[11px] leading-relaxed text-[var(--text-tertiary)]">
+              ⚠ <code className="font-mono">~/.local/bin</code> is not in your{" "}
+              <code className="font-mono">PATH</code>. Add{" "}
+              <code className="font-mono">{`export PATH="$HOME/.local/bin:$PATH"`}</code> to your
+              shell rc.
+            </div>
+          )}
         </SettingsSection>
 
         <SettingsSection

--- a/src/components/shortcut-recorder.tsx
+++ b/src/components/shortcut-recorder.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { AlertTriangle, ChevronDown, ChevronUp, X } from "lucide-react";
 
+type ShortcutRecorderVariant = "default" | "large";
+
 interface ShortcutRecorderProps {
   value: string;
   onChange: (value: string) => void;
@@ -8,6 +10,7 @@ interface ShortcutRecorderProps {
   /** System-reserved shortcuts (macOS symbolic hotkeys). Used to dim examples
    * that would conflict and to warn when a captured shortcut matches. */
   reservedShortcuts?: string[];
+  variant?: ShortcutRecorderVariant;
 }
 
 const MODIFIER_SYMBOLS: Record<string, string> = {
@@ -141,7 +144,9 @@ export function ShortcutRecorder({
   onChange,
   id,
   reservedShortcuts,
+  variant = "default",
 }: ShortcutRecorderProps) {
+  const isLarge = variant === "large";
   const [recording, setRecording] = useState(false);
   const [liveMods, setLiveMods] = useState<LiveModifiers>(EMPTY_MODS);
   const [showExamples, setShowExamples] = useState(false);
@@ -239,8 +244,14 @@ export function ShortcutRecorder({
   const tokens = displayTokens(value);
   const liveTokens = liveModifierSymbols(liveMods);
 
+  const sizeClasses = isLarge
+    ? "h-16 min-w-[140px] gap-3 rounded-2xl px-6 shadow-md"
+    : "h-7 min-w-[110px] gap-1.5 rounded-full px-3";
+  const tokenClasses = isLarge ? "font-mono text-2xl" : "font-mono text-[11px]";
+  const placeholderClasses = isLarge ? "text-base" : "text-xs";
+
   return (
-    <div className="flex flex-col items-end gap-1">
+    <div className={"flex flex-col gap-1 " + (isLarge ? "items-center" : "items-end")}>
       <div
         ref={containerRef}
         className="relative"
@@ -252,22 +263,36 @@ export function ShortcutRecorder({
           type="button"
           onClick={() => setRecording((v) => !v)}
           className={
-            "flex h-7 min-w-[110px] items-center justify-center gap-1.5 rounded-full border px-3 text-xs transition-colors " +
+            "flex items-center justify-center border text-xs transition-colors " +
+            sizeClasses +
+            " " +
             (recording
-              ? "border-[var(--accent)] bg-[var(--panel-bg)] text-[var(--accent)]"
+              ? "border-2 border-[var(--accent)] bg-[var(--panel-bg)] text-[var(--accent)] shadow-[0_0_0_3px_color-mix(in_srgb,var(--accent)_22%,transparent)]"
               : value
                 ? "border-[var(--border-subtle)] bg-[var(--panel-bg)] text-[var(--text-primary)] hover:bg-[var(--hover-bg)]"
                 : "border-[var(--border-subtle)] bg-[var(--panel-bg)] text-[var(--text-tertiary)] hover:bg-[var(--hover-bg)]")
           }
         >
-          {tokens.length > 0 ? (
+          {recording ? (
+            liveTokens.length > 0 ? (
+              liveTokens.map((t, i) => (
+                <span key={i} className={tokenClasses}>
+                  {t}
+                </span>
+              ))
+            ) : (
+              <span className={isLarge ? "text-base" : "text-[11px]"}>
+                {isLarge ? "Press keys…" : "Press…"}
+              </span>
+            )
+          ) : tokens.length > 0 ? (
             tokens.map((t, i) => (
-              <span key={i} className="font-mono text-[11px]">
+              <span key={i} className={tokenClasses}>
                 {t}
               </span>
             ))
           ) : (
-            <span>Not set</span>
+            <span className={placeholderClasses}>Not set</span>
           )}
         </button>
 
@@ -302,7 +327,13 @@ export function ShortcutRecorder({
                 ))
               )}
             </div>
-            <div className="text-xs font-medium text-[var(--accent)]">Recording…</div>
+            <div className="flex items-center gap-1.5 text-xs font-semibold text-[var(--accent)]">
+              <span className="relative flex h-2 w-2">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[var(--accent)] opacity-75" />
+                <span className="relative inline-flex h-2 w-2 rounded-full bg-[var(--accent)]" />
+              </span>
+              Recording…
+            </div>
             <div className="text-[10px] text-[var(--text-tertiary)]">Esc to cancel</div>
 
             {examples.length > 0 && (

--- a/src/lib/settings-types.ts
+++ b/src/lib/settings-types.ts
@@ -3,10 +3,24 @@ export interface SettingsPayload {
   toastPersistent: boolean;
   togglePanelShortcut: string;
   editor: string;
+  autostartEnabled: boolean;
 }
 
 export interface SaveSettingsResult {
   restartRequired: boolean;
+}
+
+export interface CliInstallStatus {
+  installed: boolean;
+  pointsToCurrentExe: boolean;
+  onPath: boolean;
+  targetPath: string;
+}
+
+export interface CliInstallResult {
+  targetPath: string;
+  onPath: boolean;
+  replacedExisting: boolean;
 }
 
 // All current settings are applied live by the backend (toast, shortcut,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
+import { OnboardingApp } from "./OnboardingApp";
 import { SettingsApp } from "./SettingsApp";
 import "./index.css";
 
 const windowType = new URLSearchParams(window.location.search).get("window");
-const Root = windowType === "settings" ? SettingsApp : App;
+const Root =
+  windowType === "settings" ? SettingsApp : windowType === "onboarding" ? OnboardingApp : App;
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary

- Add a 3-step onboarding window (welcome → shortcut → CLI/hooks) that runs once on first launch and persists `~/.local/share/agentoast/.onboarded`.
- Ship a CLI installer that symlinks `~/.local/bin/agentoast` so DMG users (and anyone without Homebrew Cask) can wire `agentoast hook claude` etc. without `command not found`.
- Harden tmux hooks: detect & replace stale `agentoast dismiss` entries on launch, and wrap the hook payload so transient `SQLITE_BUSY` / missing-bin cases no longer spam `'… dismiss …' returned N` in the tmux status bar.

## Details

### Onboarding (`src/OnboardingApp.tsx` + `src/main.tsx`)
- New Tauri window `onboarding` (480×620, transparent, decorations off, registered in `tauri.conf.json` + `capabilities/default.json`).
- Steps: WelcomeStep → ShortcutStep → HooksStep. Skip / Get Started both call `complete_onboarding`.
- Reuses `ShortcutRecorder` with a new `variant="large"` (bigger tap target, animated *Recording…* indicator, live key preview).
- HooksStep also offers per-agent README links and the CLI install toggle.

### CLI installer
- Backend: new `install_cli_symlink` / `get_cli_install_status` Tauri commands in `src-tauri/src/lib.rs`.
  - Source: `std::env::current_exe()` (resolves to `/Applications/Agentoast.app/Contents/MacOS/agentoast` for installed users).
  - Target: `$HOME/.local/bin/agentoast`. Idempotent — replaces existing symlinks, refuses to clobber regular files.
  - Returns `onPath` so the UI can warn when `~/.local/bin` isn't in `$PATH`.
- Frontend: `CliInstallStatus` / `CliInstallResult` types in `src/lib/settings-types.ts`. Onboarding installs by default; Settings exposes a manual *Install / Reinstall CLI* button + PATH warning.

### tmux hook robustness (`src-tauri/src/tmux_hooks.rs`)
- Parses `tmux show-hooks -g`, extracts `(event, idx, bin, has_or_true)` per matching line, and treats anything with the wrong bin path **or** missing `|| true` as stale. Stale entries are removed via `set-hook -gu '<event>[<idx>]'` (highest-index-first per event so indices stay stable), then re-installed with the current payload.
- New payload: `[ -x "<bin>" ] && "<bin>" dismiss -t "#{pane_id}" || true`. The `[ -x ]` guard suppresses 127 from missing binaries, the `|| true` tail suppresses the recurring `returned 1` noise caused by SQLite WAL contention with the running app's watcher.
- Unit tests cover all three payload shapes (v1 bare bin, v2 existence check, v3 with `|| true`) plus an unrelated-event negative case.

### Misc
- `tauri-plugin-autostart` (2.5.0) added so the onboarding *Launch at login* toggle has somewhere to land. `autostart:default` permission registered.
- `mark_onboarded()` / `is_onboarded()` / `onboarded_marker_path()` helpers added to `crates/agentoast-shared/src/config.rs`.


