### PR TITLE
ci: add zizmor security audit and fix workflow findings

### DIFF
--- a/.github/actions/release-app/action.yaml
+++ b/.github/actions/release-app/action.yaml
@@ -82,8 +82,8 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        TAG: ${{ inputs.tag }}
       run: |
-        TAG="${{ inputs.tag }}"
         ASSETS=$(gh release view "${TAG}" --json assets --jq '.assets[].name')
         printf '%s\n' "$ASSETS" | grep -Fxq 'latest.json' || { echo "ERROR: Missing latest.json"; exit 1; }
         printf '%s\n' "$ASSETS" | grep -Eq '\.sig$' || { echo "ERROR: Missing .sig file"; exit 1; }
@@ -92,8 +92,8 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
         GH_PAT: ${{ inputs.homebrew_tap_token }}
+        TAG: ${{ inputs.tag }}
       run: |
-        TAG="${{ inputs.tag }}"
         VERSION="${TAG#v}"
         DMG_NAME="Agentoast_${VERSION}_aarch64.dmg"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   lint:
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: setup bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - name: install dependencies

--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -16,7 +16,9 @@ jobs:
     outputs:
       tag: ${{ steps.tagpr.outputs.tag }}
     steps:
-      - name: checkout
+      # tagpr pushes the release tag/commit via checkout's persisted credentials,
+      # so persist-credentials must stay enabled here.
+      - name: checkout # zizmor: ignore[artipacked]
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Wait for commit-PR association to be indexed
         env:
@@ -51,6 +53,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.tagpr.outputs.tag }}
+          persist-credentials: false
       - name: Generate token for homebrew-tap
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -59,6 +59,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: homebrew-tap
+          permission-contents: write
       - uses: ./.github/actions/release-app
         with:
           tag: ${{ needs.tagpr.outputs.tag }}

--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -84,4 +84,5 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-        run: gh release edit ${{ needs.tagpr.outputs.tag }} --draft=false
+          TAG: ${{ needs.tagpr.outputs.tag }}
+        run: gh release edit "$TAG" --draft=false

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: ['**']
+    branches: ["**"]
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,41 @@
+name: zizmor audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ['**']
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Upload the SARIF results to GitHub Code Scanning
+      contents: read # Required for actions/checkout to fetch the repository
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Run zizmor
+        run: uvx zizmor --format=sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/cspell.json
+++ b/cspell.json
@@ -78,7 +78,8 @@
     "untap",
     "wezterm",
     "worktree",
-    "xattr"
+    "xattr",
+    "zizmor"
   ],
   "flagWords": []
 }

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -2,3 +2,5 @@ pre-push:
   commands:
     lint:
       run: cargo make lint
+    zizmor:
+      run: uvx zizmor .


### PR DESCRIPTION
## Summary

- Introduce [zizmor](https://docs.zizmor.sh/) static analysis for our GitHub Actions workflows, wired into both CI (SARIF uploaded to GitHub Code Scanning) and the local `lefthook` pre-push hook.
- Resolve every finding zizmor reported on the existing workflows, grouped into one commit per audit so each fix is easy to review.
- Setup adapted from the shuntaka-dev configuration; the `push` trigger is limited to `main` since this repo has no `preview` branch.


