### PR TITLE
feat: highlight active repo group with cyan ring

### DIFF
--- a/src/components/repo-group.tsx
+++ b/src/components/repo-group.tsx
@@ -61,8 +61,15 @@ export function RepoGroup({
   const idleCount = paneItems.filter((pi) => pi.pane.agentStatus === "idle").length;
   const waitingCount = paneItems.filter((pi) => pi.pane.agentStatus === "waiting").length;
 
+  const isGroupActive =
+    isHeaderSelected ||
+    (selectedPaneId !== null && paneItems.some((pi) => pi.pane.paneId === selectedPaneId));
+
   return (
-    <div className="border-b border-[var(--border-subtle)] last:border-b-0">
+    <div
+      className="border-b border-[var(--border-subtle)] last:border-b-0"
+      style={isGroupActive ? { boxShadow: "var(--group-selection-ring)" } : undefined}
+    >
       <button
         tabIndex={-1}
         data-nav-index={headerNavIndex}
@@ -85,7 +92,14 @@ export function RepoGroup({
           ) : (
             <Folder size={13} className="text-[var(--text-tertiary)]" />
           )}
-          <span className="text-xs font-medium text-[var(--text-secondary)] truncate flex-1">
+          <span
+            className={cn(
+              "text-xs truncate flex-1",
+              isGroupActive
+                ? "font-semibold text-[var(--text-primary)]"
+                : "font-medium text-[var(--text-secondary)]",
+            )}
+          >
             {repoName}
           </span>
           <button
@@ -116,7 +130,14 @@ export function RepoGroup({
         {/* Line 2: branch */}
         {gitBranch && (
           <div className="flex items-center pl-[33px] mt-0.5">
-            <span className="flex items-center gap-0.5 text-[10px] text-[var(--text-muted)] truncate">
+            <span
+              className={cn(
+                "flex items-center gap-0.5 text-[10px] truncate",
+                isGroupActive
+                  ? "font-medium text-[var(--text-secondary)]"
+                  : "text-[var(--text-muted)]",
+              )}
+            >
               <GitBranch size={10} className="flex-shrink-0" />
               {gitBranch}
             </span>

--- a/src/index.css
+++ b/src/index.css
@@ -36,6 +36,8 @@
 
   --new-highlight-bg: rgba(59, 130, 246, 0.08);
   --selection-ring: inset 0 0 0 1.5px rgba(0, 0, 0, 0.15);
+  --group-selection-ring:
+    inset 0 0 0 1.5px rgba(8, 145, 178, 0.7), 0 0 12px rgba(8, 145, 178, 0.25);
 
   /* Settings UI tokens */
   --surface-card: rgba(255, 255, 255, 0.6);
@@ -86,6 +88,8 @@
 
     --new-highlight-bg: rgba(59, 130, 246, 0.12);
     --selection-ring: inset 0 0 0 1.5px rgba(255, 255, 255, 0.2);
+    --group-selection-ring:
+      inset 0 0 0 1.5px rgba(34, 211, 238, 0.85), 0 0 14px rgba(34, 211, 238, 0.35);
 
     --surface-card: rgba(255, 255, 255, 0.04);
     --surface-elevated: rgba(60, 60, 62, 0.95);


### PR DESCRIPTION
## Summary
- Wrap each `RepoGroup` with a new `--group-selection-ring` token (inset cyan stroke + soft outer glow) that lights up whenever the keyboard cursor is on the group's header or on any pane within it.
- Brighten the selected group's repo name (`font-medium → font-semibold`, `text-secondary → text-primary`) and the branch label (`text-muted → font-medium / text-secondary`) so it is obvious at a glance which repository the cursor is currently navigating.

## Files
- `src/components/repo-group.tsx`: derive `isGroupActive` from `isHeaderSelected ∨ (selectedPaneId ∈ paneItems)`; apply `--group-selection-ring` as `boxShadow` on the outer wrapper; bump repo name / branch text emphasis when active.
- `src/index.css`: add `--group-selection-ring` token in light + dark themes (light: rgba(8,145,178,…) / dark: rgba(34,211,238,…)).

