### PR TITLE
fix: register Login Item via SMAppService instead of LaunchAgent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,12 +25,12 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "objc2-quartz-core",
+ "objc2-service-management",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-nspanel",
- "tauri-plugin-autostart",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-opener",
  "tauri-plugin-process",
@@ -318,17 +318,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "auto-launch"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
-dependencies = [
- "dirs 4.0.0",
- "thiserror 1.0.69",
- "winreg 0.10.1",
-]
 
 [[package]]
 name = "autocfg"
@@ -852,31 +841,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys 0.5.0",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users 0.4.6",
- "winapi",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -887,7 +856,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.2",
+ "redox_users",
  "windows-sys 0.61.2",
 ]
 
@@ -988,7 +957,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.11+spec-1.1.0",
  "vswhom",
- "winreg 0.55.0",
+ "winreg",
 ]
 
 [[package]]
@@ -2679,6 +2648,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-service-management"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b213642d6959cc6023ceb1217aa595eaaf09b8094ce95127c103cab611fe65e8"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
+]
+
+[[package]]
 name = "objc2-ui-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3285,17 +3278,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
 dependencies = [
  "bitflags 2.10.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4134,7 +4116,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs 6.0.0",
+ "dirs",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4185,7 +4167,7 @@ checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs 6.0.0",
+ "dirs",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4270,20 +4252,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tauri-plugin-autostart"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
-dependencies = [
- "auto-launch",
- "serde",
- "serde_json",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "tauri-plugin-global-shortcut"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4337,7 +4305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
 dependencies = [
  "base64 0.22.1",
- "dirs 6.0.0",
+ "dirs",
  "flate2",
  "futures-util",
  "http",
@@ -4821,7 +4789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
- "dirs 6.0.0",
+ "dirs",
  "libappindicator",
  "muda",
  "objc2",
@@ -5691,15 +5659,6 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -5730,7 +5689,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs 6.0.0",
+ "dirs",
  "dpi",
  "dunce",
  "gdkx11",

--- a/cspell.json
+++ b/cspell.json
@@ -45,6 +45,7 @@
     "nspanel",
     "objc",
     "opencode",
+    "osascript",
     "pids",
     "pkill",
     "prefs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,6 @@ tauri-plugin-opener = "2.5.3"
 tauri-plugin-global-shortcut = "2.3.1"
 tauri-plugin-updater = "2.10.1"
 tauri-plugin-process = "2.3.1"
-tauri-plugin-autostart = "2.5.1"
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
 log = "0.4.29"
 fern = "0.7.1"
@@ -62,6 +61,7 @@ objc2-app-kit = { version = "0.3.2", features = [
 objc2-core-foundation = "0.3.2"
 objc2-core-graphics = "0.3.2"
 objc2-quartz-core = { version = "0.3.2", features = ["CALayer"] }
+objc2-service-management = "0.3.2"
 block2 = "0.6.2"
 
 [dev-dependencies]

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -15,7 +15,6 @@
     "opener:default",
     "global-shortcut:default",
     "updater:default",
-    "process:allow-restart",
-    "autostart:default"
+    "process:allow-restart"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,7 +24,6 @@ use agentoast_shared::db;
 use agentoast_shared::models::{Notification, TmuxPaneGroup};
 use serde::{Deserialize, Serialize};
 use tauri::{Emitter, Manager};
-use tauri_plugin_autostart::ManagerExt as AutostartManagerExt;
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 use tauri_plugin_opener::OpenerExt;
 
@@ -122,6 +121,98 @@ fn start_sessions_safety_poller(app_handle: tauri::AppHandle, interval: Duration
         std::thread::sleep(interval);
         refresh_and_emit(&app_handle);
     });
+}
+
+/// Register / unregister the running app as a macOS Login Item via the
+/// `SMAppService.mainApp` API (macOS 13+). Unlike the older
+/// `osascript`-based approaches, this does NOT trigger the Automation /
+/// Apple Events TCC consent prompt because the app is registering itself,
+/// not controlling another process.
+#[cfg(target_os = "macos")]
+fn autostart_main_service() -> objc2::rc::Retained<objc2_service_management::SMAppService> {
+    unsafe { objc2_service_management::SMAppService::mainAppService() }
+}
+
+#[cfg(target_os = "macos")]
+fn autostart_is_enabled() -> bool {
+    use objc2_service_management::SMAppServiceStatus;
+    let service = autostart_main_service();
+    let status = unsafe { service.status() };
+    status == SMAppServiceStatus::Enabled
+}
+
+#[cfg(target_os = "macos")]
+fn autostart_enable() -> Result<(), String> {
+    let service = autostart_main_service();
+    unsafe { service.registerAndReturnError() }
+        .map_err(|e| format!("SMAppService.register failed: {}", e.localizedDescription()))
+}
+
+#[cfg(target_os = "macos")]
+fn autostart_disable() -> Result<(), String> {
+    let service = autostart_main_service();
+    unsafe { service.unregisterAndReturnError() }.map_err(|e| {
+        format!(
+            "SMAppService.unregister failed: {}",
+            e.localizedDescription()
+        )
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn autostart_is_enabled() -> bool {
+    false
+}
+
+#[cfg(not(target_os = "macos"))]
+fn autostart_enable() -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn autostart_disable() -> Result<(), String> {
+    Ok(())
+}
+
+/// Clean up the legacy `~/Library/LaunchAgents/Agentoast.plist` left by the
+/// old `tauri-plugin-autostart` LaunchAgent mode and, if it existed, re-arm
+/// autostart through SMAppService so the user's preference survives.
+///
+/// We deliberately do NOT auto-clean the buggy "agentoast" login item left
+/// by the intermediate AppleScript-mode build: removing it would require
+/// `osascript`, which would re-trigger the very TCC prompt this migration
+/// is trying to avoid. Affected testers (handful of internal users) are
+/// asked to remove that orphan entry manually from System Settings.
+#[cfg(target_os = "macos")]
+fn migrate_legacy_autostart() {
+    let Ok(home) = std::env::var("HOME") else {
+        return;
+    };
+    let plist_path = std::path::PathBuf::from(home).join("Library/LaunchAgents/Agentoast.plist");
+    if !plist_path.exists() {
+        return;
+    }
+
+    log::info!(
+        "Removing legacy LaunchAgent plist: {}",
+        plist_path.display()
+    );
+    if let Err(e) = std::process::Command::new("launchctl")
+        .arg("unload")
+        .arg(&plist_path)
+        .output()
+    {
+        log::warn!("launchctl unload failed (continuing): {}", e);
+    }
+    if let Err(e) = std::fs::remove_file(&plist_path) {
+        log::warn!("Failed to remove {}: {}", plist_path.display(), e);
+        return;
+    }
+
+    match autostart_enable() {
+        Ok(_) => log::info!("Re-registered autostart via SMAppService"),
+        Err(e) => log::warn!("Failed to re-enable autostart after migration: {}", e),
+    }
 }
 
 /// Currently-registered global shortcut for toggling the main panel. Kept
@@ -523,12 +614,9 @@ pub struct SaveSettingsResult {
 }
 
 #[tauri::command]
-fn get_settings(
-    app_handle: tauri::AppHandle,
-    state: tauri::State<'_, Mutex<AppState>>,
-) -> Result<SettingsPayload, String> {
+fn get_settings(state: tauri::State<'_, Mutex<AppState>>) -> Result<SettingsPayload, String> {
     let state = state.lock().map_err(|e| e.to_string())?;
-    let autostart_enabled = app_handle.autolaunch().is_enabled().unwrap_or(false);
+    let autostart_enabled = autostart_is_enabled();
     Ok(SettingsPayload {
         toast_duration_ms: state.config.toast.duration_ms,
         toast_persistent: state.config.toast.persistent,
@@ -663,15 +751,15 @@ fn save_settings(
     #[cfg(target_os = "macos")]
     native_toast::update_settings(payload.toast_duration_ms, payload.toast_persistent);
 
-    // --- Phase 5: autostart (LaunchAgent). Not mirrored in config.toml, so a
-    // failure here is surfaced but does not need a toml rollback. ---
-    let old_autostart = app_handle.autolaunch().is_enabled().unwrap_or(false);
+    // --- Phase 5: autostart (System Events login item). Not mirrored in
+    // config.toml, so a failure here is surfaced but does not need a toml
+    // rollback. ---
+    let old_autostart = autostart_is_enabled();
     if old_autostart != payload.autostart_enabled {
-        let manager = app_handle.autolaunch();
         let result = if payload.autostart_enabled {
-            manager.enable()
+            autostart_enable()
         } else {
-            manager.disable()
+            autostart_disable()
         };
         if let Err(e) = result {
             return Err(format!("Failed to update autostart: {}", e));
@@ -933,10 +1021,6 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_nspanel::init())
         .plugin(tauri_plugin_process::init())
-        .plugin(tauri_plugin_autostart::init(
-            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
-            None,
-        ))
         .invoke_handler(tauri::generate_handler![
             init_panel,
             hide_panel,
@@ -987,6 +1071,9 @@ pub fn run() {
             {
                 app_nap::disable_app_nap();
             }
+
+            #[cfg(target_os = "macos")]
+            migrate_legacy_autostart();
 
             let db_path = config::db_path();
             let app_config = config::load_config();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -56,7 +56,10 @@
     "targets": "all",
     "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns"],
     "resources": ["icons/tray-icon.png", "icons/tray-icon-notification.png"],
-    "createUpdaterArtifacts": true
+    "createUpdaterArtifacts": true,
+    "macOS": {
+      "minimumSystemVersion": "13.0"
+    }
   },
   "plugins": {
     "updater": {


### PR DESCRIPTION
## Summary

- Replace `tauri-plugin-autostart` with Apple's recommended `SMAppService.mainAppService` (macOS 13+) via `objc2-service-management`.
- Eliminates the macOS Automation TCC consent prompt and surfaces the entry as `Agentoast.app` (Application) under "Open at Login" instead of under the user's full name in "Allow in the Background".
- Bumps minimum macOS to 13.0 (Ventura).

## Why

The previous `MacosLauncher::LaunchAgent` mode dropped `~/Library/LaunchAgents/Agentoast.plist`, which macOS surfaces under the user's full name (e.g. "SHUINCHI TAKAHASHI") in System Settings → Login Items → "Allow in the Background".

Switching the same plugin to `MacosLauncher::AppleScript` placed the entry in the right section but:

1. Registered the Mach-O binary path, so the entry showed up as a Unix executable instead of an Application.
2. Triggered the macOS Automation TCC consent prompt ("Agentoast.app が System Events.app を制御するアクセスを要求しています") because `osascript` was used to control `System Events.app`.

`SMAppService.mainAppService()` registers the running app *itself*, so no inter-app control happens — TCC never fires, and the entry shows up cleanly as `Agentoast.app` of type Application.

## Changes

- **`src-tauri/Cargo.toml`** — drop `tauri-plugin-autostart`, add `objc2-service-management 0.3.2`
- **`src-tauri/capabilities/default.json`** — drop `autostart:default` permission
- **`src-tauri/tauri.conf.json`** — set `bundle.macOS.minimumSystemVersion = "13.0"`
- **`src-tauri/src/lib.rs`**
  - New helpers: `autostart_main_service`, `autostart_is_enabled`, `autostart_enable`, `autostart_disable` (all wrap `SMAppService.mainAppService`)
  - `migrate_legacy_autostart` cleans up `~/Library/LaunchAgents/Agentoast.plist` on first launch and re-registers via SMAppService when the user previously had it enabled
  - `get_settings` / `save_settings` now call the new helpers instead of `app_handle.autolaunch()`
- **`cspell.json`** — allow `osascript` in code comments

