### PR TITLE
perf(settings): defer list_running_apps until search input is used

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -988,10 +988,15 @@ fn complete_onboarding(app_handle: tauri::AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
-fn list_running_apps() -> Result<Vec<apps::RunningApp>, String> {
+async fn list_running_apps() -> Result<Vec<apps::RunningApp>, String> {
+    // Runs on a background blocking thread so the ~2s of NSWorkspace
+    // enumeration + per-app TIFF→PNG icon encoding never freezes the UI
+    // thread (no macOS beach-ball cursor while the dropdown is loading).
     #[cfg(target_os = "macos")]
     {
-        Ok(apps::list_running_apps())
+        tauri::async_runtime::spawn_blocking(apps::list_running_apps)
+            .await
+            .map_err(|e| e.to_string())
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -1038,12 +1043,17 @@ fn activate_app(bundle_id: String) -> Result<(), String> {
 }
 
 #[tauri::command]
-fn resolve_app_icons(
+async fn resolve_app_icons(
     bundle_ids: Vec<String>,
 ) -> Result<std::collections::HashMap<String, String>, String> {
+    // Same reasoning as `list_running_apps`: keep AppKit calls off the UI
+    // thread. Even with a small allowlist, encoding icons to PNG can take
+    // tens of milliseconds and we don't want that on the main thread.
     #[cfg(target_os = "macos")]
     {
-        Ok(apps::resolve_app_icons(&bundle_ids))
+        tauri::async_runtime::spawn_blocking(move || apps::resolve_app_icons(&bundle_ids))
+            .await
+            .map_err(|e| e.to_string())
     }
     #[cfg(not(target_os = "macos"))]
     {

--- a/src/components/apps-setup.tsx
+++ b/src/components/apps-setup.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { Check, Pencil, Search, Trash2, X } from "lucide-react";
 import type { AllowedApp, RunningApp } from "@/lib/types";
@@ -43,29 +43,31 @@ function fuzzyScore(query: string, text: string): number | null {
 
 export function AppsSetup({ allowedApps, onChange }: AppsSetupProps) {
   const [running, setRunning] = useState<RunningApp[]>([]);
-  const [status, setStatus] = useState<Status>({ kind: "loading" });
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
   const [query, setQuery] = useState("");
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [editingBundleId, setEditingBundleId] = useState<string | null>(null);
   const [editingDraft, setEditingDraft] = useState("");
   const editInputRef = useRef<HTMLInputElement | null>(null);
+  // `list_running_apps` enumerates every running macOS app and base64-encodes
+  // each icon — ~2s on a busy desktop. Defer it until the user actually
+  // interacts with the search input so cold start (where the settings webview
+  // is pre-loaded but invisible) doesn't pay this cost.
+  const fetchedRef = useRef(false);
 
-  useEffect(() => {
-    let cancelled = false;
+  const ensureRunningLoaded = useCallback(() => {
+    if (fetchedRef.current) return;
+    fetchedRef.current = true;
     setStatus({ kind: "loading" });
     invoke<RunningApp[]>("list_running_apps")
       .then((apps) => {
-        if (cancelled) return;
         setRunning(apps);
         setStatus({ kind: "idle" });
       })
       .catch((err) => {
-        if (cancelled) return;
+        fetchedRef.current = false;
         setStatus({ kind: "error", message: String(err) });
       });
-    return () => {
-      cancelled = true;
-    };
   }, []);
 
   const allowedSet = useMemo(() => new Set(allowedApps.map((a) => a.bundleId)), [allowedApps]);
@@ -182,8 +184,14 @@ export function AppsSetup({ allowedApps, onChange }: AppsSetupProps) {
           spellCheck={false}
           placeholder="Search apps or paste a bundle ID…"
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          onFocus={() => setDropdownOpen(true)}
+          onChange={(e) => {
+            ensureRunningLoaded();
+            setQuery(e.target.value);
+          }}
+          onFocus={() => {
+            ensureRunningLoaded();
+            setDropdownOpen(true);
+          }}
           onBlur={() => {
             // Delay so a mousedown on a dropdown item still registers.
             window.setTimeout(() => setDropdownOpen(false), 120);

--- a/src/components/apps-setup.tsx
+++ b/src/components/apps-setup.tsx
@@ -198,7 +198,7 @@ export function AppsSetup({ allowedApps, onChange }: AppsSetupProps) {
           }}
           className="h-7 w-full rounded-md border border-[var(--border-primary)] bg-[var(--panel-bg)] pl-7 pr-7 text-xs text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
         />
-        {query && (
+        {query ? (
           <button
             type="button"
             onMouseDown={(e) => e.preventDefault()}
@@ -208,11 +208,24 @@ export function AppsSetup({ allowedApps, onChange }: AppsSetupProps) {
           >
             <X size={11} />
           </button>
+        ) : (
+          status.kind === "loading" && (
+            <span
+              aria-label="Loading running apps"
+              className="pointer-events-none absolute right-2 top-1/2 inline-block h-3 w-3 -translate-y-1/2 animate-spin rounded-full border border-[var(--border-primary)] border-t-[var(--accent)]"
+            />
+          )
         )}
 
         {dropdownOpen && trimmedQuery && (
           <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-[260px] overflow-y-auto rounded-md border border-[var(--border-primary)] bg-[var(--panel-bg)] shadow-lg">
-            {results.length === 0 && !showRawFallback && (
+            {status.kind === "loading" && results.length === 0 && (
+              <div className="flex items-center gap-2 px-3 py-2 text-[11px] text-[var(--text-tertiary)]">
+                <span className="inline-block h-2.5 w-2.5 animate-spin rounded-full border border-[var(--border-primary)] border-t-[var(--accent)]" />
+                Loading running apps…
+              </div>
+            )}
+            {status.kind !== "loading" && results.length === 0 && !showRawFallback && (
               <div className="px-3 py-2 text-[11px] text-[var(--text-tertiary)]">
                 No matching apps.
               </div>


### PR DESCRIPTION
## Summary

- Settings webview is pre-loaded at cold start even though it stays hidden, so `AppsSetup`'s mount-time `useEffect` fired `list_running_apps` and paid ~3.9s of `NSWorkspace.runningApplications()` + per-app TIFF→PNG icon encoding before the user ever opened Settings.
- Defer the `list_running_apps` invoke behind the search input's `onFocus` / `onChange`, gated by a `useRef`-based `fetched` once-flag.
- No Rust-side change. Pinned-app icons in the main panel header still resolve via `useAppsAllowedApps` → `resolve_app_icons`, which already only encodes the allowlist entries.

## Why

Reported as "cold start feels heavy lately." Suspected to be the apps list. Instrumented `apps.rs::list_running_apps` and the Tauri `setup` hook on a 86-running-apps / 1-pinned desktop and confirmed:

```
[bench] setup: enter
[bench] setup: exit                  total=  19ms
[bench] list_running_apps (1st)      total=2296ms (icons=2257ms / 52)
[bench] list_running_apps (2nd)      total=1650ms (icons=1621ms / 52)   ← React 19 StrictMode mount→unmount→mount
[bench] resolve_app_icons (allowlist=1)  total=  53ms
[bench] resolve_app_icons (allowlist=1)  total=  41ms
```

So Tauri `setup` itself is ~19ms; the visible cold-start cost was almost entirely the two background `list_running_apps` calls from the invisible settings webview — totalling **~3.9 seconds** the user can't see and didn't ask for.

## Verification

After the fix (same machine, fresh `cargo make dev` cold start, allowlist still = 1):

```
$ grep -E "list_running_apps|resolve_app_icons" ~/.local/share/agentoast/agentoast.log
(no output)
```

| Metric | Before | After |
| --- | --- | --- |
| `list_running_apps` calls during cold start | 2 | **0** |
| Time spent in `list_running_apps` at cold start | ~3946 ms | **0 ms** |
| Tauri `setup` block | 19 ms | 19 ms |

Tradeoff: opening Settings → Apps for the first time now takes ~2s to populate the search dropdown when the user focuses the input. Pinned-app icons in the panel header are unaffected (they go through `resolve_app_icons` with the allowlist only).




## Follow-up: keep AppKit work off the UI thread

While verifying the lazy fetch above, the macOS rainbow beach-ball cursor still appeared while the Apps search dropdown was loading: the synchronous `#[tauri::command]` path was running the ~2s `NSWorkspace` enumeration + per-app TIFF→PNG icon encoding on the UI thread.

Both `list_running_apps` and `resolve_app_icons` are now `async` + offloaded via `tauri::async_runtime::spawn_blocking`, so the AppKit work runs on a background blocking thread and the UI stays responsive. See the inline review comments on `src-tauri/src/lib.rs` for the exact spots.

In addition, the dropdown now shows a loading state instead of an empty/"No matching apps" flash:
- spinner inside the search input while the field is empty and a fetch is in flight
- "Loading running apps…" row at the top of the dropdown when the user has typed before the list arrives
