### PR TITLE
feat: keep panel header fixed and add hjkl/arrow nav in apps view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -665,16 +665,36 @@ export function App() {
           setShowHelp((prev) => !prev);
           return;
         case "j":
+        case "ArrowDown":
+          if (showHelp) return;
+          e.preventDefault();
+          if (allowedApps.length > 0) {
+            setAppsSelectedIndex((prev) => Math.min(prev + 3, allowedApps.length - 1));
+          }
+          return;
+        case "k":
+        case "ArrowUp":
+          if (showHelp) return;
+          e.preventDefault();
+          if (allowedApps.length > 0) {
+            setAppsSelectedIndex((prev) => Math.max(prev - 3, 0));
+          }
+          return;
+        case "h":
+        case "ArrowLeft":
+          if (showHelp) return;
+          e.preventDefault();
+          if (allowedApps.length > 0) {
+            setAppsSelectedIndex((prev) => Math.max(prev - 1, 0));
+          }
+          return;
+        case "l":
+        case "ArrowRight":
           if (showHelp) return;
           e.preventDefault();
           if (allowedApps.length > 0) {
             setAppsSelectedIndex((prev) => Math.min(prev + 1, allowedApps.length - 1));
           }
-          return;
-        case "k":
-          if (showHelp) return;
-          e.preventDefault();
-          setAppsSelectedIndex((prev) => Math.max(prev - 1, 0));
           return;
         case "Enter":
           if (showHelp) return;
@@ -960,37 +980,36 @@ export function App() {
     <div className="h-screen flex flex-col items-center px-4 pb-4 pt-0.5 bg-transparent">
       <div className="tray-arrow" />
       <div className="w-full flex-1 min-h-0 flex flex-col bg-[var(--panel-bg)] backdrop-blur-xl rounded-xl border border-[var(--border-primary)] shadow-2xl overflow-hidden">
-        {activeView === "main" && (
-          <PanelHeader
-            globalMuted={globalMuted}
-            filterNotifiedOnly={filterNotifiedOnly}
-            showNonAgentPanes={showNonAgentPanes}
-            onToggleFilter={() => {
-              setFilterNotifiedOnly((prev) => {
-                const next = !prev;
-                void invoke("save_filter_notified_only", { value: next });
-                return next;
-              });
-            }}
-            onToggleShowNonAgentPanes={() => {
-              setShowNonAgentPanes((prev) => {
-                const next = !prev;
-                void invoke("save_show_non_agent_panes", { value: next });
-                return next;
-              });
-            }}
-            onDeleteAll={() => void deleteAll()}
-            onToggleGlobalMute={() => void toggleGlobalMute()}
-            appVersion={appVersion}
-            updateStatus={updateStatus}
-            onUpdateInstall={triggerInstall}
-            onUpdateCheck={checkForUpdates}
-            onOpenAppsView={() => {
-              setAppsSelectedIndex(0);
-              setActiveView("apps");
-            }}
-          />
-        )}
+        <PanelHeader
+          globalMuted={globalMuted}
+          filterNotifiedOnly={filterNotifiedOnly}
+          showNonAgentPanes={showNonAgentPanes}
+          appsViewActive={activeView === "apps"}
+          onToggleFilter={() => {
+            setFilterNotifiedOnly((prev) => {
+              const next = !prev;
+              void invoke("save_filter_notified_only", { value: next });
+              return next;
+            });
+          }}
+          onToggleShowNonAgentPanes={() => {
+            setShowNonAgentPanes((prev) => {
+              const next = !prev;
+              void invoke("save_show_non_agent_panes", { value: next });
+              return next;
+            });
+          }}
+          onDeleteAll={() => void deleteAll()}
+          onToggleGlobalMute={() => void toggleGlobalMute()}
+          appVersion={appVersion}
+          updateStatus={updateStatus}
+          onUpdateInstall={triggerInstall}
+          onUpdateCheck={checkForUpdates}
+          onToggleAppsView={() => {
+            setAppsSelectedIndex(0);
+            setActiveView((v) => (v === "apps" ? "main" : "apps"));
+          }}
+        />
 
         <div className="relative flex-1 min-h-0">
           {activeView === "apps" ? (

--- a/src/components/keybind-help.tsx
+++ b/src/components/keybind-help.tsx
@@ -43,7 +43,7 @@ const SECTIONS: Section[] = [
       { key: "F", action: "Filter notified" },
       { key: "T", action: "Non-agent panes" },
       { key: "y", action: "Copy $TMUX_PANE" },
-      { key: "a", action: "Apps view" },
+      { key: "a", action: "Toggle apps" },
     ],
   },
   {

--- a/src/components/panel-header.stories.tsx
+++ b/src/components/panel-header.stories.tsx
@@ -8,6 +8,7 @@ const meta: Meta<typeof PanelHeader> = {
     globalMuted: false,
     filterNotifiedOnly: false,
     showNonAgentPanes: false,
+    appsViewActive: false,
     onToggleFilter: () => {},
     onToggleShowNonAgentPanes: () => {},
     onDeleteAll: () => {},
@@ -16,7 +17,7 @@ const meta: Meta<typeof PanelHeader> = {
     updateStatus: { status: "idle" },
     onUpdateInstall: () => {},
     onUpdateCheck: () => {},
-    onOpenAppsView: () => {},
+    onToggleAppsView: () => {},
   },
 };
 

--- a/src/components/panel-header.tsx
+++ b/src/components/panel-header.tsx
@@ -7,6 +7,7 @@ interface PanelHeaderProps {
   globalMuted: boolean;
   filterNotifiedOnly: boolean;
   showNonAgentPanes: boolean;
+  appsViewActive: boolean;
   onToggleFilter: () => void;
   onToggleShowNonAgentPanes: () => void;
   onDeleteAll: () => void;
@@ -15,7 +16,7 @@ interface PanelHeaderProps {
   updateStatus: UpdateStatus;
   onUpdateInstall: () => void;
   onUpdateCheck: () => void;
-  onOpenAppsView: () => void;
+  onToggleAppsView: () => void;
 }
 
 function getUpdateTitle(status: UpdateStatus, version: string): string {
@@ -42,6 +43,7 @@ export function PanelHeader({
   globalMuted,
   filterNotifiedOnly,
   showNonAgentPanes,
+  appsViewActive,
   onToggleFilter,
   onToggleShowNonAgentPanes,
   onDeleteAll,
@@ -50,7 +52,7 @@ export function PanelHeader({
   updateStatus,
   onUpdateInstall,
   onUpdateCheck,
-  onOpenAppsView,
+  onToggleAppsView,
 }: PanelHeaderProps) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -114,9 +116,13 @@ export function PanelHeader({
         </button>
         <button
           tabIndex={-1}
-          onClick={onOpenAppsView}
-          className="p-1.5 rounded-md text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--hover-bg-strong)] transition-colors"
-          title="Open apps (a)"
+          onClick={onToggleAppsView}
+          className={`p-1.5 rounded-md hover:bg-[var(--hover-bg-strong)] transition-colors ${
+            appsViewActive
+              ? "text-[var(--text-primary)]"
+              : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
+          }`}
+          title={appsViewActive ? "Back to notifications (a)" : "Open apps (a)"}
         >
           <AppsTabIcon size={14} />
         </button>


### PR DESCRIPTION
## Summary

- Keep `PanelHeader` mounted while the main panel is showing the apps view — previously the entire panel was replaced, including the filter / mute / delete-all chrome.
- `AppsTabIcon` now acts as a toggle and lights up while the apps view is active, so the current view is obvious at a glance.
- Inside the apps view, add 2D grid navigation across the 3-column launcher: `h`/`←` move left, `l`/`→` move right, `j`/`↓` move down one row (+3), `k`/`↑` move up one row (-3). View toggling stays on the `a` key.

## Changes

- `src/App.tsx`
  - Moved `PanelHeader` outside the `activeView === "main"` branch so it always renders.
  - Replaced `onOpenAppsView` with `onToggleAppsView` and forwarded `appsViewActive`.
  - In the apps-view keyboard branch: rebuilt `j`/`k` to step by ±3 (one row) and added `h`/`l` plus all four arrow keys with proper grid math and `allowedApps.length` guards.
  - Removed the earlier `ArrowRight` / `l` shortcuts from the main-view branch so they no longer trigger a view switch.
- `src/components/panel-header.tsx`
  - Added `appsViewActive: boolean` and renamed `onOpenAppsView` → `onToggleAppsView`.
  - `AppsTabIcon` button now flips between active (`var(--text-primary)`) and inactive tones, with a `title` that swaps between "Open apps (a)" and "Back to notifications (a)".
- `src/components/panel-header.stories.tsx`
  - Updated stub args to match the new prop shape (`appsViewActive`, `onToggleAppsView`).
- `src/components/keybind-help.tsx`
  - Renamed the `a` row from "Apps view" to "Toggle apps".
