### PR TITLE
feat: refuse send-keys to panes with no detected agent

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -21,6 +21,22 @@ args = ["run", "tauri", "build"]
 description = "Build Tauri app (includes CLI)"
 dependencies = ["build-app"]
 
+# Local-dev build: only the .app bundle, with updater artifacts disabled so no
+# `TAURI_SIGNING_PRIVATE_KEY` is required. Skips the .dmg and the signed updater
+# .tar.gz that `build-app` produces for releases.
+[tasks.build-app-dev]
+description = "Build .app only, unsigned (no updater artifacts / signing key)"
+command = "bun"
+args = [
+  "run",
+  "tauri",
+  "build",
+  "--bundles",
+  "app",
+  "--config",
+  "{\"bundle\":{\"createUpdaterArtifacts\":false}}",
+]
+
 # ---------------------------------------------------------------------------
 # Install
 # ---------------------------------------------------------------------------
@@ -53,6 +69,13 @@ script = [
 [tasks.install]
 description = "Build and install app + CLI symlink"
 dependencies = ["stop-app", "build"]
+run_task = { name = ["install-app", "install-cli-symlink"], parallel = false }
+
+# Local-dev install: same as `install` but uses the unsigned `build-app-dev`
+# (no updater artifacts), so it works without `TAURI_SIGNING_PRIVATE_KEY`.
+[tasks.install-dev]
+description = "Build (unsigned, no updater) and install app + CLI symlink for local dev"
+dependencies = ["stop-app", "build-app-dev"]
 run_task = { name = ["install-app", "install-cli-symlink"], parallel = false }
 
 # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -375,6 +375,34 @@ agentoast send \
   --meta branch=your-branch
 ```
 
+### Cross-Agent Messaging (Experimental)
+
+> **Experimental**: This feature and its skill packaging are still evolving and may change or be removed without notice.
+
+`agentoast send-keys` injects a message straight into another agent's prompt running in a different tmux pane, addressed only by its pane id (e.g. `%72`) — no team, login, or registration. Your own pane (`$TMUX_PANE`) is appended as a reply address, so the receiving agent can answer back into your pane.
+
+```bash
+agentoast send-keys --pane %72 "Please review the diff on this branch"
+```
+
+| Option       | Short | Default      | Description                                           |
+| ------------ | ----- | ------------ | ----------------------------------------------------- |
+| `--pane`     | `-t`  | (required)   | Target tmux pane id (e.g. `%72`)                      |
+| `--from`     | —     | `$TMUX_PANE` | Sender pane id embedded as the reply address          |
+| `--raw`      | —     | `false`      | Inject the raw message only, without the reply hint   |
+| `--no-enter` | —     | `false`      | Type the text without submitting (no trailing Enter)  |
+| `--force`    | —     | `false`      | Send even when the target pane runs no detected agent |
+
+By default `send-keys` refuses a target pane that has no detected AI agent (a plain shell), since the message would just be typed into the shell prompt — usually a sign you picked the wrong pane. Pass `--force` when you are sure an agent is running there but the detector doesn't recognize it.
+
+To let an agent drive this on its own (delegate a task, hand off, or reply to incoming messages), install the bundled [`agentoast-send`](skills/agentoast-send/SKILL.md) skill with [apm](https://github.com/danielmeppiel/apm).
+
+```bash
+apm install shuntaka9576/agentoast -t claude
+```
+
+This deploys the skill to `.claude/skills/`. Once installed, asking your agent to "ask the agent in pane %72 to review this" routes through `send-keys` automatically.
+
 ### Tips
 
 Set up a shell alias for command completion notifications. With `--tmux-pane`, clicking the notification jumps back to the pane.

--- a/crates/agentoast-cli/src/lib.rs
+++ b/crates/agentoast-cli/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod hooks;
 
 use agentoast_shared::models::IconType;
-use agentoast_shared::{config, db, tmux};
+use agentoast_shared::{agent_detect, config, db, tmux};
 use clap::{Parser, Subcommand};
 
 use hooks::{get_git_info, parse_metadata};
@@ -112,6 +112,12 @@ enum Commands {
         /// Do not send a trailing Enter (leave the text without submitting)
         #[arg(long)]
         no_enter: bool,
+
+        /// Send even when the target pane has no detected AI agent (a plain
+        /// shell). By default send-keys refuses such targets to avoid typing
+        /// the message into a shell prompt.
+        #[arg(long)]
+        force: bool,
     },
 
     /// Open config file in editor
@@ -294,14 +300,37 @@ fn run(cli: Cli) {
             from,
             raw,
             no_enter,
+            force,
         } => {
             let tmux_override = config::load_config().system.tmux;
             let Some(tmux_bin) = tmux::find_tmux(tmux_override.as_deref()) else {
                 eprintln!("tmux not found");
                 std::process::exit(1);
             };
-            if !tmux::pane_exists(&tmux_bin, &pane) {
+            // Resolve the pane's pid. This doubles as an existence check (a
+            // bogus pane yields no pid) and feeds agent detection below — one
+            // tmux call instead of a separate existence query.
+            let Some(pid) = tmux::pane_pid(&tmux_bin, &pane) else {
                 eprintln!("pane '{}' not found", pane);
+                std::process::exit(1);
+            };
+
+            // Guard: send-keys is for agent-to-agent messaging. If the target
+            // pane runs no detected AI agent (e.g. a plain shell), refuse by
+            // default — otherwise the message would be typed into the shell
+            // prompt and executed as commands. --force overrides (for agents
+            // the detector doesn't recognize).
+            let process_tree = agent_detect::build_process_tree();
+            let detected_agent = agent_detect::detect_agent(&process_tree, pid);
+            if detected_agent.is_none() && !force {
+                // One sentence per line, no mid-sentence hard breaks — the
+                // terminal wraps long lines on its own, and an agent reading
+                // this back parses whole sentences more reliably.
+                eprintln!(
+                    "pane '{}' has no detected AI coding agent (it looks like a plain shell), so send-keys would just type the message into the shell prompt.",
+                    pane
+                );
+                eprintln!("If an agent really is running there, re-run with --force.");
                 std::process::exit(1);
             }
 
@@ -324,8 +353,11 @@ fn run(cli: Cli) {
 
             match tmux::send_keys(&tmux_bin, &pane, &body, !no_enter) {
                 Ok(()) => println!(
-                    "sent to {} (from {})",
+                    "sent to {}{} (from {})",
                     pane,
+                    detected_agent
+                        .map(|a| format!(" [{}]", a))
+                        .unwrap_or_default(),
                     from_pane.as_deref().unwrap_or("-")
                 ),
                 Err(e) => {

--- a/crates/agentoast-shared/src/agent_detect.rs
+++ b/crates/agentoast-shared/src/agent_detect.rs
@@ -1,0 +1,169 @@
+//! Detect which AI coding agent (if any) is running inside a tmux pane.
+//!
+//! Shared between the GUI (per-pane session scanning in `sessions::mod`) and the
+//! CLI (`send-keys` guard that refuses to message a pane with no agent). Keeping
+//! `AGENT_PROCESSES` here as the single source of truth means the two callers can
+//! never disagree about "what counts as an agent" — e.g. adding a fifth agent
+//! updates both the GUI display and the `send-keys` guard at once.
+
+use std::collections::HashMap;
+use std::process::Command;
+
+/// `(process basename, agent_type)` pairs. A pane is considered to be running an
+/// agent when any descendant process matches one of these names.
+pub const AGENT_PROCESSES: &[(&str, &str)] = &[
+    ("claude", "claude-code"),
+    ("codex", "codex"),
+    ("copilot", "copilot-cli"),
+    ("opencode", "opencode"),
+    (".opencode", "opencode"), // mise/npm install: actual Go binary is named .opencode
+];
+
+/// Process tree: maps parent PID to child PIDs, plus each PID's command string.
+pub struct ProcessTree {
+    children: HashMap<u32, Vec<u32>>,
+    commands: HashMap<u32, String>,
+}
+
+impl ProcessTree {
+    /// Number of processes with a recorded command (for diagnostics/logging).
+    pub fn process_count(&self) -> usize {
+        self.commands.len()
+    }
+
+    /// Number of distinct parent PIDs with at least one child (for diagnostics).
+    pub fn parent_count(&self) -> usize {
+        self.children.len()
+    }
+}
+
+/// Build the full process tree from `/bin/ps -eo pid,ppid,comm`.
+pub fn build_process_tree() -> ProcessTree {
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    let mut commands: HashMap<u32, String> = HashMap::new();
+
+    let output = match Command::new("/bin/ps")
+        .args(["-eo", "pid,ppid,comm"])
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            log::error!("agent_detect: /bin/ps exec failed: {}", e);
+            return ProcessTree { children, commands };
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines().skip(1) {
+        let mut iter = line.split_whitespace();
+        let pid: u32 = match iter.next().and_then(|s| s.parse().ok()) {
+            Some(p) => p,
+            None => continue,
+        };
+        let ppid: u32 = match iter.next().and_then(|s| s.parse().ok()) {
+            Some(p) => p,
+            None => continue,
+        };
+        let comm: String = iter.collect::<Vec<&str>>().join(" ");
+        if comm.is_empty() {
+            continue;
+        }
+
+        children.entry(ppid).or_default().push(pid);
+        commands.insert(pid, comm);
+    }
+
+    ProcessTree { children, commands }
+}
+
+/// Walk the descendants of `pane_pid` and return the first matching agent type.
+pub fn detect_agent(tree: &ProcessTree, pane_pid: u32) -> Option<String> {
+    // DFS through descendants of pane_pid
+    let mut stack = vec![pane_pid];
+    let mut visited = std::collections::HashSet::new();
+    while let Some(current) = stack.pop() {
+        if !visited.insert(current) {
+            continue;
+        }
+        if let Some(child_pids) = tree.children.get(&current) {
+            for &child in child_pids {
+                if let Some(comm) = tree.commands.get(&child) {
+                    let basename = comm.rsplit('/').next().unwrap_or(comm);
+                    for (process_name, agent_type) in AGENT_PROCESSES {
+                        if basename == *process_name {
+                            return Some(agent_type.to_string());
+                        }
+                    }
+                    // Agent Teams spawns the versioned binary directly (e.g. /…/claude/versions/2.1.59)
+                    if comm.contains("/claude/versions/") {
+                        return Some("claude-code".to_string());
+                    }
+                }
+                stack.push(child);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tree(edges: &[(u32, u32)], commands: &[(u32, &str)]) -> ProcessTree {
+        let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+        for &(ppid, pid) in edges {
+            children.entry(ppid).or_default().push(pid);
+        }
+        let commands = commands
+            .iter()
+            .map(|&(pid, c)| (pid, c.to_string()))
+            .collect();
+        ProcessTree { children, commands }
+    }
+
+    #[test]
+    fn detects_claude_among_descendants() {
+        // pane(100) -> zsh(200) -> node(300) -> claude(400)
+        let t = tree(
+            &[(100, 200), (200, 300), (300, 400)],
+            &[
+                (200, "zsh"),
+                (300, "node"),
+                (400, "/opt/homebrew/bin/claude"),
+            ],
+        );
+        assert_eq!(detect_agent(&t, 100).as_deref(), Some("claude-code"));
+    }
+
+    #[test]
+    fn detects_versioned_claude_binary() {
+        // Agent Teams spawns the versioned binary directly; the path contains
+        // "/claude/versions/" (the install dir), not the basename "claude".
+        let t = tree(
+            &[(100, 200)],
+            &[(200, "/Users/me/.local/share/claude/versions/2.1.59")],
+        );
+        assert_eq!(detect_agent(&t, 100).as_deref(), Some("claude-code"));
+    }
+
+    #[test]
+    fn detects_dot_opencode_binary() {
+        let t = tree(&[(100, 200)], &[(200, "/home/me/.local/bin/.opencode")]);
+        assert_eq!(detect_agent(&t, 100).as_deref(), Some("opencode"));
+    }
+
+    #[test]
+    fn plain_shell_has_no_agent() {
+        // pane(100) -> zsh(200), nothing else
+        let t = tree(&[(100, 200)], &[(200, "zsh")]);
+        assert_eq!(detect_agent(&t, 100), None);
+    }
+
+    #[test]
+    fn substring_match_does_not_false_positive() {
+        // A process whose name merely contains "claude" must not match.
+        let t = tree(&[(100, 200)], &[(200, "claude-helper")]);
+        assert_eq!(detect_agent(&t, 100), None);
+    }
+}

--- a/crates/agentoast-shared/src/lib.rs
+++ b/crates/agentoast-shared/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod agent_detect;
 pub mod config;
 pub mod db;
 pub mod models;

--- a/crates/agentoast-shared/src/tmux.rs
+++ b/crates/agentoast-shared/src/tmux.rs
@@ -59,13 +59,21 @@ pub fn find_tmux(tmux_override: Option<&str>) -> Option<PathBuf> {
     None
 }
 
-/// Check that a tmux pane with the given id (e.g. `%72`) currently exists.
-pub fn pane_exists(tmux: &Path, pane: &str) -> bool {
-    Command::new(tmux)
-        .args(["display-message", "-t", pane, "-p", "#{pane_id}"])
+/// Resolve a tmux pane's pid (e.g. for `%72`), or `None` if it doesn't exist.
+///
+/// This doubles as an existence check: `display-message` exits 0 even for a
+/// bogus target (tmux evaluates the format against the current client and
+/// prints an empty `#{pane_pid}`), but an empty / unparseable pid yields `None`
+/// — so a real pane is the only way to get `Some`.
+pub fn pane_pid(tmux: &Path, pane: &str) -> Option<u32> {
+    let out = Command::new(tmux)
+        .args(["display-message", "-t", pane, "-p", "#{pane_pid}"])
         .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&out.stdout).trim().parse().ok()
 }
 
 /// Inject `body` into the target pane as literal keystrokes, then optionally

--- a/cspell.json
+++ b/cspell.json
@@ -75,6 +75,7 @@
     "topo",
     "unlisten",
     "unminimize",
+    "unparseable",
     "untap",
     "wezterm",
     "worktree",

--- a/skills/agentoast-send/SKILL.md
+++ b/skills/agentoast-send/SKILL.md
@@ -48,5 +48,6 @@ The agent knows its own context and will summarize it far better than a screen g
 ## Notes
 
 - Address = tmux pane id; ids stay stable for the life of the pane.
+- The target must be a pane running an AI coding agent. `send-keys` refuses a pane with no detected agent (a plain shell), since the message would just be typed into the shell prompt — a sign you picked the wrong pane. Pass `--force` only when you are sure an agent is there but the detector doesn't recognize it.
 - If the target looks busy mid-generation, injected keystrokes can interleave — prefer sending when it is idle or waiting for input.
 - `--raw` sends without the reply hint; `--no-enter` types without submitting.

--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -9,13 +9,7 @@ use crate::terminal::{find_git, find_tmux};
 pub(crate) mod agents;
 use agents::{capture_pane, detect_agent_status_with_content};
 
-const AGENT_PROCESSES: &[(&str, &str)] = &[
-    ("claude", "claude-code"),
-    ("codex", "codex"),
-    ("copilot", "copilot-cli"),
-    ("opencode", "opencode"),
-    (".opencode", "opencode"), // mise/npm install: actual Go binary is named .opencode
-];
+use agentoast_shared::agent_detect::{build_process_tree, detect_agent};
 
 struct GitInfo {
     repo_root: String,
@@ -194,8 +188,8 @@ pub fn list_tmux_panes_grouped(show_non_agent: bool) -> Result<Vec<TmuxPaneGroup
     let process_tree = build_process_tree();
     log::debug!(
         "sessions: process tree: {} processes, {} parent entries",
-        process_tree.commands.len(),
-        process_tree.children.len()
+        process_tree.process_count(),
+        process_tree.parent_count()
     );
 
     // Parse panes (without git info yet)
@@ -508,77 +502,4 @@ pub fn find_focused_pane() -> Result<Option<TmuxPane>, String> {
         git_branch: git_info.as_ref().and_then(|g| g.branch.clone()),
         current_command,
     }))
-}
-
-/// Process tree: maps parent PID to (child PID, command name) pairs.
-struct ProcessTree {
-    children: HashMap<u32, Vec<u32>>,
-    commands: HashMap<u32, String>,
-}
-
-fn build_process_tree() -> ProcessTree {
-    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
-    let mut commands: HashMap<u32, String> = HashMap::new();
-
-    let output = match Command::new("/bin/ps")
-        .args(["-eo", "pid,ppid,comm"])
-        .output()
-    {
-        Ok(o) => o,
-        Err(e) => {
-            log::error!("sessions: /bin/ps exec failed: {}", e);
-            return ProcessTree { children, commands };
-        }
-    };
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    for line in stdout.lines().skip(1) {
-        let mut iter = line.split_whitespace();
-        let pid: u32 = match iter.next().and_then(|s| s.parse().ok()) {
-            Some(p) => p,
-            None => continue,
-        };
-        let ppid: u32 = match iter.next().and_then(|s| s.parse().ok()) {
-            Some(p) => p,
-            None => continue,
-        };
-        let comm: String = iter.collect::<Vec<&str>>().join(" ");
-        if comm.is_empty() {
-            continue;
-        }
-
-        children.entry(ppid).or_default().push(pid);
-        commands.insert(pid, comm);
-    }
-
-    ProcessTree { children, commands }
-}
-
-fn detect_agent(tree: &ProcessTree, pane_pid: u32) -> Option<String> {
-    // DFS through descendants of pane_pid
-    let mut stack = vec![pane_pid];
-    let mut visited = std::collections::HashSet::new();
-    while let Some(current) = stack.pop() {
-        if !visited.insert(current) {
-            continue;
-        }
-        if let Some(child_pids) = tree.children.get(&current) {
-            for &child in child_pids {
-                if let Some(comm) = tree.commands.get(&child) {
-                    let basename = comm.rsplit('/').next().unwrap_or(comm);
-                    for (process_name, agent_type) in AGENT_PROCESSES {
-                        if basename == *process_name {
-                            return Some(agent_type.to_string());
-                        }
-                    }
-                    // Agent Teams spawns the versioned binary directly (e.g. /…/claude/versions/2.1.59)
-                    if comm.contains("/claude/versions/") {
-                        return Some("claude-code".to_string());
-                    }
-                }
-                stack.push(child);
-            }
-        }
-    }
-    None
 }


### PR DESCRIPTION
## Summary

- Share process-tree agent detection between the GUI and the CLI so both agree on "what counts as an agent" from a single source of truth.
- `send-keys` now refuses a target pane that runs no detected AI agent (a plain shell) unless `--force` is passed, preventing a message from being typed into a shell prompt.
- Add unsigned local-dev build tasks so a build works without `TAURI_SIGNING_PRIVATE_KEY`.

## Changes

### Shared agent detection (`crates/agentoast-shared/src/agent_detect.rs`, new)
- Extract `build_process_tree` / `detect_agent` / `AGENT_PROCESSES` (and the `ProcessTree` type with `process_count` / `parent_count`) into a shared module as the single source of truth.
- Covered by 5 unit tests (claude among descendants, versioned binary, `.opencode`, plain shell, substring non-match).

### GUI (`src-tauri/src/sessions/mod.rs`)
- Consume `agentoast_shared::agent_detect` and drop the duplicated process-tree / detection copy.

### CLI (`crates/agentoast-cli/src/lib.rs`)
- Add `--force` to `send-keys`.
- Resolve the target pid via `tmux::pane_pid`, build the process tree, and run `detect_agent`. When no agent is detected and `--force` is not set, print a clear error and exit non-zero.
- The success message now reports the detected agent type, e.g. `sent to %72 [claude-code] (from %45)`.

### tmux helper (`crates/agentoast-shared/src/tmux.rs`)
- Replace `pane_exists` with `pane_pid`, which resolves the pane pid and doubles as an existence check. `display-message` exits 0 even for a bogus target (printing an empty pid), so an empty/unparseable pid is the real "does not exist" signal.

### Local-dev build (`Makefile.toml`)
- Add `build-app-dev` (builds the `.app` only, `createUpdaterArtifacts: false`) and `install-dev` (build + install + CLI symlink) so local installs work without a signing key.

### Docs
- `README.md`: cross-agent messaging section + `--force` row and the default-refuse-plain-shell behavior.
- `skills/agentoast-send/SKILL.md`: note about the agent-only guard and when to use `--force`.


