### PR TITLE
docs: split Codex notify into argv array form

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,9 @@ No Deno dependency required. The CLI reads hook data from stdin and writes direc
 
 ```toml
 notify = [
-  "agentoast hook codex",
+  "agentoast",
+  "hook",
+  "codex",
 ]
 ```
 


### PR DESCRIPTION
## Summary
- Fix the Codex `notify` example in README so it actually triggers.
- The previous single-string `"agentoast hook codex"` was passed to codex 0.139.0 as **one** argv element. codex tried to spawn a binary literally named `agentoast hook codex` and failed with `ENOENT` (`hook_name=legacy_notify error=No such file or directory (os error 2)`), so no notification was ever delivered.
- Splitting it into the argv array form (`["agentoast", "hook", "codex"]`) makes codex spawn `agentoast` with `hook codex` as separate arguments, which works as intended.

## Change
`README.md` — Codex section under the Notify configuration:

```toml
# before
notify = [
  "agentoast hook codex",
]

# after
notify = [
  "agentoast",
  "hook",
  "codex",
]
```

