### PR TITLE
fix: replace clipped CSS panel shadow with native macOS window shadow

### DIFF
--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -81,7 +81,12 @@ pub fn init(app_handle: &tauri::AppHandle) -> tauri::Result<()> {
     let window = app_handle.get_webview_window("main").unwrap();
     let panel = window.to_panel::<AgentNotifyPanel>()?;
 
-    panel.set_has_shadow(false);
+    // Native macOS window shadow. AppKit derives the shadow shape from the
+    // window's rendered alpha, so it hugs the rounded panel + tray arrow the
+    // same way NSMenu/NSPopover shadows do. A CSS box-shadow can't do this:
+    // it gets clipped at the window bounds (the padding around the panel),
+    // leaving a visible rectangular gradient edge on light backgrounds.
+    panel.set_has_shadow(true);
     panel.set_opaque(false);
     panel.set_level(PanelLevel::MainMenu.value() + 1);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1081,7 +1081,7 @@ export function App() {
   return (
     <div className="h-screen flex flex-col items-center px-4 pb-4 pt-0.5 bg-transparent">
       <div className="tray-arrow" />
-      <div className="w-full flex-1 min-h-0 flex flex-col bg-[var(--panel-bg)] backdrop-blur-xl rounded-xl border border-[var(--border-primary)] shadow-2xl overflow-hidden">
+      <div className="w-full flex-1 min-h-0 flex flex-col bg-[var(--panel-bg)] backdrop-blur-xl rounded-xl border border-[var(--border-primary)] overflow-hidden">
         <PanelHeader
           globalMuted={globalMuted}
           filterNotifiedOnly={filterNotifiedOnly}


### PR DESCRIPTION
## Summary

- The tray panel's CSS `shadow-2xl` was painted inside the window's 16px transparent padding and got hard-clipped at the window bounds, leaving a visible rectangular gradient "frame" around the panel (very noticeable on light backgrounds).
- Replace it with the native macOS window shadow: enable `set_has_shadow(true)` on the NSPanel and drop the CSS box-shadow entirely.
- AppKit derives the shadow shape from the window's rendered alpha, so the shadow hugs the rounded panel and tray arrow the same way NSMenu/NSPopover shadows do, and is never clipped.

## Changes

- `src-tauri/src/panel.rs`: `set_has_shadow(false)` → `set_has_shadow(true)` with a comment explaining why a CSS box-shadow can't be used here.
- `src/App.tsx`: remove `shadow-2xl` from the main panel container.


