### PR TITLE
fix: add link to open System Settings Login Items

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -64,6 +64,7 @@
     "subviews",
     "staticlib",
     "symbolichotkeys",
+    "systempreferences",
     "tauri",
     "tinyspeck",
     "topo",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -824,6 +824,24 @@ fn open_hook_readme(app_handle: tauri::AppHandle, agent: String) -> Result<(), S
         .map_err(|e| e.to_string())
 }
 
+#[cfg(target_os = "macos")]
+#[tauri::command]
+fn open_login_items_settings(app_handle: tauri::AppHandle) -> Result<(), String> {
+    app_handle
+        .opener()
+        .open_url(
+            "x-apple.systempreferences:com.apple.LoginItems-Settings.extension",
+            None::<&str>,
+        )
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(not(target_os = "macos"))]
+#[tauri::command]
+fn open_login_items_settings(_app_handle: tauri::AppHandle) -> Result<(), String> {
+    Err("Opening Login Items settings is only supported on macOS".to_string())
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct CliInstallStatus {
@@ -1117,6 +1135,7 @@ pub fn run() {
             get_reserved_shortcuts,
             complete_onboarding,
             open_hook_readme,
+            open_login_items_settings,
             get_cli_install_status,
             install_cli_symlink,
             list_running_apps,

--- a/src/SettingsApp.tsx
+++ b/src/SettingsApp.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { Check } from "lucide-react";
+import { Check, ExternalLink } from "lucide-react";
 import { AppsSetup } from "@/components/apps-setup";
 import { NotificationSetup } from "@/components/notification-setup";
 import type { CliInstallState } from "@/components/notification-setup";
@@ -242,6 +242,18 @@ export function SettingsApp() {
               ariaLabel="Launch at login"
             />
           </SettingsRow>
+          <button
+            type="button"
+            onClick={() => {
+              void invoke("open_login_items_settings").catch((err) => {
+                console.error("Failed to open Login Items settings:", err);
+              });
+            }}
+            className="flex w-full items-center gap-1.5 px-3.5 py-2 text-left text-[11px] text-[var(--accent)] transition-colors hover:bg-[var(--row-hover)]"
+          >
+            <ExternalLink size={12} />
+            <span className="hover:underline">Open Login Items in System Settings</span>
+          </button>
         </SettingsSection>
 
         <section className="mb-5">


### PR DESCRIPTION
## Summary

- Add an inline link in **Settings → Startup** that opens macOS *System Settings → General → Login Items & Extensions*, so users can verify whether agentoast is actually registered as a login item.
- Wire up a new `open_login_items_settings` Tauri command that uses `tauri-plugin-opener` to launch the `x-apple.systempreferences:com.apple.LoginItems-Settings.extension` URL scheme.

## Background

The `Launch at login` toggle (`src/SettingsApp.tsx`) flips `SMAppService` registration, but the resulting state can only be confirmed visually inside macOS System Settings. Users have asked for a one-click jump to that pane so they don't have to dig through the Settings app manually.

## Changes

| File | Description |
|---|---|
| `src-tauri/src/lib.rs` | New `open_login_items_settings` command. macOS opens the Login Items pane via `app_handle.opener().open_url(...)`. Non-macOS returns `Err("…only supported on macOS")`. Registered in `generate_handler!`. |
| `src/SettingsApp.tsx` | New `ExternalLink`-styled link button rendered just below the **Launch at login** row, calling `open_login_items_settings`. |
| `cspell.json` | Whitelisted `systempreferences` (URL scheme keyword). |

No changes to the autostart logic (`SMAppService` registration / unregistration), capabilities, or the existing settings persistence flow.



## Notes

- The link is purely a navigation shortcut; the toggle's source-of-truth remains `SMAppService.status` via `get_settings`. No extra state synchronization was needed.
- Relies on `opener:default` capability (already present in `src-tauri/capabilities/default.json`).
