### PR TITLE
perf: cache resolved tmux/git binary paths in GUI hot paths

### DIFF
--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -6,6 +6,13 @@ use agentoast_shared::config::{self, AppConfig};
 
 static CONFIG: OnceLock<AppConfig> = OnceLock::new();
 
+// Resolved binary paths, cached after the first successful probe so hot paths
+// (per-pane capture, watcher repo resolution) don't re-stat the filesystem.
+// A failed probe is intentionally NOT cached: if tmux/git gets installed while
+// the app is running, the next call can still find it.
+static TMUX_PATH: OnceLock<PathBuf> = OnceLock::new();
+static GIT_PATH: OnceLock<PathBuf> = OnceLock::new();
+
 fn get_config() -> &'static AppConfig {
     CONFIG.get_or_init(config::load_config)
 }
@@ -20,12 +27,26 @@ const KNOWN_TERMINAL_BUNDLE_IDS: &[&str] = &[
 ];
 
 pub(crate) fn find_tmux() -> Option<PathBuf> {
+    if let Some(p) = TMUX_PATH.get() {
+        return Some(p.clone());
+    }
     // Delegate to the shared resolver, passing the cached config override so
     // session scanning (a hot path) doesn't re-read config.toml on every call.
-    agentoast_shared::tmux::find_tmux(get_config().system.tmux.as_deref())
+    let found = agentoast_shared::tmux::find_tmux(get_config().system.tmux.as_deref())?;
+    let _ = TMUX_PATH.set(found.clone());
+    Some(found)
 }
 
 pub(crate) fn find_git() -> Option<PathBuf> {
+    if let Some(p) = GIT_PATH.get() {
+        return Some(p.clone());
+    }
+    let found = probe_git()?;
+    let _ = GIT_PATH.set(found.clone());
+    Some(found)
+}
+
+fn probe_git() -> Option<PathBuf> {
     // config.toml override (highest priority)
     if let Some(ref path) = get_config().system.git {
         let p = PathBuf::from(path);


### PR DESCRIPTION
## Summary

- Cache the resolved tmux/git binary paths in `OnceLock<PathBuf>` statics so GUI hot paths stop re-probing the filesystem on every call
- `find_tmux()` is called per pane via `capture_pane()` fan-out, and `find_git()` runs on every session refresh and watcher repo resolution — each call previously cost 3-6 `stat(2)` probes plus a `$PATH` scan fallback
- A failed probe is intentionally NOT cached, so tmux/git installed after app launch can still be discovered on a later call

## Changes

### `src-tauri/src/terminal.rs`

- Added `static TMUX_PATH: OnceLock<PathBuf>` / `static GIT_PATH: OnceLock<PathBuf>`
- `find_tmux()` returns the cached path when present; otherwise delegates to the shared resolver and stores the result only on success
- `find_git()` follows the same pattern, with the existing probe logic extracted unchanged into a private `probe_git()`
- The shared crate resolver (`agentoast-shared::tmux::find_tmux`) and the CLI path are unchanged — the CLI is a short-lived process and needs no caching

### Trade-off

If the binary is moved or removed after caching, the stale path makes subsequent tmux/git invocations fail (logged, non-fatal). This matches the existing behavior where config changes also require an app restart.


