### PR TITLE
fix: relabel CLI Install as Link and add Saved badge

### DIFF
--- a/src/SettingsApp.tsx
+++ b/src/SettingsApp.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { Check } from "lucide-react";
 import { AppsSetup } from "@/components/apps-setup";
 import { NotificationSetup } from "@/components/notification-setup";
 import type { CliInstallState } from "@/components/notification-setup";
@@ -9,6 +10,7 @@ import { SettingsRow, SettingsSection } from "@/components/settings-section";
 import { ShortcutRecorder } from "@/components/shortcut-recorder";
 import { Toggle } from "@/components/toggle";
 import type { AllowedApp } from "@/lib/types";
+import { cn } from "@/lib/utils";
 import type {
   CliInstallResult,
   CliInstallStatus,
@@ -36,6 +38,7 @@ export function SettingsApp() {
   const [cliStatus, setCliStatus] = useState<CliInstallStatus | null>(null);
   const [cliInstallState, setCliInstallState] = useState<CliInstallState>({ kind: "idle" });
   const [allowedApps, setAllowedApps] = useState<AllowedApp[]>([]);
+  const [appsSavedAt, setAppsSavedAt] = useState<number | null>(null);
 
   const refreshCliStatus = useCallback(() => {
     invoke<CliInstallStatus>("get_cli_install_status")
@@ -73,10 +76,21 @@ export function SettingsApp() {
 
   const handleAllowedAppsChange = useCallback((next: AllowedApp[]) => {
     setAllowedApps(next);
-    void invoke("save_apps_allowed_apps", { allowedApps: next }).catch((err) => {
-      console.warn("save_apps_allowed_apps failed:", err);
-    });
+    invoke("save_apps_allowed_apps", { allowedApps: next })
+      .then(() => setAppsSavedAt(Date.now()))
+      .catch((err) => {
+        console.warn("save_apps_allowed_apps failed:", err);
+      });
   }, []);
+
+  // Hide the "Saved" badge 1.5s after the most recent successful save. Each
+  // new save resets the timer (the previous effect's cleanup clears its old
+  // timeout), so rapid edits keep the badge visible until activity stops.
+  useEffect(() => {
+    if (appsSavedAt === null) return;
+    const t = window.setTimeout(() => setAppsSavedAt(null), 1500);
+    return () => window.clearTimeout(t);
+  }, [appsSavedAt]);
 
   const handleInstallCli = async () => {
     setCliInstallState({ kind: "installing" });
@@ -151,8 +165,19 @@ export function SettingsApp() {
   }
 
   return (
-    <div className="flex h-screen flex-col bg-[var(--panel-bg)] text-[var(--text-primary)]">
+    <div className="relative flex h-screen flex-col bg-[var(--panel-bg)] text-[var(--text-primary)]">
       {showRestartBanner && <RestartBanner onRestart={handleRestart} />}
+
+      <div
+        aria-live="polite"
+        className={cn(
+          "pointer-events-none absolute bottom-14 right-4 z-50 flex items-center gap-1.5 rounded-md border border-[rgba(34,197,94,0.4)] bg-[rgba(34,197,94,0.15)] px-2.5 py-1 text-[11px] font-medium text-[#22c55e] shadow-md backdrop-blur-sm transition-opacity duration-300",
+          appsSavedAt !== null ? "opacity-100" : "opacity-0",
+        )}
+      >
+        <Check size={12} strokeWidth={2.5} />
+        Saved
+      </div>
 
       <div className="flex-1 overflow-y-auto px-5 py-5">
         <SettingsSection
@@ -244,7 +269,7 @@ export function SettingsApp() {
               Apps
             </h2>
             <p className="mt-1 text-[11px] text-[var(--text-tertiary)]">
-              Pin frequently-used apps so you can switch to them from the panel’s Apps tab.
+              Pin frequently-used apps so you can switch to them from the panel’s Apps view.
             </p>
           </header>
           <AppsSetup allowedApps={allowedApps} onChange={handleAllowedAppsChange} />

--- a/src/components/notification-setup.tsx
+++ b/src/components/notification-setup.tsx
@@ -65,11 +65,11 @@ function CliBlock(props: NotificationSetupProps) {
       <div className="flex flex-col gap-0.5">
         <div className="flex items-center gap-2">
           <span className="text-sm font-semibold text-[var(--text-primary)]">
-            Install <code className="font-mono text-xs">agentoast</code> CLI
+            Link <code className="font-mono text-xs">agentoast</code> CLI
           </span>
           {installed ? (
             <span className="rounded-full bg-[rgba(34,197,94,0.15)] px-2 py-0.5 text-[10px] font-medium text-[#22c55e]">
-              Already installed
+              Already linked
             </span>
           ) : (
             <span className="rounded-full bg-[rgba(239,68,68,0.15)] px-2 py-0.5 text-[10px] font-medium text-[var(--delete-hover-text)]">
@@ -78,8 +78,10 @@ function CliBlock(props: NotificationSetupProps) {
           )}
         </div>
         <span className="text-[11px] text-[var(--text-tertiary)]">
-          Hook scripts call <code className="font-mono">agentoast hook</code>, so the CLI must be on
-          your <code className="font-mono">PATH</code>.
+          Creates a symlink at <code className="font-mono">~/.local/bin/agentoast</code> pointing to
+          the bundled binary, so hook scripts can find{" "}
+          <code className="font-mono">agentoast hook</code> on your{" "}
+          <code className="font-mono">PATH</code>.
         </span>
       </div>
 
@@ -88,7 +90,7 @@ function CliBlock(props: NotificationSetupProps) {
           <Toggle
             checked={props.installCli}
             onChange={props.onInstallCliChange}
-            ariaLabel="Install CLI symlink"
+            ariaLabel="Link CLI symlink"
           />
           <span className="text-[12px] text-[var(--text-secondary)]">
             Symlink to <code className="font-mono text-[11px]">~/.local/bin/agentoast</code>
@@ -136,8 +138,8 @@ function SettingsCliControls({
     ? installed
       ? `Linked at ${cliStatus.targetPath}`
       : cliStatus.installed
-        ? `${cliStatus.targetPath} exists but points elsewhere — reinstall to update.`
-        : `Not installed (will create ${cliStatus.targetPath})`
+        ? `${cliStatus.targetPath} exists but points elsewhere — relink to update.`
+        : `Not linked (will create ${cliStatus.targetPath})`
     : "Checking…";
 
   return (
@@ -149,7 +151,7 @@ function SettingsCliControls({
           disabled={installing || cliStatus === null}
           className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-xs font-medium text-white shadow-sm transition-colors hover:bg-[var(--accent-hover)] disabled:cursor-not-allowed disabled:bg-[var(--text-faint)] disabled:text-[var(--text-tertiary)] disabled:shadow-none"
         >
-          {installing ? "Installing…" : installed ? "Reinstall" : "Install"}
+          {installing ? "Linking…" : installed ? "Relink" : "Link"}
         </button>
         <span className="text-[11px] text-[var(--text-tertiary)]">{statusHint}</span>
       </div>
@@ -160,7 +162,7 @@ function SettingsCliControls({
       )}
       {cliInstallState.kind === "error" && (
         <span className="text-[11px] text-[var(--delete-hover-text)]">
-          Install failed: {cliInstallState.message}
+          Link failed: {cliInstallState.message}
         </span>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Relabel the Settings → Notifications "Install agentoast CLI" action as "Link", since it only creates a symlink at `~/.local/bin/agentoast` pointing to the bundled binary. Users with the CLI already on PATH (e.g. via Homebrew Cask) were being told to install something they have.
- Flash a transient "Saved" badge in the bottom-right of the Settings window after a successful `save_apps_allowed_apps` call. The badge fades out 1.5s after the latest save; rapid edits keep it visible until activity stops.
- Reword the Apps section copy from "Apps tab" to "Apps view" to match the launcher's actual surface.

## Changes

### `src/components/notification-setup.tsx`
- Heading: `Install agentoast CLI` → `Link agentoast CLI`
- Status badge: `Already installed` → `Already linked`
- Description: now explicitly says it creates a symlink at `~/.local/bin/agentoast` pointing to the bundled binary
- Button labels: `Install` / `Reinstall` / `Installing…` → `Link` / `Relink` / `Linking…`
- Status hints: `Not installed (...)` → `Not linked (...)`, `reinstall to update` → `relink to update`
- Error text: `Install failed:` → `Link failed:`
- Aria label: `Install CLI symlink` → `Link CLI symlink`
- Internal type names (`CliInstallStatus`, `CliInstallState`) and Tauri command names (`install_cli_symlink`, etc.) are left untouched — they're coupled to the backend.

### `src/SettingsApp.tsx`
- Add `appsSavedAt` state + `useEffect` that auto-clears it 1.5s after the most recent save.
- Wire `handleAllowedAppsChange` to bump `appsSavedAt` on `save_apps_allowed_apps` success.
- Render a `pointer-events-none` "Saved" pill in the bottom-right of the Settings window with `aria-live="polite"`, fading via `opacity` transition.
- Apps section description: "Apps tab" → "Apps view".


