### PR TITLE
feat: add vim-style fuzzy search to main panel

### DIFF
--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -13,7 +13,8 @@ tauri_panel! {
     })
 
     panel_event!(AgentNotifyPanelEventHandler {
-        window_did_resign_key(notification: &NSNotification) -> ()
+        window_did_resign_key(notification: &NSNotification) -> (),
+        window_should_close(window: &NSWindow) -> Bool
     })
 }
 
@@ -46,6 +47,11 @@ pub fn init(app_handle: &tauri::AppHandle) -> tauri::Result<()> {
             panel.hide();
         }
     });
+    // Block NSPanel's default Esc → cancelOperation: → performClose: → close
+    // path. Hiding always goes through `panel.hide()` (orderOut:), so blocking
+    // close has no functional cost — but stops the panel from disappearing when
+    // the user presses Esc inside the SearchBar input.
+    event_handler.window_should_close(|_window| Bool::new(false));
 
     panel.set_event_handler(Some(event_handler.as_ref()));
 

--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -1,8 +1,63 @@
+#![allow(deprecated)] // msg_send_id! is deprecated in objc2 0.6, but still works
+
+use std::sync::OnceLock;
+
+use block2::RcBlock;
+use objc2::msg_send_id;
+use objc2_app_kit::NSEventMask;
 use tauri::tray::TrayIconId;
+use tauri::Emitter;
 use tauri::{Manager, PhysicalPosition, PhysicalSize, Position, Size};
 use tauri_nspanel::{
     tauri_panel, CollectionBehavior, ManagerExt, PanelLevel, StyleMask, WebviewWindowExt,
 };
+
+static ESC_MONITOR_INSTALLED: OnceLock<()> = OnceLock::new();
+
+// Intercept Esc at the AppKit local-event-monitor layer, before NSWindow's
+// `cancelOperation:` (which on NSPanel calls into the close path even when
+// `windowShouldClose:` returns false in some configurations) and before the
+// keystroke reaches WebKit. We swallow it and re-deliver as a Tauri event so
+// the JS side stays the single source of truth for Esc semantics inside the
+// panel (close help / cancel search / leave apps view / hide panel).
+fn install_esc_monitor(app_handle: &tauri::AppHandle) {
+    let handle = app_handle.clone();
+    ESC_MONITOR_INSTALLED.get_or_init(|| {
+        unsafe {
+            let block = RcBlock::new(
+                move |event: std::ptr::NonNull<objc2_app_kit::NSEvent>| -> *mut objc2_app_kit::NSEvent {
+                    let event_ref = event.as_ref();
+                    let key_code: u16 = objc2::msg_send![event_ref, keyCode];
+                    if key_code != 0x35 {
+                        return event.as_ptr();
+                    }
+
+                    // Only intercept when the event targets our main panel.
+                    let panel_window_num: i64 = match handle.get_webview_panel("main") {
+                        Ok(p) => objc2::msg_send![p.as_panel(), windowNumber],
+                        Err(_) => return event.as_ptr(),
+                    };
+                    let event_window_num: i64 = objc2::msg_send![event_ref, windowNumber];
+                    if event_window_num != panel_window_num {
+                        return event.as_ptr();
+                    }
+
+                    let _ = handle.emit("panel:esc", ());
+                    std::ptr::null_mut()
+                },
+            );
+
+            let mask = NSEventMask::KeyDown;
+            let _monitor: Option<objc2::rc::Retained<objc2_foundation::NSObject>> = msg_send_id![
+                objc2_app_kit::NSEvent::class(),
+                addLocalMonitorForEventsMatchingMask: mask.0,
+                handler: &*block
+            ];
+            std::mem::forget(_monitor);
+            std::mem::forget(block);
+        }
+    });
+}
 
 tauri_panel! {
     panel!(AgentNotifyPanel {
@@ -47,13 +102,14 @@ pub fn init(app_handle: &tauri::AppHandle) -> tauri::Result<()> {
             panel.hide();
         }
     });
-    // Block NSPanel's default Esc → cancelOperation: → performClose: → close
-    // path. Hiding always goes through `panel.hide()` (orderOut:), so blocking
-    // close has no functional cost — but stops the panel from disappearing when
-    // the user presses Esc inside the SearchBar input.
+    // Defensive: any future programmatic close request goes through this
+    // delegate, which always returns false. Hiding always goes through
+    // `panel.hide()` (orderOut:), so blocking close has no functional cost.
     event_handler.window_should_close(|_window| Bool::new(false));
 
     panel.set_event_handler(Some(event_handler.as_ref()));
+
+    install_esc_monitor(app_handle);
 
     Ok(())
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,9 @@ import { PanelHeader } from "@/components/panel-header";
 import { AppsView } from "@/components/apps-view";
 import { RepoGroup } from "@/components/repo-group";
 import { KeybindHelp } from "@/components/keybind-help";
+import { SearchBar } from "@/components/search-bar";
 import { Bell } from "lucide-react";
+import { fuzzyScore } from "@/lib/fuzzy";
 import type { Notification, PanelView, UnifiedGroup, FlatItem, PaneItem } from "@/lib/types";
 
 export function App() {
@@ -44,6 +46,11 @@ export function App() {
   const autoExpandTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [recentlyCopiedPaneId, setRecentlyCopiedPaneId] = useState<string | null>(null);
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [searchActive, setSearchActive] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchCursor, setSearchCursor] = useState(0);
+  const savedKeyBeforeSearchRef = useRef<SelectedKey | null>(null);
 
   const needFetchVersionRef = useRef(-1);
   const repositionCancelledRef = useRef(false);
@@ -321,6 +328,61 @@ export function App() {
     return result;
   }, [displayGroups, collapsedGroups]);
 
+  // Group-header indices in document order so n/N traverse linearly, vim style.
+  const searchMatches = useMemo(() => {
+    const q = searchQuery.trim();
+    if (q === "") return [] as number[];
+    const out: number[] = [];
+    const groupByKey = new Map<string, UnifiedGroup>();
+    for (const ug of displayGroups) groupByKey.set(ug.groupKey, ug);
+    for (let i = 0; i < flatItems.length; i++) {
+      const item = flatItems[i];
+      if (item.type !== "group-header") continue;
+      const ug = groupByKey.get(item.groupKey);
+      if (!ug) continue;
+      const target = `${ug.repoName} ${ug.gitBranch ?? ""}`.trim();
+      if (fuzzyScore(q, target) !== null) out.push(i);
+    }
+    return out;
+  }, [searchQuery, flatItems, displayGroups]);
+
+  useEffect(() => {
+    if (searchMatches.length === 0) {
+      if (searchCursor !== 0) setSearchCursor(0);
+      return;
+    }
+    if (searchCursor >= searchMatches.length) setSearchCursor(0);
+  }, [searchMatches, searchCursor]);
+
+  // Group keys whose header matched the query — scopes HighlightText so
+  // non-matching groups don't show stray amber spans.
+  const matchedGroupKeys = useMemo(() => {
+    const set = new Set<string>();
+    for (const idx of searchMatches) {
+      const item = flatItems[idx];
+      if (item?.type === "group-header") set.add(item.groupKey);
+    }
+    return set;
+  }, [searchMatches, flatItems]);
+
+  // Read latest matches/items via refs so this effect only fires on query
+  // change — subscribing to flatItems would reset the cursor on every poll.
+  const searchMatchesRef = useRef(searchMatches);
+  searchMatchesRef.current = searchMatches;
+  const flatItemsRef = useRef(flatItems);
+  flatItemsRef.current = flatItems;
+  useEffect(() => {
+    if (!searchActive) return;
+    const matches = searchMatchesRef.current;
+    if (matches.length === 0) return;
+    setSearchCursor(0);
+    const target = flatItemsRef.current[matches[0]];
+    if (target) {
+      repositionCancelledRef.current = true;
+      setSelectedKey(keyFromItem(target));
+    }
+  }, [searchQuery, searchActive]);
+
   // Resolve the numeric index of the currently-selected key. Falls back to the
   // last known index (clamped) when the key disappears so the cursor stays near
   // its old position instead of snapping to the top or activating a random item.
@@ -351,6 +413,11 @@ export function App() {
       // Always start on the main view — the apps view is a one-shot launcher.
       setActiveView("main");
       setAppsSelectedIndex(0);
+      // Search state is per-session — clear it on every panel show.
+      setSearchActive(false);
+      setSearchQuery("");
+      setSearchCursor(0);
+      savedKeyBeforeSearchRef.current = null;
     });
     return () => {
       unlisten.then((f) => f()).catch(() => {});
@@ -508,6 +575,31 @@ export function App() {
     }
   }, [autoExpandedPaneId, selectedIndex]);
 
+  const cancelSearch = useCallback(() => {
+    setSearchActive(false);
+    setSearchQuery("");
+    setSearchCursor(0);
+    if (savedKeyBeforeSearchRef.current) {
+      repositionCancelledRef.current = true;
+      setSelectedKey(savedKeyBeforeSearchRef.current);
+      savedKeyBeforeSearchRef.current = null;
+    }
+  }, []);
+
+  const jumpToMatch = useCallback(
+    (direction: 1 | -1) => {
+      const matches = searchMatches;
+      if (matches.length === 0) return;
+      const next = (searchCursor + direction + matches.length) % matches.length;
+      const target = flatItems[matches[next]];
+      if (!target) return;
+      repositionCancelledRef.current = true;
+      setSearchCursor(next);
+      setSelectedKey(keyFromItem(target));
+    },
+    [searchMatches, searchCursor, flatItems],
+  );
+
   const activatePaneItem = useCallback((paneItem: PaneItem) => {
     if (paneItem.notification) {
       void invoke("delete_notifications_by_pane", {
@@ -532,6 +624,17 @@ export function App() {
   // Keyboard navigation — ref callback pattern for stable listener
   const keyHandlerRef = useRef<(e: KeyboardEvent) => void>(() => {});
   keyHandlerRef.current = (e: KeyboardEvent) => {
+    // SearchBar's own input owns the keystrokes (Enter/Esc/typing). Skip
+    // the global handler so j/k/d don't fire while the user types a query.
+    // Esc is a fallback escape hatch — works even when the input lost focus
+    // (e.g. user clicked elsewhere in the panel).
+    if (searchActive) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        cancelSearch();
+      }
+      return;
+    }
     // Apps view has its own (much smaller) navigation surface. Handle it
     // inline so the main-view branch below stays focused on the unified
     // group/pane list.
@@ -806,6 +909,29 @@ export function App() {
         }
         break;
       }
+      case "/": {
+        if (showHelp) break;
+        e.preventDefault();
+        savedKeyBeforeSearchRef.current = selectedKeyRef.current;
+        setSearchQuery("");
+        setSearchCursor(0);
+        setSearchActive(true);
+        break;
+      }
+      case "n": {
+        if (showHelp || e.shiftKey || e.metaKey || e.ctrlKey || e.altKey) break;
+        if (searchMatches.length === 0) break;
+        e.preventDefault();
+        jumpToMatch(1);
+        break;
+      }
+      case "N": {
+        if (showHelp || e.metaKey || e.ctrlKey || e.altKey) break;
+        if (searchMatches.length === 0) break;
+        e.preventDefault();
+        jumpToMatch(-1);
+        break;
+      }
     }
   };
   useEffect(() => {
@@ -905,6 +1031,7 @@ export function App() {
                     autoExpandedPaneId={autoExpandedPaneId}
                     recentlyCopiedPaneId={recentlyCopiedPaneId}
                     statusReady={statusReady}
+                    highlightQuery={matchedGroupKeys.has(ug.groupKey) ? searchQuery : ""}
                     onDeleteNotification={(id) => void deleteNotification(id)}
                     onDeleteByPanes={(paneIds) => void deleteByPanes(paneIds)}
                     onToggleRepoMute={(path) => void toggleRepoMute(path)}
@@ -915,7 +1042,7 @@ export function App() {
             </div>
           )}
           {showHelp && <KeybindHelp onClose={() => setShowHelp(false)} />}
-          {!showHelp && (
+          {!showHelp && !searchActive && (
             <button
               type="button"
               tabIndex={-1}
@@ -927,6 +1054,16 @@ export function App() {
             </button>
           )}
         </div>
+        {searchActive && activeView === "main" && (
+          <SearchBar
+            query={searchQuery}
+            matchCount={searchMatches.length}
+            matchPosition={searchMatches.length > 0 ? searchCursor + 1 : 0}
+            onChange={setSearchQuery}
+            onConfirm={() => setSearchActive(false)}
+            onCancel={cancelSearch}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -649,7 +649,7 @@ export function App() {
           if (showHelp) {
             setShowHelp(false);
           } else {
-            void invoke("hide_panel");
+            setActiveView("main");
           }
           return;
         case "j":

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -403,6 +403,32 @@ export function App() {
     return clamped;
   }, [flatItems, selectedKey]);
 
+  // Esc routing — the Rust side intercepts Esc at the AppKit local-monitor
+  // layer and re-delivers it as `panel:esc`. The native event never reaches
+  // WebKit, so all Esc semantics inside the panel funnel through here.
+  const handleEscRef = useRef<() => void>(() => {});
+  handleEscRef.current = () => {
+    if (showHelp) {
+      setShowHelp(false);
+      return;
+    }
+    if (searchActive) {
+      cancelSearch();
+      return;
+    }
+    if (activeView === "apps") {
+      setActiveView("main");
+      return;
+    }
+    void invoke("hide_panel");
+  };
+  useEffect(() => {
+    const unlisten = listen("panel:esc", () => handleEscRef.current());
+    return () => {
+      unlisten.then((f) => f()).catch(() => {});
+    };
+  }, []);
+
   // Reset selection when panel is shown
   useEffect(() => {
     const unlisten = listen("panel:shown", () => {
@@ -621,20 +647,14 @@ export function App() {
     void invoke("hide_panel");
   }, []);
 
-  // Keyboard navigation — ref callback pattern for stable listener
+  // Keyboard navigation — ref callback pattern for stable listener.
+  // Esc is intercepted at the AppKit level and re-delivered via `panel:esc`
+  // (handled by handleEscRef above), so this handler never sees it.
   const keyHandlerRef = useRef<(e: KeyboardEvent) => void>(() => {});
   keyHandlerRef.current = (e: KeyboardEvent) => {
-    // SearchBar's own input owns the keystrokes (Enter/Esc/typing). Skip
-    // the global handler so j/k/d don't fire while the user types a query.
-    // Esc is a fallback escape hatch — works even when the input lost focus
-    // (e.g. user clicked elsewhere in the panel).
-    if (searchActive) {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        cancelSearch();
-      }
-      return;
-    }
+    // While the search input is mounted, swallow keystrokes so j/k/d don't
+    // fire underneath the typing cursor.
+    if (searchActive) return;
     // Apps view has its own (much smaller) navigation surface. Handle it
     // inline so the main-view branch below stays focused on the unified
     // group/pane list.
@@ -643,14 +663,6 @@ export function App() {
         case "?":
           e.preventDefault();
           setShowHelp((prev) => !prev);
-          return;
-        case "Escape":
-          e.preventDefault();
-          if (showHelp) {
-            setShowHelp(false);
-          } else {
-            setActiveView("main");
-          }
           return;
         case "j":
           if (showHelp) return;
@@ -703,14 +715,6 @@ export function App() {
       case "?":
         e.preventDefault();
         setShowHelp((prev) => !prev);
-        break;
-      case "Escape":
-        e.preventDefault();
-        if (showHelp) {
-          setShowHelp(false);
-        } else {
-          void invoke("hide_panel");
-        }
         break;
       case "a":
         if (showHelp) break;
@@ -1061,7 +1065,6 @@ export function App() {
             matchPosition={searchMatches.length > 0 ? searchCursor + 1 : 0}
             onChange={setSearchQuery}
             onConfirm={() => setSearchActive(false)}
-            onCancel={cancelSearch}
           />
         )}
       </div>

--- a/src/components/apps-setup.tsx
+++ b/src/components/apps-setup.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { Check, Pencil, Search, Trash2, X } from "lucide-react";
+import { fuzzyScore } from "@/lib/fuzzy";
 import type { AllowedApp, RunningApp } from "@/lib/types";
 
 interface AppsSetupProps {
@@ -15,30 +16,6 @@ interface Candidate {
   name: string;
   iconDataUrl?: string;
   running: boolean;
-}
-
-/**
- * Subsequence-based fuzzy match: every character of `query` must appear in
- * `text` in order (case-insensitive). Returns a score (lower = better) when
- * matched, or `null` when not. Score combines the match-window length and
- * the index of the first hit so that earlier / tighter matches rank higher.
- */
-function fuzzyScore(query: string, text: string): number | null {
-  if (!query) return 0;
-  const q = query.toLowerCase();
-  const t = text.toLowerCase();
-  let qi = 0;
-  let firstHit = -1;
-  let lastHit = -1;
-  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
-    if (t[ti] === q[qi]) {
-      if (firstHit < 0) firstHit = ti;
-      lastHit = ti;
-      qi++;
-    }
-  }
-  if (qi !== q.length) return null;
-  return (lastHit - firstHit) * 100 + firstHit;
 }
 
 export function AppsSetup({ allowedApps, onChange }: AppsSetupProps) {

--- a/src/components/highlight-text.tsx
+++ b/src/components/highlight-text.tsx
@@ -1,0 +1,53 @@
+import { Fragment } from "react";
+import { fuzzyMatch } from "@/lib/fuzzy";
+
+interface Props {
+  text: string;
+  query: string;
+}
+
+export function HighlightText({ text, query }: Props) {
+  if (query.trim() === "") return <>{text}</>;
+  const match = fuzzyMatch(query, text);
+  if (!match || match.positions.length === 0) return <>{text}</>;
+
+  // Coalesce contiguous positions into single highlighted segments to avoid
+  // one <span> per char, which would also defeat any letter-spacing / kerning.
+  const hits = new Set(match.positions);
+  const segments: Array<{ text: string; matched: boolean }> = [];
+  let buf = "";
+  let bufMatched = false;
+  for (let i = 0; i < text.length; i++) {
+    const matched = hits.has(i);
+    if (i === 0) {
+      buf = text[i];
+      bufMatched = matched;
+      continue;
+    }
+    if (matched === bufMatched) {
+      buf += text[i];
+    } else {
+      segments.push({ text: buf, matched: bufMatched });
+      buf = text[i];
+      bufMatched = matched;
+    }
+  }
+  if (buf) segments.push({ text: buf, matched: bufMatched });
+
+  return (
+    <>
+      {segments.map((seg, i) =>
+        seg.matched ? (
+          <span
+            key={i}
+            className="font-semibold bg-amber-500/25 text-[var(--text-primary)] rounded-sm"
+          >
+            {seg.text}
+          </span>
+        ) : (
+          <Fragment key={i}>{seg.text}</Fragment>
+        ),
+      )}
+    </>
+  );
+}

--- a/src/components/highlight-text.tsx
+++ b/src/components/highlight-text.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from "react";
-import { fuzzyMatch } from "@/lib/fuzzy";
+import { findMatchPositions } from "@/lib/fuzzy";
 
 interface Props {
   text: string;
@@ -8,12 +8,12 @@ interface Props {
 
 export function HighlightText({ text, query }: Props) {
   if (query.trim() === "") return <>{text}</>;
-  const match = fuzzyMatch(query, text);
-  if (!match || match.positions.length === 0) return <>{text}</>;
+  const positions = findMatchPositions(query, text);
+  if (positions.length === 0) return <>{text}</>;
 
   // Coalesce contiguous positions into single highlighted segments to avoid
   // one <span> per char, which would also defeat any letter-spacing / kerning.
-  const hits = new Set(match.positions);
+  const hits = new Set(positions);
   const segments: Array<{ text: string; matched: boolean }> = [];
   let buf = "";
   let bufMatched = false;

--- a/src/components/keybind-help.tsx
+++ b/src/components/keybind-help.tsx
@@ -16,6 +16,9 @@ const KEYBINDS = [
   { key: "F", action: "Filter action needed" },
   { key: "T", action: "Toggle non-agent panes" },
   { key: "y", action: "Copy pane prompt" },
+  { key: "/", action: "Search repos" },
+  { key: "n", action: "Next match" },
+  { key: "N", action: "Prev match" },
   { key: "Esc", action: "Close" },
   { key: "?", action: "Help" },
 ] as const;

--- a/src/components/keybind-help.tsx
+++ b/src/components/keybind-help.tsx
@@ -2,51 +2,84 @@ interface KeybindHelpProps {
   onClose: () => void;
 }
 
-const KEYBINDS = [
-  { key: "j", action: "Next" },
-  { key: "k", action: "Previous" },
-  { key: "gg", action: "Jump to top" },
-  { key: "G", action: "Jump to bottom" },
-  { key: "Enter", action: "Open / Fold" },
-  { key: "a", action: "Apps view" },
-  { key: "d", action: "Delete notif" },
-  { key: "D", action: "Delete all notifs" },
-  { key: "C", action: "Collapse all" },
-  { key: "E", action: "Expand all" },
-  { key: "F", action: "Filter action needed" },
-  { key: "T", action: "Toggle non-agent panes" },
-  { key: "y", action: "Copy pane prompt" },
-  { key: "/", action: "Search repos" },
-  { key: "n", action: "Next match" },
-  { key: "N", action: "Prev match" },
-  { key: "Esc", action: "Close" },
-  { key: "?", action: "Help" },
-] as const;
+interface Keybind {
+  key: string;
+  action: string;
+}
+
+interface Section {
+  title: string;
+  binds: Keybind[];
+}
+
+const SECTIONS: Section[] = [
+  {
+    title: "Navigation",
+    binds: [
+      { key: "j", action: "Next" },
+      { key: "k", action: "Previous" },
+      { key: "gg", action: "Jump to top" },
+      { key: "G", action: "Jump to bottom" },
+      { key: "Tab", action: "Next notif" },
+      { key: "⇧Tab", action: "Prev notif" },
+    ],
+  },
+  {
+    title: "Search",
+    binds: [
+      { key: "/", action: "Search repos" },
+      { key: "n", action: "Next match" },
+      { key: "N", action: "Prev match" },
+    ],
+  },
+  {
+    title: "Actions",
+    binds: [
+      { key: "Enter", action: "Open / Fold" },
+      { key: "d", action: "Delete notif" },
+      { key: "D", action: "Delete all" },
+      { key: "C", action: "Collapse all" },
+      { key: "E", action: "Expand all" },
+      { key: "F", action: "Filter notified" },
+      { key: "T", action: "Non-agent panes" },
+      { key: "y", action: "Copy $TMUX_PANE" },
+      { key: "a", action: "Apps view" },
+    ],
+  },
+  {
+    title: "Misc",
+    binds: [
+      { key: "?", action: "Help" },
+      { key: "Esc", action: "Close" },
+    ],
+  },
+];
 
 export function KeybindHelp({ onClose }: KeybindHelpProps) {
   return (
     <div
-      className="absolute inset-0 z-10 flex items-center justify-center"
-      style={{ backgroundColor: "var(--panel-bg)" }}
+      className="absolute inset-0 z-10 flex items-start justify-center overflow-y-auto px-4 py-4 bg-[var(--panel-bg)]"
       onClick={onClose}
       tabIndex={-1}
     >
-      <div className="flex flex-col gap-2" onClick={(e) => e.stopPropagation()}>
-        {KEYBINDS.map(({ key, action }) => (
-          <div key={key} className="flex items-center gap-3">
-            <span
-              className="w-12 text-center text-[11px] font-mono py-0.5 px-1.5 rounded"
-              style={{
-                backgroundColor: "var(--hover-bg-strong)",
-                color: "var(--text-primary)",
-                border: "1px solid var(--border-subtle)",
-              }}
-            >
-              {key}
-            </span>
-            <span className="text-[11px]" style={{ color: "var(--text-secondary)" }}>
-              {action}
-            </span>
+      <div className="w-full flex flex-col gap-3" onClick={(e) => e.stopPropagation()}>
+        {SECTIONS.map((section) => (
+          <div key={section.title} className="flex flex-col gap-1">
+            <div className="text-[9px] uppercase tracking-wider font-semibold text-[var(--text-muted)] pl-1">
+              {section.title}
+            </div>
+            <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+              {section.binds.map(({ key, action }) => (
+                <div key={key} className="flex items-center gap-2">
+                  <span className="min-w-[44px] text-center text-[10px] font-mono py-0.5 px-1.5 rounded bg-[var(--hover-bg-strong)] text-[var(--text-primary)] border border-[var(--border-subtle)]">
+                    {key}
+                  </span>
+                  <span className="text-[11px] text-[var(--text-secondary)] truncate">
+                    {action}
+                  </span>
+                </div>
+              ))}
+            </div>
           </div>
         ))}
       </div>

--- a/src/components/repo-group.tsx
+++ b/src/components/repo-group.tsx
@@ -13,6 +13,7 @@ import { useMemo } from "react";
 import { cn } from "@/lib/utils";
 import type { PaneItem, FlatItem } from "@/lib/types";
 import { PaneCard } from "./pane-card";
+import { HighlightText } from "./highlight-text";
 
 interface RepoGroupProps {
   groupKey: string;
@@ -30,6 +31,7 @@ interface RepoGroupProps {
   autoExpandedPaneId: string | null;
   recentlyCopiedPaneId: string | null;
   statusReady: boolean;
+  highlightQuery: string;
   onDeleteNotification: (id: number) => void;
   onDeleteByPanes: (paneIds: string[]) => void;
   onToggleRepoMute: (repoPath: string) => void;
@@ -52,6 +54,7 @@ export function RepoGroup({
   autoExpandedPaneId,
   recentlyCopiedPaneId,
   statusReady,
+  highlightQuery,
   onDeleteNotification,
   onDeleteByPanes,
   onToggleRepoMute,
@@ -102,7 +105,7 @@ export function RepoGroup({
                 : "font-medium text-[var(--text-secondary)]",
             )}
           >
-            {repoName}
+            <HighlightText text={repoName} query={highlightQuery} />
           </span>
           <button
             tabIndex={-1}
@@ -141,7 +144,7 @@ export function RepoGroup({
               )}
             >
               <GitBranch size={10} className="flex-shrink-0" />
-              {gitBranch}
+              <HighlightText text={gitBranch} query={highlightQuery} />
             </span>
           </div>
         )}

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -6,7 +6,6 @@ interface SearchBarProps {
   matchPosition: number; // 1-indexed; 0 when matchCount === 0
   onChange: (q: string) => void;
   onConfirm: () => void;
-  onCancel: () => void;
 }
 
 export function SearchBar({
@@ -15,7 +14,6 @@ export function SearchBar({
   matchPosition,
   onChange,
   onConfirm,
-  onCancel,
 }: SearchBarProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   useEffect(() => {
@@ -38,9 +36,6 @@ export function SearchBar({
           if (e.key === "Enter") {
             e.preventDefault();
             onConfirm();
-          } else if (e.key === "Escape") {
-            e.preventDefault();
-            onCancel();
           }
         }}
         className="flex-1 bg-transparent outline-none border-none p-0 text-[var(--text-primary)]"

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from "react";
+
+interface SearchBarProps {
+  query: string;
+  matchCount: number;
+  matchPosition: number; // 1-indexed; 0 when matchCount === 0
+  onChange: (q: string) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function SearchBar({
+  query,
+  matchCount,
+  matchPosition,
+  onChange,
+  onConfirm,
+  onCancel,
+}: SearchBarProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const indicator =
+    query.trim() === "" ? "" : matchCount === 0 ? "no matches" : `${matchPosition}/${matchCount}`;
+
+  return (
+    <div className="flex items-center gap-1 px-3 py-1.5 border-t border-[var(--border-primary)] bg-[var(--panel-bg)] font-mono text-[11px] text-[var(--text-secondary)]">
+      <span className="text-[var(--text-tertiary)]">/</span>
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.nativeEvent.isComposing) return;
+          if (e.key === "Enter") {
+            e.preventDefault();
+            onConfirm();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            onCancel();
+          }
+        }}
+        className="flex-1 bg-transparent outline-none border-none p-0 text-[var(--text-primary)]"
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+      />
+      {indicator && <span className="ml-2 text-[var(--text-tertiary)]">{indicator}</span>}
+    </div>
+  );
+}

--- a/src/lib/fuzzy.ts
+++ b/src/lib/fuzzy.ts
@@ -1,0 +1,53 @@
+export interface FuzzyMatch {
+  score: number;
+  positions: number[]; // 0-indexed positions into target.toLowerCase()
+}
+
+// Fuzzy match. Lower score is better. Returns null when query is not a
+// subsequence of target. Empty/whitespace-only queries match with score 0.
+export function fuzzyMatch(query: string, target: string): FuzzyMatch | null {
+  const q = query.trim().toLowerCase();
+  if (q === "") return { score: 0, positions: [] };
+  const t = target.toLowerCase();
+
+  const subIdx = t.indexOf(q);
+  if (subIdx >= 0) {
+    const positions: number[] = [];
+    for (let i = 0; i < q.length; i++) positions.push(subIdx + i);
+    return { score: subIdx * 2 + (t.length - q.length), positions };
+  }
+
+  let ti = 0;
+  let score = 0;
+  let lastMatch = -2;
+  const positions: number[] = [];
+  for (let qi = 0; qi < q.length; qi++) {
+    const ch = q[qi];
+    let found = -1;
+    while (ti < t.length) {
+      if (t[ti] === ch) {
+        found = ti;
+        ti++;
+        break;
+      }
+      ti++;
+    }
+    if (found < 0) return null;
+    let charCost = found * 0.1 + 1;
+    if (found === lastMatch + 1) charCost -= 0.8;
+    if (found === 0 || isWordBoundary(t[found - 1])) charCost -= 0.5;
+    score += Math.max(charCost, 0);
+    lastMatch = found;
+    positions.push(found);
+  }
+  // keep subsequence matches strictly worse than substring
+  return { score: score + 100, positions };
+}
+
+export function fuzzyScore(query: string, target: string): number | null {
+  return fuzzyMatch(query, target)?.score ?? null;
+}
+
+function isWordBoundary(ch: string): boolean {
+  return ch === " " || ch === "-" || ch === "_" || ch === "/" || ch === ".";
+}

--- a/src/lib/fuzzy.ts
+++ b/src/lib/fuzzy.ts
@@ -5,11 +5,58 @@ export interface FuzzyMatch {
 
 // Fuzzy match. Lower score is better. Returns null when query is not a
 // subsequence of target. Empty/whitespace-only queries match with score 0.
+//
+// Whitespace in the query splits it into independent tokens, fzf-style:
+// every token must match somewhere in the target. Tokens may overlap and
+// appear in any order; positions are merged for highlighting.
 export function fuzzyMatch(query: string, target: string): FuzzyMatch | null {
-  const q = query.trim().toLowerCase();
-  if (q === "") return { score: 0, positions: [] };
+  const tokens = query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t !== "");
+  if (tokens.length === 0) return { score: 0, positions: [] };
   const t = target.toLowerCase();
 
+  if (tokens.length === 1) return matchToken(tokens[0], t);
+
+  const positions = new Set<number>();
+  let total = 0;
+  for (const token of tokens) {
+    const m = matchToken(token, t);
+    if (!m) return null;
+    total += m.score;
+    for (const p of m.positions) positions.add(p);
+  }
+  return { score: total, positions: [...positions].sort((a, b) => a - b) };
+}
+
+export function fuzzyScore(query: string, target: string): number | null {
+  return fuzzyMatch(query, target)?.score ?? null;
+}
+
+// Per-field highlight helper: returns positions of any tokens that hit
+// `target`. Unlike `fuzzyMatch`, tokens that don't match are silently
+// skipped instead of failing the whole match — needed when the AND-style
+// combined-target match passes but a single field doesn't see every token
+// (e.g. query "agent main" against just `repoName = "agentoast"`).
+export function findMatchPositions(query: string, target: string): number[] {
+  const tokens = query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t !== "");
+  if (tokens.length === 0) return [];
+  const t = target.toLowerCase();
+  const positions = new Set<number>();
+  for (const token of tokens) {
+    const m = matchToken(token, t);
+    if (!m) continue;
+    for (const p of m.positions) positions.add(p);
+  }
+  return [...positions].sort((a, b) => a - b);
+}
+
+// `q` and `t` must already be lower-cased.
+function matchToken(q: string, t: string): FuzzyMatch | null {
   const subIdx = t.indexOf(q);
   if (subIdx >= 0) {
     const positions: number[] = [];
@@ -42,10 +89,6 @@ export function fuzzyMatch(query: string, target: string): FuzzyMatch | null {
   }
   // keep subsequence matches strictly worse than substring
   return { score: score + 100, positions };
-}
-
-export function fuzzyScore(query: string, target: string): number | null {
-  return fuzzyMatch(query, target)?.score ?? null;
 }
 
 function isWordBoundary(ch: string): boolean {


### PR DESCRIPTION
## Summary

- Add vim-style `/` fuzzy search to the main panel (incsearch, `n`/`N` traversal, space-separated AND tokens).
- Highlight matched characters in the group header per field with a soft amber background.
- Reorganize the keybind help into Navigation / Search / Actions / Misc sections (2-column layout) and add the missing `Tab`/`Shift+Tab` rows.
- Intercept Esc at the AppKit `addLocalMonitorForEventsMatchingMask` layer and re-deliver as a Tauri `panel:esc` event so search/help/Apps-view dismissal never accidentally closes the whole NSPanel.

## Details

### Search & highlight

| Path | Change |
|---|---|
| `src/lib/fuzzy.ts` (new) | `fuzzyScore` + `fuzzyMatch` (positions) + `findMatchPositions` (per-field highlight tokens). Consolidates the duplicate scorer that lived in `apps-setup.tsx`. Whitespace splits the query into AND-style tokens, matched in any order. |
| `src/components/search-bar.tsx` (new) | Bottom-fixed vim-style command line. `[N/M]` indicator, IME-aware Enter, owns its input ref. |
| `src/components/highlight-text.tsx` (new) | Coalesces matched character runs into single spans so kerning is preserved. |
| `src/App.tsx` | `searchActive` / `searchQuery` / `searchCursor` state, `searchMatches` memo, incsearch effect, `/` `n` `N` key handlers, `matchedGroupKeys` set, `panel:shown` reset. |
| `src/components/repo-group.tsx` | New `highlightQuery` prop wires repo name + branch through `<HighlightText>`. |
| `src/components/apps-setup.tsx` | Import `fuzzyScore` from the shared module instead of redefining locally. |

### Help overlay

| Path | Change |
|---|---|
| `src/components/keybind-help.tsx` | Sectioned (Navigation / Search / Actions / Misc) 2-column grid. Adds `Tab`, `Shift+Tab` rows. `y` action label changed to `Copy $TMUX_PANE` for clarity over the previous `Copy prompt`. |

### Esc routing

| Path | Change |
|---|---|
| `src-tauri/src/panel.rs` | `install_esc_monitor` swallows keyCode 0x35 events targeting the main panel and emits `panel:esc`. AppKit's default `cancelOperation:` path can no longer reach the close/hide chain. `window_should_close` now plays a purely defensive role for hypothetical programmatic close requests. |
| `src/App.tsx` | `handleEscRef` listener routes Esc to: close help → cancel search → leave Apps view → hide panel. Replaces the previous main-view / apps-view / search switch cases. |

## Test plan

- [ ] `/` opens the search bar; typing jumps the cursor to the first matched group; `n` / `N` traverse matches.
- [ ] `agent main` style space-separated query matches groups containing both tokens (any order); per-field highlight shows `agent` in the repo name and `main` in the branch row.
- [ ] Matched characters in repo name / branch show the amber highlight only on groups in the active result set.
- [ ] `Enter` in the search bar closes the bar and keeps the selection; `Esc` cancels and restores the prior selection.
- [ ] **`Esc` inside the search bar does not dismiss the whole panel** (was the regression that motivated the AppKit monitor).
- [ ] `Esc` in the Apps view returns to the main view; in the help overlay closes the help; in the main view hides the panel.
- [ ] IME composition: pressing Enter to commit Japanese input does NOT close the search bar.
- [ ] Re-opening the panel resets search state.
- [ ] Existing app search in Settings → Apps still filters via the shared `fuzzyScore`.
- [ ] Help overlay shows the new sectioned layout with `/`, `n`, `N`, `Tab`, `⇧Tab` rows visible and the `y` row reading `Copy $TMUX_PANE`.
- [ ] `cargo make lint` passes.
