### PR TITLE
feat: add r/R to jump to running panes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1021,17 +1021,38 @@ export function App() {
         e.preventDefault();
         repositionCancelledRef.current = true;
         const direction = e.shiftKey ? -1 : 1;
-        const curIdx = indexOfKey(flatItems, selectedKeyRef.current);
-        let nextIndex =
-          curIdx < 0 ? (direction === 1 ? 0 : flatItems.length - 1) : curIdx + direction;
-        while (nextIndex >= 0 && nextIndex < flatItems.length) {
-          const fi = flatItems[nextIndex];
-          const hasNotif = fi.type === "pane-item" && fi.paneItem.notification !== null;
-          if (hasNotif) {
-            setSelectedKey(keyFromItem(fi));
-            break;
+        const target = findNextPaneByPredicate(
+          displayGroups,
+          selectedKeyRef.current,
+          direction,
+          (pi) => pi.notification !== null,
+        );
+        if (target) {
+          if (collapsedGroups.has(target.groupKey)) {
+            toggleGroupExpanded(target.groupKey);
           }
-          nextIndex += direction;
+          setSelectedKey({ kind: "pane", paneId: target.paneId });
+        }
+        break;
+      }
+      case "r":
+      case "R": {
+        if (showHelp || e.metaKey || e.ctrlKey || e.altKey) break;
+        if (e.key === "r" && e.shiftKey) break;
+        e.preventDefault();
+        repositionCancelledRef.current = true;
+        const direction = e.key === "R" ? -1 : 1;
+        const target = findNextPaneByPredicate(
+          displayGroups,
+          selectedKeyRef.current,
+          direction,
+          (pi) => pi.pane.agentStatus === "running",
+        );
+        if (target) {
+          if (collapsedGroups.has(target.groupKey)) {
+            toggleGroupExpanded(target.groupKey);
+          }
+          setSelectedKey({ kind: "pane", paneId: target.paneId });
         }
         break;
       }
@@ -1200,6 +1221,45 @@ function keyFromItem(f: FlatItem): SelectedKey {
     return { kind: "group", groupKey: f.groupKey };
   }
   return { kind: "pane", paneId: f.paneItem.pane.paneId };
+}
+
+function findNextPaneByPredicate(
+  displayGroups: UnifiedGroup[],
+  currentKey: SelectedKey | null,
+  direction: 1 | -1,
+  predicate: (pi: PaneItem) => boolean,
+): { groupKey: string; paneId: string } | null {
+  type FlatPane = { groupKey: string; paneItem: PaneItem };
+  const allPanes: FlatPane[] = [];
+  for (const ug of displayGroups) {
+    for (const pi of ug.paneItems) {
+      allPanes.push({ groupKey: ug.groupKey, paneItem: pi });
+    }
+  }
+  const total = allPanes.length;
+  if (total === 0) return null;
+  const outOfBounds = direction === 1 ? -1 : total;
+
+  let startIdx: number;
+  if (currentKey?.kind === "pane") {
+    const idx = allPanes.findIndex((p) => p.paneItem.pane.paneId === currentKey.paneId);
+    startIdx = idx < 0 ? outOfBounds : idx;
+  } else if (currentKey?.kind === "group") {
+    const first = allPanes.findIndex((p) => p.groupKey === currentKey.groupKey);
+    startIdx = first < 0 ? outOfBounds : direction === 1 ? first - 1 : first;
+  } else {
+    startIdx = outOfBounds;
+  }
+
+  for (let step = 1; step <= total; step++) {
+    const raw = startIdx + direction * step;
+    const idx = ((raw % total) + total) % total;
+    const fp = allPanes[idx];
+    if (predicate(fp.paneItem)) {
+      return { groupKey: fp.groupKey, paneId: fp.paneItem.pane.paneId };
+    }
+  }
+  return null;
 }
 
 function indexOfKey(items: FlatItem[], key: SelectedKey | null): number {

--- a/src/components/keybind-help.tsx
+++ b/src/components/keybind-help.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from "react";
+
 interface KeybindHelpProps {
   onClose: () => void;
 }
@@ -7,82 +9,179 @@ interface Keybind {
   action: string;
 }
 
+interface SubGroup {
+  title?: string;
+  binds: Keybind[];
+}
+
 interface Section {
   title: string;
-  binds: Keybind[];
+  groups: SubGroup[];
 }
 
 const SECTIONS: Section[] = [
   {
     title: "Navigation",
-    binds: [
-      { key: "j", action: "Next" },
-      { key: "k", action: "Previous" },
-      { key: "gg", action: "Jump to top" },
-      { key: "G", action: "Jump to bottom" },
-      { key: "Tab", action: "Next notif" },
-      { key: "⇧Tab", action: "Prev notif" },
-    ],
-  },
-  {
-    title: "Search",
-    binds: [
-      { key: "/", action: "Search repos" },
-      { key: "n", action: "Next match" },
-      { key: "N", action: "Prev match" },
+    groups: [
+      {
+        title: "Step",
+        binds: [
+          { key: "j", action: "Next" },
+          { key: "k", action: "Previous" },
+          { key: "gg", action: "Jump to top" },
+          { key: "G", action: "Jump to bottom" },
+        ],
+      },
+      {
+        title: "By status",
+        binds: [
+          { key: "Tab", action: "Next notif" },
+          { key: "S-Tab", action: "Prev notif" },
+          { key: "r", action: "Next running" },
+          { key: "R", action: "Prev running" },
+        ],
+      },
+      {
+        title: "tmux",
+        binds: [{ key: "t", action: "Jump to current pane" }],
+      },
     ],
   },
   {
     title: "Actions",
-    binds: [
-      { key: "Enter", action: "Open / Fold" },
-      { key: "d", action: "Delete notif" },
-      { key: "D", action: "Delete all" },
-      { key: "C", action: "Collapse all" },
-      { key: "E", action: "Expand all" },
-      { key: "F", action: "Filter notified" },
-      { key: "T", action: "Non-agent panes" },
-      { key: "t", action: "Jump to current pane" },
-      { key: "y", action: "Copy $TMUX_PANE" },
-      { key: "a", action: "Toggle apps" },
+    groups: [
+      {
+        binds: [
+          { key: "d", action: "Delete notif" },
+          { key: "D", action: "Delete all" },
+          { key: "C", action: "Collapse all" },
+          { key: "E", action: "Expand all" },
+          { key: "F", action: "Filter notified" },
+          { key: "T", action: "Show all tmux panes" },
+          { key: "y", action: "Copy $TMUX_PANE" },
+          { key: "a", action: "Toggle apps" },
+          { key: "Enter", action: "Open / Fold" },
+        ],
+      },
+    ],
+  },
+  {
+    title: "Search",
+    groups: [
+      {
+        binds: [
+          { key: "n", action: "Next match" },
+          { key: "N", action: "Prev match" },
+          { key: "/", action: "Search repos" },
+        ],
+      },
     ],
   },
   {
     title: "Misc",
-    binds: [
-      { key: "?", action: "Help" },
-      { key: "Esc", action: "Close" },
+    groups: [
+      {
+        binds: [
+          { key: "?", action: "Help" },
+          { key: "Esc", action: "Close" },
+        ],
+      },
     ],
   },
 ];
 
 export function KeybindHelp({ onClose }: KeybindHelpProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const el = containerRef.current;
+      if (!el) return;
+      if (e.metaKey || e.altKey) return;
+
+      const lineStep = 28;
+      switch (e.key) {
+        case "j":
+          if (e.ctrlKey || e.shiftKey) return;
+          el.scrollBy({ top: lineStep });
+          break;
+        case "k":
+          if (e.ctrlKey || e.shiftKey) return;
+          el.scrollBy({ top: -lineStep });
+          break;
+        case "g":
+          if (e.ctrlKey || e.shiftKey) return;
+          el.scrollTo({ top: 0 });
+          break;
+        case "G":
+          if (e.ctrlKey) return;
+          el.scrollTo({ top: el.scrollHeight });
+          break;
+        default:
+          return;
+      }
+      e.preventDefault();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
   return (
     <div
-      className="absolute inset-0 z-10 flex items-start justify-center overflow-y-auto px-4 py-4 bg-[var(--panel-bg)]"
+      className="absolute inset-0 z-10 flex flex-col bg-[var(--panel-bg)]"
       onClick={onClose}
       tabIndex={-1}
     >
-      <div className="w-full flex flex-col gap-3" onClick={(e) => e.stopPropagation()}>
-        {SECTIONS.map((section) => (
-          <div key={section.title} className="flex flex-col gap-1">
-            <div className="text-[9px] uppercase tracking-wider font-semibold text-[var(--text-muted)] pl-1">
-              {section.title}
+      <div
+        ref={containerRef}
+        className="flex-1 overflow-y-auto px-4 py-4 flex items-start justify-center"
+      >
+        <div className="w-full flex flex-col gap-3" onClick={(e) => e.stopPropagation()}>
+          {SECTIONS.map((section) => (
+            <div key={section.title} className="flex flex-col gap-1">
+              <div className="text-[9px] uppercase tracking-wider font-semibold text-[var(--text-muted)] pl-1">
+                {section.title}
+              </div>
+              <div className="flex flex-col gap-1.5">
+                {section.groups.map((group, gi) => (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: subgroup index is stable per section
+                  <div key={gi} className="flex flex-col gap-0.5">
+                    {group.title && (
+                      <div className="text-[9px] tracking-wide text-[var(--text-muted)] opacity-60 pl-1">
+                        {group.title}
+                      </div>
+                    )}
+                    <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+                      {group.binds.map(({ key, action }) => (
+                        <div key={key} className="flex items-center gap-2">
+                          <span className="min-w-[44px] text-center text-[10px] font-mono py-0.5 px-1.5 rounded bg-[var(--hover-bg-strong)] text-[var(--text-primary)] border border-[var(--border-subtle)]">
+                            {key}
+                          </span>
+                          <span className="text-[11px] text-[var(--text-secondary)] truncate">
+                            {action}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
-            <div className="grid grid-cols-2 gap-x-3 gap-y-1">
-              {section.binds.map(({ key, action }) => (
-                <div key={key} className="flex items-center gap-2">
-                  <span className="min-w-[44px] text-center text-[10px] font-mono py-0.5 px-1.5 rounded bg-[var(--hover-bg-strong)] text-[var(--text-primary)] border border-[var(--border-subtle)]">
-                    {key}
-                  </span>
-                  <span className="text-[11px] text-[var(--text-secondary)] truncate">
-                    {action}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-        ))}
+          ))}
+        </div>
+      </div>
+      <div
+        className="border-t border-[var(--border-subtle)] px-3 py-1.5 flex items-center gap-3 text-[9px] text-[var(--text-muted)] bg-[var(--panel-bg)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <span className="flex items-center gap-1">
+          <kbd className="font-mono text-[var(--text-primary)]">j/k</kbd>
+          scroll
+        </span>
+        <span className="flex items-center gap-1">
+          <kbd className="font-mono text-[var(--text-primary)]">g/G</kbd>
+          top/bottom
+        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add `r` / `R` shortcut to cycle to the next / previous running agent pane in the main panel.
- Make `Tab` / `S-Tab` and `r` / `R` work across collapsed groups (auto-expand the target group when a match lands inside it) and wrap around at list boundaries.
- Restructure the help overlay with sub-groups (Step / By status / tmux) and add keyboard scrolling (`j` / `k` / `g` / `G`) with a visible footer hint so users can discover that scrolling is possible.

## Changes

### `src/App.tsx`
- Extract `findNextPaneByPredicate` helper next to `keyFromItem` / `indexOfKey`. Returns the next pane matching a predicate, walking `displayGroups` directly so collapsed groups are not skipped, with modulo wrap-around.
- Replace the `Tab` / `S-Tab` handler body with a call to the helper using `(pi) => pi.notification !== null`.
- Add `r` / `R` handler using the same helper with `(pi) => pi.pane.agentStatus === "running"`.
- Both handlers auto-expand the destination group via `toggleGroupExpanded` when the target pane is in a collapsed group.

### `src/components/keybind-help.tsx`
- Reshape `Section` to `groups: SubGroup[]` so Navigation can show sub-headers (`Step`, `By status`, `tmux`); single-group sections are unchanged visually.
- Reorder sections to `Navigation → Actions → Search → Misc` and rebalance pairs (`d`/`D`, `C`/`E`, `F`/`T`, `n`/`N`) so partners share a row.
- Relabel `T` to `Show all tmux panes` (was `Non-agent panes`).
- Move `t` (Jump to current pane) from Actions to Navigation > tmux.
- Add a keyboard scroll handler (`j` / `k` line, `g` / `G` top/bottom) on a window-level listener; cleanup on unmount.
- Add a fixed footer hint showing the scroll keys so the affordance is discoverable.
