### PR TITLE
feat: add send-keys for cross-agent tmux messaging

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -74,6 +74,25 @@ echo "Done! Uninstalled agentoast"
 '''
 
 # ---------------------------------------------------------------------------
+# Skill (cross-agent messaging)
+# ---------------------------------------------------------------------------
+[tasks.install-skill]
+description = "Copy the agentoast-send skill into ~/.config/claude/skills/"
+script = [
+  "mkdir -p ~/.config/claude/skills",
+  "rm -rf ~/.config/claude/skills/agentoast-send",
+  "cp -R skills/agentoast-send ~/.config/claude/skills/",
+  "echo 'Installed skill -> ~/.config/claude/skills/agentoast-send/'",
+]
+
+[tasks.uninstall-skill]
+description = "Remove the agentoast-send skill from ~/.config/claude/skills/"
+script = [
+  "rm -rf ~/.config/claude/skills/agentoast-send",
+  "echo 'Removed skill -> ~/.config/claude/skills/agentoast-send/'",
+]
+
+# ---------------------------------------------------------------------------
 # Dev
 # ---------------------------------------------------------------------------
 [tasks.dev]

--- a/crates/agentoast-cli/src/lib.rs
+++ b/crates/agentoast-cli/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod hooks;
 
 use agentoast_shared::models::IconType;
-use agentoast_shared::{config, db};
+use agentoast_shared::{config, db, tmux};
 use clap::{Parser, Subcommand};
 
 use hooks::{get_git_info, parse_metadata};
@@ -92,6 +92,28 @@ enum Commands {
         tmux_pane: String,
     },
 
+    /// Inject a message into another tmux pane's agent (cross-agent messaging)
+    SendKeys {
+        /// Target tmux pane ID (e.g. %72)
+        #[arg(short = 't', long)]
+        pane: String,
+
+        /// Message text to inject
+        message: String,
+
+        /// Sender pane ID embedded as the reply address (default: $TMUX_PANE)
+        #[arg(long)]
+        from: Option<String>,
+
+        /// Inject the raw message only, without the reply hint
+        #[arg(long)]
+        raw: bool,
+
+        /// Do not send a trailing Enter (leave the text without submitting)
+        #[arg(long)]
+        no_enter: bool,
+    },
+
     /// Open config file in editor
     Config,
 }
@@ -128,6 +150,7 @@ pub fn try_run_cli() -> bool {
     let first = &args[1];
     let known = [
         "send",
+        "send-keys",
         "hook",
         "list",
         "dismiss",
@@ -263,6 +286,52 @@ fn run(cli: Cli) {
             if let Err(e) = db::delete_notifications_by_pane(&conn, &tmux_pane) {
                 eprintln!("Failed to delete notifications: {}", e);
                 std::process::exit(1);
+            }
+        }
+        Commands::SendKeys {
+            pane,
+            message,
+            from,
+            raw,
+            no_enter,
+        } => {
+            let tmux_override = config::load_config().system.tmux;
+            let Some(tmux_bin) = tmux::find_tmux(tmux_override.as_deref()) else {
+                eprintln!("tmux not found");
+                std::process::exit(1);
+            };
+            if !tmux::pane_exists(&tmux_bin, &pane) {
+                eprintln!("pane '{}' not found", pane);
+                std::process::exit(1);
+            }
+
+            // Reply address: --from > $TMUX_PANE (the sender agent's own pane).
+            let from_pane = from
+                .or_else(|| std::env::var("TMUX_PANE").ok())
+                .filter(|s| !s.is_empty());
+
+            // Append a single-line reply hint unless --raw, so the receiving
+            // agent knows where and how to reply.
+            let body = if raw {
+                message
+            } else if let Some(fp) = &from_pane {
+                format!(
+                    "[agentoast] from {fp}: {message}  (reply: agentoast send-keys --pane {fp} \"<reply>\")"
+                )
+            } else {
+                message
+            };
+
+            match tmux::send_keys(&tmux_bin, &pane, &body, !no_enter) {
+                Ok(()) => println!(
+                    "sent to {} (from {})",
+                    pane,
+                    from_pane.as_deref().unwrap_or("-")
+                ),
+                Err(e) => {
+                    eprintln!("send-keys failed: {}", e);
+                    std::process::exit(1);
+                }
             }
         }
         Commands::Config => {

--- a/crates/agentoast-shared/src/lib.rs
+++ b/crates/agentoast-shared/src/lib.rs
@@ -2,3 +2,4 @@ pub mod config;
 pub mod db;
 pub mod models;
 pub mod schema;
+pub mod tmux;

--- a/crates/agentoast-shared/src/tmux.rs
+++ b/crates/agentoast-shared/src/tmux.rs
@@ -1,0 +1,96 @@
+//! tmux helpers shared between the CLI and the GUI.
+//!
+//! `find_tmux` resolves the tmux binary with a single lookup order used by
+//! both the CLI and the Tauri app: the `[system] tmux` config override first,
+//! then well-known install paths, then a `$PATH` scan. The override is passed
+//! in by the caller so this module stays independent of config loading — the
+//! GUI caches its `AppConfig` (hot path) while the CLI reads it once per run.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Resolve the tmux binary path.
+///
+/// Priority: `tmux_override` (from `config.toml` `[system] tmux`) → well-known
+/// paths (Homebrew / system / Nix) → `$PATH` scan. Returns `None` when not found.
+pub fn find_tmux(tmux_override: Option<&str>) -> Option<PathBuf> {
+    // config.toml override (highest priority)
+    if let Some(path) = tmux_override {
+        let p = PathBuf::from(path);
+        if p.exists() {
+            return Some(p);
+        }
+        log::warn!(
+            "config.toml system.tmux={} not found, falling back to auto-detection",
+            path
+        );
+    }
+
+    let mut candidates: Vec<PathBuf> = vec![
+        PathBuf::from("/opt/homebrew/bin/tmux"), // Homebrew (Apple Silicon)
+        PathBuf::from("/usr/local/bin/tmux"),    // Homebrew (Intel) / manual
+        PathBuf::from("/usr/bin/tmux"),          // system
+    ];
+
+    // Nix Home Manager: /etc/profiles/per-user/<username>/bin/tmux
+    if let Ok(user) = std::env::var("USER") {
+        candidates.push(PathBuf::from(format!(
+            "/etc/profiles/per-user/{}/bin/tmux",
+            user
+        )));
+    }
+    // Nix single-user profile
+    candidates.push(PathBuf::from("/nix/var/nix/profiles/default/bin/tmux"));
+
+    if let Some(found) = candidates.iter().find(|p| p.exists()) {
+        return Some(found.clone());
+    }
+
+    // PATH-based fallback (mise, asdf, custom installs, etc.)
+    if let Ok(path_var) = std::env::var("PATH") {
+        for dir in path_var.split(':') {
+            let candidate = PathBuf::from(dir).join("tmux");
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+    }
+
+    None
+}
+
+/// Check that a tmux pane with the given id (e.g. `%72`) currently exists.
+pub fn pane_exists(tmux: &Path, pane: &str) -> bool {
+    Command::new(tmux)
+        .args(["display-message", "-t", pane, "-p", "#{pane_id}"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Inject `body` into the target pane as literal keystrokes, then optionally
+/// submit it with Enter.
+///
+/// `-l` sends the text literally (no key-name interpretation) and `--`
+/// terminates option parsing, so a body starting with `-` is delivered safely.
+pub fn send_keys(tmux: &Path, pane: &str, body: &str, enter: bool) -> Result<(), String> {
+    let out = Command::new(tmux)
+        .args(["send-keys", "-t", pane, "-l", "--", body])
+        .output()
+        .map_err(|e| format!("failed to run tmux send-keys: {e}"))?;
+    if !out.status.success() {
+        return Err(String::from_utf8_lossy(&out.stderr).trim().to_string());
+    }
+
+    if enter {
+        let out = Command::new(tmux)
+            .args(["send-keys", "-t", pane, "Enter"])
+            .output()
+            .map_err(|e| format!("failed to run tmux send-keys Enter: {e}"))?;
+        if !out.status.success() {
+            return Err(String::from_utf8_lossy(&out.stderr).trim().to_string());
+        }
+    }
+
+    Ok(())
+}

--- a/skills/agentoast-send/SKILL.md
+++ b/skills/agentoast-send/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: agentoast-send
+description: >-
+  Send a request or question to another AI coding agent running in a different
+  tmux pane, and reply to messages from other agents — via the `agentoast
+  send-keys` CLI (address = a tmux pane id like %72; no team, login, or setup).
+  Use this whenever the user wants to delegate to, ask, hand off to, or relay a
+  message to an agent in another pane/window/session — e.g. "ask the agent in
+  pane %72 to review this", "have the other session check X", or right after the
+  user pastes "Please take a look at tmux pane %72." — and whenever an incoming
+  prompt contains a "(reply: agentoast send-keys --pane %NN ...)" hint to answer.
+  Prefer this over reading another pane's screen with `tmux capture-pane`, which
+  truncates lines and cannot see the full conversation.
+---
+
+# agentoast-send: cross-pane agent messaging
+
+Talk to AI coding agents running in OTHER tmux panes by injecting a message into
+their prompt, and reply to messages they send you. The transport is the
+`agentoast send-keys` CLI and the address is just a tmux pane id (e.g. `%72`).
+There is no team, login, or registration: if you know the pane, you can message it.
+
+## Sending a message
+
+1. Resolve the target pane id (`%NN`).
+   - The user usually provides it — often by pasting agentoast's clipboard string
+     `Please take a look at tmux pane %72.` Take the `%72` from there.
+   - If no pane id is present, ask the user which pane to send to.
+2. Run:
+   ```
+   agentoast send-keys --pane %72 "your message"
+   ```
+   The text is typed straight into that agent's prompt and submitted. Your own
+   pane is read from `$TMUX_PANE` and appended as a reply address, so the
+   receiver sees a trailing `(reply: agentoast send-keys --pane <you> "<reply>")`.
+   You do not add that hint yourself.
+3. Tell the user it was sent. The reply arrives later as a new prompt in YOUR
+   pane — there is nothing to poll or watch.
+
+Write the message yourself from the conversation so far. You hold context the
+other agent lacks, so phrase a self-contained request (summarize the task or
+question) rather than a bare "see above" — the other pane can't see your screen.
+
+## Replying to an incoming message
+
+If your prompt contains a line like `(reply: agentoast send-keys --pane %45
+"<reply>")`, that is a message from another agent. Do the work it asks for, then
+run that exact command with your answer in place of `<reply>`.
+
+## Don't scrape the screen — ask the agent
+
+To learn what another agent is doing or what its task is, do NOT run
+`tmux capture-pane`. In a conversation TUI the captured text is clipped to the
+pane width and truncated, and scrollback can't hold the whole conversation — you
+get a broken, partial view. Instead, ask the agent and let it answer in clean,
+authored prose:
+
+```
+agentoast send-keys --pane %72 "What task or blocker are you working on right now?"
+```
+
+The agent knows its own context and will summarize it far better than a screen grab.
+
+## Notes
+
+- Address = tmux pane id; ids stay stable for the life of the pane.
+- If the target looks busy mid-generation, injected keystrokes can interleave —
+  prefer sending when it is idle or waiting for input.
+- `--raw` sends without the reply hint; `--no-enter` types without submitting.

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -20,49 +20,9 @@ const KNOWN_TERMINAL_BUNDLE_IDS: &[&str] = &[
 ];
 
 pub(crate) fn find_tmux() -> Option<PathBuf> {
-    // config.toml override (highest priority)
-    if let Some(ref path) = get_config().system.tmux {
-        let p = PathBuf::from(path);
-        if p.exists() {
-            return Some(p);
-        }
-        log::warn!(
-            "config.toml system.tmux={} not found, falling back to auto-detection",
-            path
-        );
-    }
-
-    let mut candidates: Vec<PathBuf> = vec![
-        PathBuf::from("/opt/homebrew/bin/tmux"), // Homebrew (Apple Silicon)
-        PathBuf::from("/usr/local/bin/tmux"),    // Homebrew (Intel) / manual
-        PathBuf::from("/usr/bin/tmux"),          // system
-    ];
-
-    // Nix Home Manager: /etc/profiles/per-user/<username>/bin/tmux
-    if let Ok(user) = std::env::var("USER") {
-        candidates.push(PathBuf::from(format!(
-            "/etc/profiles/per-user/{}/bin/tmux",
-            user
-        )));
-    }
-    // Nix single-user profile
-    candidates.push(PathBuf::from("/nix/var/nix/profiles/default/bin/tmux"));
-
-    if let Some(found) = candidates.iter().find(|p| p.exists()) {
-        return Some(found.clone());
-    }
-
-    // PATH-based fallback (mise, asdf, custom installs, etc.)
-    if let Ok(path_var) = std::env::var("PATH") {
-        for dir in path_var.split(':') {
-            let candidate = PathBuf::from(dir).join("tmux");
-            if candidate.exists() {
-                return Some(candidate);
-            }
-        }
-    }
-
-    None
+    // Delegate to the shared resolver, passing the cached config override so
+    // session scanning (a hot path) doesn't re-read config.toml on every call.
+    agentoast_shared::tmux::find_tmux(get_config().system.tmux.as_deref())
 }
 
 pub(crate) fn find_git() -> Option<PathBuf> {


### PR DESCRIPTION
## Overview

- Add an `agentoast send-keys` subcommand that injects a message into another tmux pane's agent prompt, enabling cross-agent messaging addressed solely by pane id (e.g. `%72`) — no team, login, or registration.
- Introduce a shared `tmux` module so the CLI resolves the tmux binary the same way the GUI does.
- Ship an `agentoast-send` skill that documents how agents talk to each other, plus cargo-make tasks to install/uninstall it.

## Changes

### `crates/agentoast-shared/src/tmux.rs` (new)
- `find_tmux()` — resolves the tmux binary with the same lookup order as the Tauri app's `terminal::find_tmux` (`[system] tmux` config override → well-known Homebrew/system/Nix paths → `$PATH` scan).
- `pane_exists()` — verifies a target pane id exists via `tmux display-message`.
- `send_keys()` — injects the body as literal keystrokes (`send-keys -l --`) and optionally submits with a trailing `Enter`.

### `crates/agentoast-shared/src/lib.rs`
- Register the new `tmux` module.

### `crates/agentoast-cli/src/lib.rs`
- Add the `SendKeys` command with `--pane`, `--from`, `--raw`, `--no-enter` flags and register `send-keys` in the CLI fast-path allowlist.
- Resolve the reply address from `--from` → `$TMUX_PANE`, and (unless `--raw`) append a single-line reply hint so the receiving agent knows where and how to reply.

### `skills/agentoast-send/SKILL.md` (new)
- Document cross-pane agent messaging: sending, replying to incoming `(reply: ...)` hints, and why to prefer this over scraping the screen with `tmux capture-pane`.

### `Makefile.toml`
- Add `install-skill` / `uninstall-skill` tasks to copy the skill into `~/.config/claude/skills/`.


