### PR TITLE
feat(panel): add experimental easy-motion jump (press 'e')

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -17,6 +17,7 @@
   "words": [
     "agentoast",
     "appdir",
+    "asdfjkl",
     "autolaunch",
     "Backquote",
     "bezeled",
@@ -25,6 +26,7 @@
     "cfnumber",
     "cfstring",
     "codegen",
+    "ghetyuiopqwrvbnmcxz",
     "ghostty",
     "googlecode",
     "humantime",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,8 +11,10 @@ import { PanelHeader } from "@/components/panel-header";
 import { AppsView } from "@/components/apps-view";
 import { RepoGroup } from "@/components/repo-group";
 import { KeybindHelp } from "@/components/keybind-help";
+import { EasyMotionGrid } from "@/components/easy-motion-grid";
 import { Bell } from "lucide-react";
 import type { Notification, PanelView, UnifiedGroup, FlatItem, PaneItem } from "@/lib/types";
+import { assignLabels } from "@/lib/easy-motion-labels";
 
 export function App() {
   const { notifications, loading, deleteNotification, deleteByPanes, deleteAll, newIds } =
@@ -38,6 +40,9 @@ export function App() {
   const [showHelp, setShowHelp] = useState(false);
   const [filterNotifiedOnly, setFilterNotifiedOnly] = useState(false);
   const [showNonAgentPanes, setShowNonAgentPanes] = useState(false);
+  const [easyMotion, setEasyMotion] = useState<EasyMotionState>({ active: false });
+  // Labels are assigned only to panes fully inside the viewport. null = unmeasured.
+  const [easyMotionVisibleIds, setEasyMotionVisibleIds] = useState<Set<string> | null>(null);
   const [manuallyToggledGroups, setManuallyToggledGroups] = useState<Set<string>>(new Set());
   const [autoExpandedPaneId, setAutoExpandedPaneId] = useState<string | null>(null);
   const autoExpandTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -347,6 +352,8 @@ export function App() {
       // Always start on the main view — the apps view is a one-shot launcher.
       setActiveView("main");
       setAppsSelectedIndex(0);
+      setEasyMotion({ active: false });
+      setEasyMotionVisibleIds(null);
     });
     return () => {
       unlisten.then((f) => f()).catch(() => {});
@@ -516,6 +523,56 @@ export function App() {
     });
   }, []);
 
+  // Easy-motion: only running / waiting / notified panes are jump targets.
+  // Idle-without-notification panes are hidden from the grid so the screen
+  // stays compact and labels never run out within the panel viewport.
+  const easyMotionGroups = useMemo(() => {
+    const result: UnifiedGroup[] = [];
+    for (const ug of displayGroups) {
+      const filtered = ug.paneItems.filter(isEasyMotionTarget);
+      if (filtered.length === 0) continue;
+      result.push({ ...ug, paneItems: filtered });
+    }
+    return result;
+  }, [displayGroups]);
+
+  const easyMotionTargets = useMemo(() => {
+    const targets: PaneItem[] = [];
+    for (const ug of easyMotionGroups) {
+      for (const pi of ug.paneItems) {
+        targets.push(pi);
+      }
+    }
+    return targets;
+  }, [easyMotionGroups]);
+
+  // Only panes inside the viewport receive a label. While visibleIds is
+  // still null (unmeasured), tiles render without labels; once
+  // useLayoutEffect finishes measuring, a re-render fills them in.
+  // Pre-labeling all tiles before measurement would briefly flash labels
+  // onto off-screen tiles, so we deliberately keep the map empty until then.
+  const easyMotionLabels = useMemo(() => {
+    if (easyMotionVisibleIds === null) {
+      return new Map<string, string>();
+    }
+    const visibleTargets = easyMotionTargets.filter((pi) =>
+      easyMotionVisibleIds.has(pi.pane.paneId),
+    );
+    const labels = assignLabels(visibleTargets.length);
+    const map = new Map<string, string>();
+    visibleTargets.forEach((pi, i) => {
+      map.set(pi.pane.paneId, labels[i] ?? "");
+    });
+    return map;
+  }, [easyMotionTargets, easyMotionVisibleIds]);
+
+  const easyMotionRef = useRef(easyMotion);
+  easyMotionRef.current = easyMotion;
+  const easyMotionTargetsRef = useRef(easyMotionTargets);
+  easyMotionTargetsRef.current = easyMotionTargets;
+  const easyMotionLabelsRef = useRef(easyMotionLabels);
+  easyMotionLabelsRef.current = easyMotionLabels;
+
   const activateAppByBundleId = useCallback((bundleId: string) => {
     void invoke("activate_app", { bundleId }).catch((err) => {
       // Activation can fail when the app is no longer running — keep the
@@ -528,6 +585,50 @@ export function App() {
   // Keyboard navigation — ref callback pattern for stable listener
   const keyHandlerRef = useRef<(e: KeyboardEvent) => void>(() => {});
   keyHandlerRef.current = (e: KeyboardEvent) => {
+    // Easy-motion mode swallows everything: Esc cancels, label match jumps,
+    // single-char keys advance/match labels. Other keys are ignored so the
+    // user can recover by pressing Esc.
+    const em = easyMotionRef.current;
+    if (em.active) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setEasyMotion({ active: false });
+        setEasyMotionVisibleIds(null);
+        return;
+      }
+      if (e.key.length !== 1) return;
+      e.preventDefault();
+      const next = em.prefix + e.key;
+      const labels = easyMotionLabelsRef.current;
+      const targets = easyMotionTargetsRef.current;
+
+      // Exact match → jump.
+      for (const [paneId, label] of labels) {
+        if (label === next) {
+          const target = targets.find((pi) => pi.pane.paneId === paneId);
+          if (target) {
+            setEasyMotion({ active: false });
+            setEasyMotionVisibleIds(null);
+            void invoke("hide_panel");
+            activatePaneItem(target);
+          }
+          return;
+        }
+      }
+      // Prefix match for two-char labels → advance prefix.
+      let hasPrefix = false;
+      for (const label of labels.values()) {
+        if (label.length === 2 && label.startsWith(next)) {
+          hasPrefix = true;
+          break;
+        }
+      }
+      if (hasPrefix) {
+        setEasyMotion({ active: true, prefix: next });
+      }
+      return;
+    }
+
     // Apps view has its own (much smaller) navigation surface. Handle it
     // inline so the main-view branch below stays focused on the unified
     // group/pane list.
@@ -590,6 +691,15 @@ export function App() {
         setAppsSelectedIndex(0);
         setActiveView("apps");
         break;
+      case "e": {
+        if (showHelp) break;
+        e.preventDefault();
+        if (easyMotionTargetsRef.current.length > 0) {
+          setEasyMotionVisibleIds(null);
+          setEasyMotion({ active: true, prefix: "" });
+        }
+        break;
+      }
       case "j":
         if (showHelp) break;
         e.preventDefault();
@@ -806,6 +916,13 @@ export function App() {
                 onActivate={activateAppByBundleId}
               />
             </div>
+          ) : easyMotion.active ? (
+            <EasyMotionGrid
+              groups={easyMotionGroups}
+              labels={easyMotionLabels}
+              prefix={easyMotion.prefix}
+              onVisibilityComputed={setEasyMotionVisibleIds}
+            />
           ) : (
             <div className="h-full overflow-y-auto" ref={scrollContainerRef}>
               {loading ? (
@@ -865,6 +982,19 @@ export function App() {
 }
 
 type SelectedKey = { kind: "pane"; paneId: string } | { kind: "group"; groupKey: string };
+
+// easy-motion only targets running / waiting / notified panes. Fully idle
+// panes are excluded and not rendered at all in mode so the screen stays
+// compact.
+function isEasyMotionTarget(pi: PaneItem): boolean {
+  return (
+    pi.pane.agentStatus === "running" ||
+    pi.pane.agentStatus === "waiting" ||
+    pi.notification !== null
+  );
+}
+
+type EasyMotionState = { active: false } | { active: true; prefix: string };
 
 function keyFromItem(f: FlatItem): SelectedKey {
   if (f.type === "group-header") {

--- a/src/components/easy-motion-grid.tsx
+++ b/src/components/easy-motion-grid.tsx
@@ -1,0 +1,186 @@
+import { useLayoutEffect, useRef } from "react";
+import { Folder, FolderGit2, Circle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { UnifiedGroup, PaneItem, TmuxPane } from "@/lib/types";
+
+interface EasyMotionGridProps {
+  groups: UnifiedGroup[];
+  labels: Map<string, string>;
+  prefix: string;
+  onVisibilityComputed: (visibleIds: Set<string>) => void;
+}
+
+const PANE_ID_ATTR = "data-em-pane-id";
+
+function statusDotClass(status: TmuxPane["agentStatus"]): string {
+  switch (status) {
+    case "running":
+      return "text-green-500 fill-green-500";
+    case "idle":
+      return "text-[var(--text-muted)] fill-[var(--text-muted)]";
+    case "waiting":
+      return "text-amber-500 fill-amber-500";
+    default:
+      return "text-[var(--text-muted)] fill-[var(--text-muted)]";
+  }
+}
+
+export function EasyMotionGrid({
+  groups,
+  labels,
+  prefix,
+  onVisibilityComputed,
+}: EasyMotionGridProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // After entering mode (once `groups` are settled), measure tile positions
+  // and only keep tiles that are fully inside the viewport as jump targets.
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const containerRect = container.getBoundingClientRect();
+    const visibleIds = new Set<string>();
+    container.querySelectorAll(`[${PANE_ID_ATTR}]`).forEach((el) => {
+      const rect = (el as HTMLElement).getBoundingClientRect();
+      // Only count tiles fully inside the viewport. Labeling partially
+      // clipped tiles would force the user to guess at hidden labels.
+      if (rect.top >= containerRect.top && rect.bottom <= containerRect.bottom) {
+        const id = (el as HTMLElement).getAttribute(PANE_ID_ATTR);
+        if (id) visibleIds.add(id);
+      }
+    });
+    onVisibilityComputed(visibleIds);
+  }, [groups, onVisibilityComputed]);
+
+  const totalTargets = groups.reduce((acc, g) => acc + g.paneItems.length, 0);
+
+  return (
+    <div ref={containerRef} className="h-full overflow-y-auto overflow-x-hidden p-1.5">
+      <div className="text-[10px] text-[var(--text-muted)] mb-1 px-0.5 flex items-center justify-between">
+        <span>Press label to jump · Esc to cancel</span>
+        <span className="text-[var(--text-faint)]">
+          {totalTargets} target{totalTargets === 1 ? "" : "s"}
+        </span>
+      </div>
+      {groups.length === 0 ? (
+        <div className="text-[11px] text-[var(--text-muted)] text-center py-8">
+          No running, waiting, or notified panes
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {groups.map((g) => (
+            <RepoSection key={g.groupKey} group={g} labels={labels} prefix={prefix} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RepoSection({
+  group,
+  labels,
+  prefix,
+}: {
+  group: UnifiedGroup;
+  labels: Map<string, string>;
+  prefix: string;
+}) {
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center gap-1 min-w-0 px-0.5 py-0.5 mb-0.5 border-b border-[var(--border-subtle)]">
+        {group.gitBranch ? (
+          <FolderGit2 size={10} className="text-[var(--text-tertiary)] flex-shrink-0" />
+        ) : (
+          <Folder size={10} className="text-[var(--text-tertiary)] flex-shrink-0" />
+        )}
+        <span
+          className="text-[10px] font-medium text-[var(--text-secondary)] truncate"
+          title={group.repoName}
+        >
+          {group.repoName}
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-1">
+        {group.paneItems.map((pi) => (
+          <PaneTile
+            key={pi.pane.paneId}
+            paneItem={pi}
+            label={labels.get(pi.pane.paneId) ?? ""}
+            prefix={prefix}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PaneTile({
+  paneItem,
+  label,
+  prefix,
+}: {
+  paneItem: PaneItem;
+  label: string;
+  prefix: string;
+}) {
+  const { pane, notification } = paneItem;
+  const hasLabel = label.length > 0;
+  const matchesPrefix = prefix.length === 0 || (hasLabel && label.startsWith(prefix));
+  const dimmed = !matchesPrefix;
+  const subtitle =
+    pane.teamName ??
+    (pane.windowName && pane.windowName.length > 0 ? pane.windowName : pane.sessionName) ??
+    pane.paneId;
+  const tooltip = `${subtitle} (${pane.paneId})`;
+
+  return (
+    <div
+      {...{ [PANE_ID_ATTR]: pane.paneId }}
+      className={cn(
+        "relative rounded border border-[var(--border-subtle)] bg-[var(--hover-bg)]",
+        "flex flex-col items-center justify-center px-1 py-1 min-h-[44px] w-[76px]",
+        "transition-opacity",
+        dimmed && "opacity-20",
+        notification && "ring-1 ring-blue-500/50",
+      )}
+      title={tooltip}
+    >
+      <LabelBadge label={label} prefix={prefix} dimmed={dimmed} />
+      <div className="mt-0.5 flex items-center gap-0.5 max-w-full min-w-0">
+        {pane.agentType && (
+          <Circle size={5} className={cn("flex-shrink-0", statusDotClass(pane.agentStatus))} />
+        )}
+        <span className="text-[9px] text-[var(--text-muted)] truncate leading-tight">
+          {subtitle}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function LabelBadge({ label, prefix, dimmed }: { label: string; prefix: string; dimmed: boolean }) {
+  if (label.length === 0) {
+    return (
+      <span className="inline-flex items-center justify-center w-[26px] h-[22px] rounded text-[11px] font-mono border border-dashed border-[var(--border-subtle)] text-[var(--text-faint)]">
+        ·
+      </span>
+    );
+  }
+  const isTwoChar = label.length === 2;
+  const consumed = !dimmed && prefix.length > 0 ? prefix : "";
+  const remaining = label.slice(consumed.length);
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center justify-center h-[22px] rounded font-mono font-bold leading-none",
+        "bg-yellow-400 text-black border border-yellow-500 shadow-[0_0_4px_rgba(250,204,21,0.4)]",
+        isTwoChar ? "px-1.5 text-[13px] gap-px" : "w-[26px] text-[14px]",
+      )}
+    >
+      {consumed && <span className="opacity-50">{consumed}</span>}
+      <span>{remaining}</span>
+    </span>
+  );
+}

--- a/src/components/keybind-help.tsx
+++ b/src/components/keybind-help.tsx
@@ -2,11 +2,18 @@ interface KeybindHelpProps {
   onClose: () => void;
 }
 
-const KEYBINDS = [
+interface Keybind {
+  key: string;
+  action: string;
+  experimental?: boolean;
+}
+
+const KEYBINDS: readonly Keybind[] = [
   { key: "j", action: "Next" },
   { key: "k", action: "Previous" },
   { key: "Enter", action: "Open / Fold" },
   { key: "a", action: "Apps view" },
+  { key: "e", action: "Easy motion jump", experimental: true },
   { key: "d", action: "Delete notif" },
   { key: "D", action: "Delete all notifs" },
   { key: "C", action: "Collapse all" },
@@ -15,7 +22,7 @@ const KEYBINDS = [
   { key: "T", action: "Toggle non-agent panes" },
   { key: "Esc", action: "Close" },
   { key: "?", action: "Help" },
-] as const;
+];
 
 export function KeybindHelp({ onClose }: KeybindHelpProps) {
   return (
@@ -26,7 +33,7 @@ export function KeybindHelp({ onClose }: KeybindHelpProps) {
       tabIndex={-1}
     >
       <div className="flex flex-col gap-2" onClick={(e) => e.stopPropagation()}>
-        {KEYBINDS.map(({ key, action }) => (
+        {KEYBINDS.map(({ key, action, experimental }) => (
           <div key={key} className="flex items-center gap-3">
             <span
               className="w-12 text-center text-[11px] font-mono py-0.5 px-1.5 rounded"
@@ -41,6 +48,11 @@ export function KeybindHelp({ onClose }: KeybindHelpProps) {
             <span className="text-[11px]" style={{ color: "var(--text-secondary)" }}>
               {action}
             </span>
+            {experimental && (
+              <span className="text-[9px] font-medium uppercase tracking-wide px-1 py-px rounded bg-amber-500/20 text-amber-400 border border-amber-500/40">
+                experimental
+              </span>
+            )}
           </div>
         ))}
       </div>

--- a/src/lib/easy-motion-labels.ts
+++ b/src/lib/easy-motion-labels.ts
@@ -1,0 +1,28 @@
+export const EASY_MOTION_KEYS = "asdfjkl;ghetyuiopqwrvbnmcxz";
+
+export function assignLabels(count: number, keys: string = EASY_MOTION_KEYS): string[] {
+  if (count <= 0) return [];
+  const k = keys.length;
+  if (count <= k) {
+    return keys.slice(0, count).split("");
+  }
+
+  // flash.nvim style: use the last p keys as prefixes for two-char labels.
+  // Single-char labels = (k - p), two-char labels = p * k.
+  // (k - p) + p * k >= count  <=>  p >= (count - k) / (k - 1)
+  const p = Math.min(k, Math.ceil((count - k) / (k - 1)));
+
+  const singles: string[] = keys.slice(0, k - p).split("");
+  const doubles: string[] = [];
+  for (let i = k - p; i < k; i++) {
+    for (let j = 0; j < k; j++) {
+      doubles.push(keys[i] + keys[j]);
+    }
+  }
+
+  const result = [...singles, ...doubles];
+  // Capacity is 26 + 26*26 = 702. Anything beyond that returns an empty
+  // string so the UI can render it as "no label".
+  while (result.length < count) result.push("");
+  return result.slice(0, count);
+}


### PR DESCRIPTION
## Summary

- Adds an experimental flash.nvim-inspired easy-motion jump to the notification panel: press `e` to switch the list into a wrap grid where each jumpable pane gets a 1–2 char label, then press that label to jump (uses the existing `focus_terminal` flow).
- Limits jump targets to `running` / `waiting` / notified panes — idle-without-notification panes are hidden in the mode so the grid stays compact.
- Only labels panes whose tile is **fully inside the viewport** (flash.nvim style) so the user never has to guess at off-screen labels.

## Changes

### Frontend
- `src/lib/easy-motion-labels.ts` *(new)* — flash.nvim-style label assignment over the home-row sequence `asdfjkl;ghetyuiopqwrvbnmcxz`. ≤26 targets get single-char labels; >26 falls back to two-char labels by reusing the tail keys as prefixes.
- `src/components/easy-motion-grid.tsx` *(new)* — Grid view rendered while easy-motion is active. Each repo becomes a section with `flex-wrap` 76px tiles, a yellow label badge, and a status dot + truncated subtitle. `useLayoutEffect` measures tile bounds and reports the visible set back to the parent.
- `src/App.tsx` — Adds `easyMotion` state, `easyMotionGroups` / `easyMotionTargets` / `easyMotionLabels` memos, the visible-id state, and the keyboard handler branch that swallows input while the mode is active. `e` enters mode, label match jumps + hides panel, `Escape` and `panel:shown` exit.
- `src/components/keybind-help.tsx` — Adds the `e` keybind row with a small `experimental` badge.

### Spell check
- `cspell.json` — Whitelists the home-row key sequences `asdfjkl` and `ghetyuiopqwrvbnmcxz`.

## How it works

1. Press `e` while the panel is open.
2. The list switches to a grid: each repo is a section, tiles wrap inside it, every running / waiting / notified pane (visible in the viewport) gets a yellow 1–2 char label.
3. Type the label characters; on a full match the panel hides and the matched pane is focused via `focus_terminal`.
4. `Escape` cancels and goes back to the list.

## Test plan

- [ ] Open the panel with several running/idle/waiting panes — `e` opens the grid, idle panes (no notification) are not shown.
- [ ] Press a label single-char — panel hides, terminal switches to that tmux pane.
- [ ] With >26 jumpable panes, two-char labels render and resolve correctly (`a` → narrow → `s` → jump).
- [ ] When tiles overflow the panel height, only fully-visible tiles get a label; off-screen tiles render with no badge.
- [ ] `Escape` exits mode without jumping.
- [ ] Re-opening the panel (menu bar click / hotkey) always starts in normal list view.
- [ ] `?` help panel shows the new `e` row with the `experimental` badge.
