### PR TITLE
fix: stop opencode notify plugin from writing unbounded debug log to /tmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,13 @@ mkdir -p ~/.config/opencode/plugins
 cp examples/notify/opencode.ts ~/.config/opencode/plugins/
 ```
 
+> **Note**: Earlier versions of `examples/notify/opencode.ts` included development-time debug logging that wrote every opencode event to `/tmp/opencode-notify-debug.log`, growing without bound. If you installed the plugin before this was fixed, re-copy the plugin and remove the stale log:
+>
+> ```bash
+> cp examples/notify/opencode.ts ~/.config/opencode/plugins/
+> rm -f /tmp/opencode-notify-debug.log
+> ```
+
 Supported events
 
 | Event                   | Notification      |

--- a/examples/notify/opencode.ts
+++ b/examples/notify/opencode.ts
@@ -1,8 +1,3 @@
-import { appendFileSync } from "node:fs";
-
-const DEBUG_LOG = "/tmp/opencode-notify-debug.log";
-const log = (msg: string) => appendFileSync(DEBUG_LOG, `${new Date().toISOString()} ${msg}\n`);
-
 export const NotifyPlugin = async ({
   $,
   directory,
@@ -19,21 +14,13 @@ export const NotifyPlugin = async ({
 }) => {
   return {
     event: async ({ event }: { event: { type: string; properties: Record<string, unknown> } }) => {
-      log(`event: ${event.type} props: ${JSON.stringify(event.properties)}`);
-
       const payload = JSON.stringify({
         type: event.type,
         properties: event.properties,
         directory,
       });
 
-      log(`agentoast hook opencode: ${payload}`);
-      try {
-        await $`agentoast hook opencode ${payload}`.nothrow().quiet();
-        log("agentoast: success");
-      } catch (e) {
-        log(`agentoast: error ${e}`);
-      }
+      await $`agentoast hook opencode ${payload}`.nothrow().quiet();
     },
   };
 };


### PR DESCRIPTION
## Summary

fixed https://github.com/shuntaka9576/agentoast/issues/267

- The shipped `examples/notify/opencode.ts` plugin contained a development-time `appendFileSync` logger that wrote every opencode event to `/tmp/opencode-notify-debug.log`. Since users copy the file directly into `~/.config/opencode/plugins/`, the log grew without bound — one user reported a 70GB file, refilling to ~500MB overnight after deletion.
- Remove the debug logger entirely (import, constant, helper, and all four call sites) from the plugin example.
- Add a README note so existing users know they need to re-copy the plugin and delete the stale log.

## Changes

- `examples/notify/opencode.ts` — remove `appendFileSync` import, `DEBUG_LOG` constant, `log()` helper, and the four `log(...)` call sites. Keep the rest of the plugin behavior identical (`agentoast hook opencode <payload>` via `.nothrow().quiet()`).
- `README.md` — add a note under the opencode plugin install steps pointing existing users at the re-copy + `rm -f /tmp/opencode-notify-debug.log` cleanup.

## User remediation

Existing users who installed the plugin before this fix should run:

```bash
cp examples/notify/opencode.ts ~/.config/opencode/plugins/
rm -f /tmp/opencode-notify-debug.log
```
