### PR TITLE
fix: add Notifications section to Settings

### DIFF
--- a/src/OnboardingApp.tsx
+++ b/src/OnboardingApp.tsx
@@ -2,25 +2,12 @@ import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { ArrowRight } from "lucide-react";
 import { IconPreset } from "@/components/icons/source-icon";
+import { NotificationSetup } from "@/components/notification-setup";
 import { ShortcutRecorder } from "@/components/shortcut-recorder";
 import { Toggle } from "@/components/toggle";
-import type { Icon } from "@/lib/types";
 import type { CliInstallStatus, SettingsPayload } from "@/lib/settings-types";
 
 type Step = 0 | 1 | 2;
-
-interface AgentEntry {
-  id: string;
-  label: string;
-  icon: Icon;
-}
-
-const AGENTS: AgentEntry[] = [
-  { id: "claude-code", label: "Claude Code", icon: "claude-code" },
-  { id: "codex", label: "Codex", icon: "codex" },
-  { id: "copilot-cli", label: "Copilot CLI", icon: "copilot-cli" },
-  { id: "opencode", label: "opencode", icon: "opencode" },
-];
 
 export function OnboardingApp() {
   const [step, setStep] = useState<Step>(0);
@@ -226,8 +213,6 @@ function HooksStep({
   onFinish,
   disabled,
 }: HooksStepProps) {
-  const showPathWarning = installCli && cliStatus !== null && !cliStatus.onPath;
-
   return (
     <div className="flex h-full flex-col px-6 pt-3 pb-6">
       <div className="flex flex-col gap-2">
@@ -238,89 +223,13 @@ function HooksStep({
         </p>
       </div>
 
-      <div className="mt-5 flex flex-col gap-2 rounded-xl border border-[var(--border-subtle)] p-4">
-        <div className="flex items-start gap-3">
-          <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[var(--accent)] text-[10px] font-bold text-white">
-            1
-          </span>
-          <div className="flex flex-1 flex-col gap-2">
-            <div className="flex flex-col gap-0.5">
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-semibold text-[var(--text-primary)]">
-                  Install <code className="font-mono text-xs">agentoast</code> CLI
-                </span>
-                {cliStatus?.pointsToCurrentExe ? (
-                  <span className="rounded-full bg-[rgba(34,197,94,0.15)] px-2 py-0.5 text-[10px] font-medium text-[#22c55e]">
-                    Already installed
-                  </span>
-                ) : (
-                  <span className="rounded-full bg-[rgba(239,68,68,0.15)] px-2 py-0.5 text-[10px] font-medium text-[var(--delete-hover-text)]">
-                    Required for hooks
-                  </span>
-                )}
-              </div>
-              <span className="text-[11px] text-[var(--text-tertiary)]">
-                Hook scripts call <code className="font-mono">agentoast hook</code>, so the CLI must
-                be on your <code className="font-mono">PATH</code>.
-              </span>
-            </div>
-            {!cliStatus?.pointsToCurrentExe && (
-              <div className="flex items-center gap-2">
-                <Toggle
-                  checked={installCli}
-                  onChange={onInstallCliChange}
-                  ariaLabel="Install CLI symlink"
-                />
-                <span className="text-[12px] text-[var(--text-secondary)]">
-                  Symlink to <code className="font-mono text-[11px]">~/.local/bin/agentoast</code>
-                </span>
-              </div>
-            )}
-            {showPathWarning && (
-              <p className="rounded-md bg-[var(--hover-bg)] px-3 py-2 text-[11px] leading-relaxed text-[var(--text-tertiary)]">
-                <span className="text-[var(--text-secondary)]">
-                  ⚠ <code className="font-mono">~/.local/bin</code> is not in your{" "}
-                  <code className="font-mono">PATH</code>.
-                </span>{" "}
-                Add <code className="font-mono">{`export PATH="$HOME/.local/bin:$PATH"`}</code> to
-                your shell rc.
-              </p>
-            )}
-          </div>
-        </div>
-      </div>
-
-      <div className="mt-3 flex flex-col gap-2 rounded-xl border border-[var(--border-subtle)] p-4">
-        <div className="flex items-start gap-3">
-          <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[var(--accent)] text-[10px] font-bold text-white">
-            2
-          </span>
-          <div className="flex flex-1 flex-col gap-2">
-            <div className="flex flex-col gap-0.5">
-              <span className="text-sm font-semibold text-[var(--text-primary)]">
-                Configure your agent
-              </span>
-              <span className="text-[11px] text-[var(--text-tertiary)]">
-                Open the README for the agent you use and follow the hook setup steps.
-              </span>
-            </div>
-            <div className="grid grid-cols-4 gap-2">
-              {AGENTS.map((a) => (
-                <button
-                  key={a.id}
-                  type="button"
-                  onClick={() => {
-                    void invoke("open_hook_readme", { agent: a.id });
-                  }}
-                  className="flex flex-col items-center gap-1.5 rounded-xl border border-[var(--border-subtle)] bg-[var(--panel-bg)] py-3 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--hover-bg)] hover:text-[var(--text-primary)]"
-                >
-                  <IconPreset icon={a.icon} size={22} className="text-[var(--text-primary)]" />
-                  {a.label}
-                </button>
-              ))}
-            </div>
-          </div>
-        </div>
+      <div className="mt-5">
+        <NotificationSetup
+          variant="onboarding"
+          installCli={installCli}
+          onInstallCliChange={onInstallCliChange}
+          cliStatus={cliStatus}
+        />
       </div>
 
       <div className="mt-auto flex items-center justify-between gap-3 pt-6">

--- a/src/SettingsApp.tsx
+++ b/src/SettingsApp.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { NotificationSetup } from "@/components/notification-setup";
+import type { CliInstallState } from "@/components/notification-setup";
 import { NumberStepper } from "@/components/number-stepper";
 import { RestartBanner } from "@/components/restart-banner";
 import { SettingsRow, SettingsSection } from "@/components/settings-section";
@@ -19,12 +21,6 @@ type SaveState =
   | { kind: "idle" }
   | { kind: "saving" }
   | { kind: "saved"; restartRequired: boolean }
-  | { kind: "error"; message: string };
-
-type CliInstallState =
-  | { kind: "idle" }
-  | { kind: "installing" }
-  | { kind: "installed"; replaced: boolean }
   | { kind: "error"; message: string };
 
 const MIN_TOAST_DURATION_MS = 500;
@@ -207,56 +203,24 @@ export function SettingsApp() {
           </SettingsRow>
         </SettingsSection>
 
-        <SettingsSection
-          title="CLI"
-          description="Symlink the agentoast CLI into ~/.local/bin so hook scripts can invoke `agentoast`."
-        >
-          <SettingsRow
-            label="Install agentoast CLI"
-            hint={
-              cliStatus
-                ? cliStatus.pointsToCurrentExe
-                  ? `Linked at ${cliStatus.targetPath}`
-                  : cliStatus.installed
-                    ? `${cliStatus.targetPath} exists but points elsewhere — reinstall to update.`
-                    : `Not installed (will create ${cliStatus.targetPath})`
-                : "Checking…"
-            }
-          >
-            <button
-              type="button"
-              onClick={() => {
-                void handleInstallCli();
-              }}
-              disabled={cliInstallState.kind === "installing" || cliStatus === null}
-              className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-xs font-medium text-white shadow-sm transition-colors hover:bg-[var(--accent-hover)] disabled:cursor-not-allowed disabled:bg-[var(--text-faint)] disabled:text-[var(--text-tertiary)] disabled:shadow-none"
-            >
-              {cliInstallState.kind === "installing"
-                ? "Installing…"
-                : cliStatus?.pointsToCurrentExe
-                  ? "Reinstall"
-                  : "Install"}
-            </button>
-          </SettingsRow>
-          {cliInstallState.kind === "installed" && (
-            <div className="px-3.5 py-2 text-[11px] text-[var(--text-tertiary)]">
-              {cliInstallState.replaced ? "Symlink replaced." : "Symlink created."}
-            </div>
-          )}
-          {cliInstallState.kind === "error" && (
-            <div className="px-3.5 py-2 text-[11px] text-[var(--delete-hover-text)]">
-              Install failed: {cliInstallState.message}
-            </div>
-          )}
-          {cliStatus && !cliStatus.onPath && (
-            <div className="px-3.5 py-2 text-[11px] leading-relaxed text-[var(--text-tertiary)]">
-              ⚠ <code className="font-mono">~/.local/bin</code> is not in your{" "}
-              <code className="font-mono">PATH</code>. Add{" "}
-              <code className="font-mono">{`export PATH="$HOME/.local/bin:$PATH"`}</code> to your
-              shell rc.
-            </div>
-          )}
-        </SettingsSection>
+        <section className="mb-5">
+          <header className="mb-2 px-1">
+            <h2 className="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-tertiary)]">
+              Notifications
+            </h2>
+            <p className="mt-1 text-[11px] text-[var(--text-tertiary)]">
+              Connect your AI coding agent so it can send notifications to agentoast.
+            </p>
+          </header>
+          <NotificationSetup
+            variant="settings"
+            cliStatus={cliStatus}
+            cliInstallState={cliInstallState}
+            onInstallCliClick={() => {
+              void handleInstallCli();
+            }}
+          />
+        </section>
 
         <SettingsSection
           title="Editor"

--- a/src/components/notification-setup.tsx
+++ b/src/components/notification-setup.tsx
@@ -1,0 +1,198 @@
+import { invoke } from "@tauri-apps/api/core";
+import { IconPreset } from "@/components/icons/source-icon";
+import { Toggle } from "@/components/toggle";
+import type { Icon } from "@/lib/types";
+import type { CliInstallStatus } from "@/lib/settings-types";
+
+interface AgentEntry {
+  id: string;
+  label: string;
+  icon: Icon;
+}
+
+const AGENTS: AgentEntry[] = [
+  { id: "claude-code", label: "Claude Code", icon: "claude-code" },
+  { id: "codex", label: "Codex", icon: "codex" },
+  { id: "copilot-cli", label: "Copilot CLI", icon: "copilot-cli" },
+  { id: "opencode", label: "opencode", icon: "opencode" },
+];
+
+export type CliInstallState =
+  | { kind: "idle" }
+  | { kind: "installing" }
+  | { kind: "installed"; replaced: boolean }
+  | { kind: "error"; message: string };
+
+interface OnboardingProps {
+  variant: "onboarding";
+  installCli: boolean;
+  onInstallCliChange: (value: boolean) => void;
+  cliStatus: CliInstallStatus | null;
+}
+
+interface SettingsProps {
+  variant: "settings";
+  cliStatus: CliInstallStatus | null;
+  cliInstallState: CliInstallState;
+  onInstallCliClick: () => void;
+}
+
+type NotificationSetupProps = OnboardingProps | SettingsProps;
+
+export function NotificationSetup(props: NotificationSetupProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <CliBlock {...props} />
+      <AgentBlock />
+    </div>
+  );
+}
+
+function CliBlock(props: NotificationSetupProps) {
+  const { cliStatus } = props;
+  const installed = cliStatus?.pointsToCurrentExe ?? false;
+  // GUI app sees launchd's PATH, not the shell's. If the symlink already
+  // points to the current exe, hooks (run from the user's terminal) will
+  // find it via the shell's PATH — suppress the false-positive warning.
+  const showPathWarning =
+    cliStatus !== null &&
+    !cliStatus.onPath &&
+    !installed &&
+    (props.variant === "settings" || props.installCli);
+
+  return (
+    <div className="flex flex-col gap-2 rounded-xl border border-[var(--border-subtle)] p-4">
+      <div className="flex flex-col gap-0.5">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-semibold text-[var(--text-primary)]">
+            Install <code className="font-mono text-xs">agentoast</code> CLI
+          </span>
+          {installed ? (
+            <span className="rounded-full bg-[rgba(34,197,94,0.15)] px-2 py-0.5 text-[10px] font-medium text-[#22c55e]">
+              Already installed
+            </span>
+          ) : (
+            <span className="rounded-full bg-[rgba(239,68,68,0.15)] px-2 py-0.5 text-[10px] font-medium text-[var(--delete-hover-text)]">
+              Required for hooks
+            </span>
+          )}
+        </div>
+        <span className="text-[11px] text-[var(--text-tertiary)]">
+          Hook scripts call <code className="font-mono">agentoast hook</code>, so the CLI must be on
+          your <code className="font-mono">PATH</code>.
+        </span>
+      </div>
+
+      {props.variant === "onboarding" && !installed && (
+        <div className="flex items-center gap-2">
+          <Toggle
+            checked={props.installCli}
+            onChange={props.onInstallCliChange}
+            ariaLabel="Install CLI symlink"
+          />
+          <span className="text-[12px] text-[var(--text-secondary)]">
+            Symlink to <code className="font-mono text-[11px]">~/.local/bin/agentoast</code>
+          </span>
+        </div>
+      )}
+
+      {props.variant === "settings" && (
+        <SettingsCliControls
+          cliStatus={cliStatus}
+          cliInstallState={props.cliInstallState}
+          onInstallCliClick={props.onInstallCliClick}
+        />
+      )}
+
+      {showPathWarning && (
+        <p className="rounded-md bg-[var(--hover-bg)] px-3 py-2 text-[11px] leading-relaxed text-[var(--text-tertiary)]">
+          <span className="text-[var(--text-secondary)]">
+            ⚠ <code className="font-mono">~/.local/bin</code> is not in your{" "}
+            <code className="font-mono">PATH</code>.
+          </span>{" "}
+          Add <code className="font-mono">{`export PATH="$HOME/.local/bin:$PATH"`}</code> to your
+          shell rc.
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface SettingsCliControlsProps {
+  cliStatus: CliInstallStatus | null;
+  cliInstallState: CliInstallState;
+  onInstallCliClick: () => void;
+}
+
+function SettingsCliControls({
+  cliStatus,
+  cliInstallState,
+  onInstallCliClick,
+}: SettingsCliControlsProps) {
+  const installed = cliStatus?.pointsToCurrentExe ?? false;
+  const installing = cliInstallState.kind === "installing";
+
+  const statusHint = cliStatus
+    ? installed
+      ? `Linked at ${cliStatus.targetPath}`
+      : cliStatus.installed
+        ? `${cliStatus.targetPath} exists but points elsewhere — reinstall to update.`
+        : `Not installed (will create ${cliStatus.targetPath})`
+    : "Checking…";
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onInstallCliClick}
+          disabled={installing || cliStatus === null}
+          className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-xs font-medium text-white shadow-sm transition-colors hover:bg-[var(--accent-hover)] disabled:cursor-not-allowed disabled:bg-[var(--text-faint)] disabled:text-[var(--text-tertiary)] disabled:shadow-none"
+        >
+          {installing ? "Installing…" : installed ? "Reinstall" : "Install"}
+        </button>
+        <span className="text-[11px] text-[var(--text-tertiary)]">{statusHint}</span>
+      </div>
+      {cliInstallState.kind === "installed" && (
+        <span className="text-[11px] text-[var(--text-tertiary)]">
+          {cliInstallState.replaced ? "Symlink replaced." : "Symlink created."}
+        </span>
+      )}
+      {cliInstallState.kind === "error" && (
+        <span className="text-[11px] text-[var(--delete-hover-text)]">
+          Install failed: {cliInstallState.message}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function AgentBlock() {
+  return (
+    <div className="flex flex-col gap-2 rounded-xl border border-[var(--border-subtle)] p-4">
+      <div className="flex flex-col gap-0.5">
+        <span className="text-sm font-semibold text-[var(--text-primary)]">
+          Configure your agent
+        </span>
+        <span className="text-[11px] text-[var(--text-tertiary)]">
+          Open the README for the agent you use and follow the hook setup steps.
+        </span>
+      </div>
+      <div className="grid grid-cols-4 gap-2">
+        {AGENTS.map((a) => (
+          <button
+            key={a.id}
+            type="button"
+            onClick={() => {
+              void invoke("open_hook_readme", { agent: a.id });
+            }}
+            className="flex flex-col items-center gap-1.5 rounded-xl border border-[var(--border-subtle)] bg-[var(--panel-bg)] py-3 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--hover-bg)] hover:text-[var(--text-primary)]"
+          >
+            <IconPreset icon={a.icon} size={22} className="text-[var(--text-primary)]" />
+            {a.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a **Notifications** section to Settings that surfaces the Onboarding "Enable notifications" guidance, so users can revisit hook setup at any time.
- Extract the CLI install + agent README block into a shared `NotificationSetup` component used by both `OnboardingApp` and `SettingsApp`, replacing the standalone CLI section.
- Suppress the misleading `~/.local/bin not in PATH` warning when the symlink already points to the running exe (the macOS GUI process inherits launchd's PATH, not the shell's, so the previous check was a false positive).

## Changes

| File | Change |
| --- | --- |
| `src/components/notification-setup.tsx` (new) | Shared component with `variant: "onboarding" \| "settings"`. Renders the CLI install block (toggle for Onboarding, immediate Install/Reinstall button for Settings) and the agent README grid (Claude Code / Codex / Copilot CLI / opencode → `invoke("open_hook_readme")`). |
| `src/OnboardingApp.tsx` | Replace inline `HooksStep` JSX (numbered blocks) with `<NotificationSetup variant="onboarding" />`. Skip / Finish footer kept as-is. |
| `src/SettingsApp.tsx` | Drop the standalone "CLI" section. Insert a new "Notifications" section in its place using `<NotificationSetup variant="settings" />`. Reuses existing `cliStatus` / `cliInstallState` / `handleInstallCli`. |

No backend changes — `open_hook_readme`, `install_cli_symlink`, `get_cli_install_status` are reused.

