### PR TITLE
feat: add lowercase t shortcut to jump to current tmux pane

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -453,6 +453,20 @@ async fn get_sessions(app_handle: tauri::AppHandle) -> Result<Vec<TmuxPaneGroup>
 }
 
 #[tauri::command]
+async fn get_focused_pane() -> Result<Option<agentoast_shared::models::TmuxPane>, String> {
+    #[cfg(target_os = "macos")]
+    {
+        tauri::async_runtime::spawn_blocking(sessions::find_focused_pane)
+            .await
+            .map_err(|e| e.to_string())?
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err("get_focused_pane is only supported on macOS".to_string())
+    }
+}
+
+#[tauri::command]
 fn get_notifications(
     state: tauri::State<'_, Mutex<AppState>>,
     limit: Option<i64>,
@@ -1124,6 +1138,7 @@ pub fn run() {
             show_panel,
             focus_terminal,
             get_sessions,
+            get_focused_pane,
             get_notifications,
             get_unread_count,
             delete_notification,

--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -422,6 +422,94 @@ pub fn list_tmux_panes_grouped(show_non_agent: bool) -> Result<Vec<TmuxPaneGroup
     Ok(groups)
 }
 
+/// Return the tmux pane that is actually focused right now, without the
+/// agent-promotion logic that `list_tmux_panes_grouped` applies when
+/// `show_non_agent=false`. Returns `Ok(None)` when no pane is attached.
+pub fn find_focused_pane() -> Result<Option<TmuxPane>, String> {
+    const DELIM: &str = "|||";
+    let format_str = format!(
+        "#{{pane_id}}{d}#{{pane_pid}}{d}#{{session_name}}{d}#{{window_name}}{d}#{{pane_current_path}}{d}#{{pane_active}}{d}#{{window_active}}{d}#{{session_attached}}{d}#{{pane_current_command}}",
+        d = DELIM
+    );
+
+    let stdout_lines: Vec<String> = {
+        let tmux_path = find_tmux().ok_or_else(|| "tmux not found".to_string())?;
+        let output = Command::new(&tmux_path)
+            .env_remove("TMPDIR")
+            .args(["list-panes", "-a", "-F", &format_str])
+            .output()
+            .map_err(|e| format!("tmux list-panes failed: {}", e))?;
+        if !output.status.success() {
+            return Err(format!(
+                "tmux list-panes failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(|s| s.to_string())
+            .collect()
+    };
+
+    let mut focused: Option<(String, u32, String, String, String, Option<String>)> = None;
+    for line in &stdout_lines {
+        let parts: Vec<&str> = line.splitn(9, DELIM).collect();
+        if parts.len() < 9 {
+            continue;
+        }
+        let raw_attached: u32 = parts[7].parse().unwrap_or(0);
+        let is_active = parts[5] == "1" && parts[6] == "1" && raw_attached >= 1;
+        if !is_active {
+            continue;
+        }
+        let pane_pid: u32 = parts[1].parse().unwrap_or(0);
+        let current_command = if parts[8].is_empty() {
+            None
+        } else {
+            Some(parts[8].to_string())
+        };
+        focused = Some((
+            parts[0].to_string(),
+            pane_pid,
+            parts[2].to_string(),
+            parts[3].to_string(),
+            parts[4].to_string(),
+            current_command,
+        ));
+        break;
+    }
+
+    let Some((pane_id, pane_pid, session_name, window_name, current_path, current_command)) =
+        focused
+    else {
+        return Ok(None);
+    };
+
+    let process_tree = build_process_tree();
+    let agent_type = detect_agent(&process_tree, pane_pid);
+
+    let git_info =
+        find_git().and_then(|git_path| resolve_single_git_info(&git_path, &current_path));
+
+    Ok(Some(TmuxPane {
+        pane_id,
+        pane_pid,
+        session_name,
+        window_name,
+        current_path,
+        is_active: true,
+        agent_type,
+        agent_status: None,
+        waiting_reason: None,
+        agent_modes: Vec::new(),
+        team_role: None,
+        team_name: None,
+        git_repo_root: git_info.as_ref().map(|g| g.repo_root.clone()),
+        git_branch: git_info.as_ref().and_then(|g| g.branch.clone()),
+        current_command,
+    }))
+}
+
 /// Process tree: maps parent PID to (child PID, command name) pairs.
 struct ProcessTree {
     children: HashMap<u32, Vec<u32>>,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,15 @@ import { KeybindHelp } from "@/components/keybind-help";
 import { SearchBar } from "@/components/search-bar";
 import { Bell } from "lucide-react";
 import { fuzzyScore } from "@/lib/fuzzy";
-import type { Notification, PanelView, UnifiedGroup, FlatItem, PaneItem } from "@/lib/types";
+import type {
+  Notification,
+  PanelView,
+  UnifiedGroup,
+  FlatItem,
+  PaneItem,
+  TmuxPane,
+  TmuxPaneGroup,
+} from "@/lib/types";
 
 export function App() {
   const { notifications, loading, deleteNotification, deleteByPanes, deleteAll, newIds } =
@@ -46,6 +54,11 @@ export function App() {
   const autoExpandTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [recentlyCopiedPaneId, setRecentlyCopiedPaneId] = useState<string | null>(null);
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Ephemeral pane injected by the lowercase `t` shortcut when the real
+  // focused tmux pane is hidden (non-agent + showNonAgentPanes=false).
+  // Cleared the moment the cursor moves to a different row.
+  const [ephemeralPane, setEphemeralPane] = useState<TmuxPane | null>(null);
 
   const [searchActive, setSearchActive] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
@@ -85,6 +98,37 @@ export function App() {
     });
   }, []);
 
+  // Inject the ephemeral pane (set by lowercase `t`) into the session groups
+  // so the rest of the pipeline (unifiedGroups → flatItems) treats it like a
+  // normal pane for one render. Skips injection when the pane already exists
+  // in the live data so duplicates can't appear if showNonAgentPanes flips on.
+  const effectiveSessionGroups = useMemo<TmuxPaneGroup[]>(() => {
+    if (!ephemeralPane) return sessionGroups;
+    const alreadyPresent = sessionGroups.some((g) =>
+      g.panes.some((p) => p.paneId === ephemeralPane.paneId),
+    );
+    if (alreadyPresent) return sessionGroups;
+    const groupKey = ephemeralPane.gitRepoRoot ?? ephemeralPane.currentPath;
+    const matchedIdx = sessionGroups.findIndex((g) => g.currentPath === groupKey);
+    if (matchedIdx >= 0) {
+      const next = sessionGroups.slice();
+      const target = next[matchedIdx];
+      next[matchedIdx] = { ...target, panes: [...target.panes, ephemeralPane] };
+      return next;
+    }
+    const repoName =
+      groupKey.split("/").filter(Boolean).pop() ?? ephemeralPane.sessionName ?? groupKey;
+    return [
+      ...sessionGroups,
+      {
+        repoName,
+        currentPath: groupKey,
+        gitBranch: ephemeralPane.gitBranch,
+        panes: [ephemeralPane],
+      },
+    ];
+  }, [sessionGroups, ephemeralPane]);
+
   // Merge notifications and session groups into unified groups
   const unifiedGroups = useMemo(() => {
     // Build tmuxPane -> Notification map (latest notification per pane)
@@ -102,7 +146,7 @@ export function App() {
     const map = new Map<string, UnifiedGroup>();
 
     // Process session groups: create pane items with matched notifications
-    for (const sg of sessionGroups) {
+    for (const sg of effectiveSessionGroups) {
       const groupKey = sg.currentPath;
       const repoName = sg.repoName;
       const gitBranch = sg.gitBranch;
@@ -260,7 +304,7 @@ export function App() {
     });
 
     return result;
-  }, [notifications, sessionGroups]);
+  }, [notifications, effectiveSessionGroups]);
 
   // Filter groups based on notification filter toggle
   const displayGroups = useMemo(() => {
@@ -553,6 +597,20 @@ export function App() {
       setSelectedKey(keyFromItem(flatItems[activeIdx]));
     }
   }, [flatItems]);
+
+  // Drop the ephemeral pane (set by lowercase `t`) the moment the cursor moves
+  // to a different row, or whenever showNonAgentPanes flips on (since all
+  // non-agent panes become visible naturally).
+  useEffect(() => {
+    if (!ephemeralPane) return;
+    if (showNonAgentPanes) {
+      setEphemeralPane(null);
+      return;
+    }
+    if (selectedKey?.kind !== "pane" || selectedKey.paneId !== ephemeralPane.paneId) {
+      setEphemeralPane(null);
+    }
+  }, [selectedKey, ephemeralPane, showNonAgentPanes]);
 
   // Scroll selected item into view
   useEffect(() => {
@@ -850,6 +908,28 @@ export function App() {
           void invoke("save_show_non_agent_panes", { value: next });
           return next;
         });
+        break;
+      }
+      case "t": {
+        if (showHelp || e.shiftKey || e.metaKey || e.ctrlKey || e.altKey) break;
+        e.preventDefault();
+        void (async () => {
+          const real = await invoke<TmuxPane | null>("get_focused_pane").catch(() => null);
+          if (!real) return;
+          const items = flatItemsRef.current;
+          const existing = items.findIndex(
+            (f) => f.type === "pane-item" && f.paneItem.pane.paneId === real.paneId,
+          );
+          if (existing >= 0) {
+            repositionCancelledRef.current = true;
+            setSelectedKey(keyFromItem(items[existing]));
+            return;
+          }
+          // Hidden non-agent pane → inject as ephemeral and select it.
+          repositionCancelledRef.current = true;
+          setEphemeralPane(real);
+          setSelectedKey({ kind: "pane", paneId: real.paneId });
+        })();
         break;
       }
       case "y": {

--- a/src/components/keybind-help.tsx
+++ b/src/components/keybind-help.tsx
@@ -42,6 +42,7 @@ const SECTIONS: Section[] = [
       { key: "E", action: "Expand all" },
       { key: "F", action: "Filter notified" },
       { key: "T", action: "Non-agent panes" },
+      { key: "t", action: "Jump to current pane" },
       { key: "y", action: "Copy $TMUX_PANE" },
       { key: "a", action: "Apps view" },
     ],


### PR DESCRIPTION
## Summary

- Add a lowercase `t` shortcut that focuses the panel cursor on the actual focused tmux pane, independent of the `T` (`showNonAgentPanes`) toggle.
- When the real focused pane is a non-agent shell hidden by `T=off`, inject it into the list as an **ephemeral** row — moving the cursor away (`j/k/Tab/...`) drops it automatically, and the persisted `showNonAgentPanes` setting is never touched.
- Backend adds a lightweight `get_focused_pane` Tauri command that skips capture-pane, agent-status detection, and per-path git resolution, so pressing `t` feels instant (no full `list_tmux_panes_grouped` round-trip like `T` triggers).

## Changes

### Backend (Rust)
- `src-tauri/src/sessions/mod.rs`: new `find_focused_pane()` — runs a single `tmux list-panes -a`, picks the row where `pane_active && window_active && session_attached`, resolves git info only for that one path, and returns a `TmuxPane` without applying the agent-promotion logic.
- `src-tauri/src/lib.rs`: new `#[tauri::command] get_focused_pane()` plus handler registration.

### Frontend (TypeScript / React)
- `src/App.tsx`:
  - New `ephemeralPane: TmuxPane | null` state.
  - `effectiveSessionGroups` memo injects the ephemeral pane into the matching `currentPath` group (or a new group as a fallback) before `unifiedGroups` runs. Skips injection when the pane already exists in the live data so duplicates can't appear if `T` is flipped on.
  - `case "t"` handler: calls `get_focused_pane`, jumps to the pane if already visible, otherwise stashes it as the ephemeral pane and selects it.
  - Cleanup effect drops the ephemeral pane the moment `selectedKey` no longer points to it (or when `showNonAgentPanes` flips on).
- `src/components/keybind-help.tsx`: add `t: Jump to current pane` next to the existing `T` entry.


