### PR TITLE
fix: route send-keys through tmux paste-buffer to eliminate Codex enter race

### DIFF
--- a/crates/agentoast-shared/src/tmux.rs
+++ b/crates/agentoast-shared/src/tmux.rs
@@ -76,16 +76,39 @@ pub fn pane_pid(tmux: &Path, pane: &str) -> Option<u32> {
     String::from_utf8_lossy(&out.stdout).trim().parse().ok()
 }
 
-/// Inject `body` into the target pane as literal keystrokes, then optionally
-/// submit it with Enter.
+/// Inject `body` into the target pane via a bracketed-paste sequence, then
+/// optionally submit it with Enter.
 ///
-/// `-l` sends the text literally (no key-name interpretation) and `--`
-/// terminates option parsing, so a body starting with `-` is delivered safely.
+/// We deliberately avoid `tmux send-keys -l <body>` followed by a separate
+/// `send-keys Enter`: on some agent TUIs (notably Codex's crossterm-based
+/// input loop) the trailing Enter arrives within the body burst and is
+/// absorbed as paste content, so the message lands in the input box but
+/// never submits. The failure is intermittent — it depends on tmux server
+/// scheduling and the receiver's paste-detection heuristics.
+///
+/// Instead we stage the body in a uniquely-named tmux paste buffer and
+/// dispatch it with `paste-buffer -p`, which wraps the bytes in bracketed-
+/// paste markers (`ESC [200~ … ESC [201~`). Receivers that opt into
+/// bracketed paste mode (every modern agent TUI does) see an explicit
+/// paste-end marker before our subsequent Enter, so the Enter is
+/// unambiguously a key press and not part of the paste — eliminating the
+/// race at the byte-stream level regardless of how the TUI schedules reads.
+/// `-d` deletes the buffer after pasting so we don't leak names.
 pub fn send_keys(tmux: &Path, pane: &str, body: &str, enter: bool) -> Result<(), String> {
+    let buf_name = format!("agentoast-send-{}", std::process::id());
+
     let out = Command::new(tmux)
-        .args(["send-keys", "-t", pane, "-l", "--", body])
+        .args(["set-buffer", "-b", &buf_name, "--", body])
         .output()
-        .map_err(|e| format!("failed to run tmux send-keys: {e}"))?;
+        .map_err(|e| format!("failed to run tmux set-buffer: {e}"))?;
+    if !out.status.success() {
+        return Err(String::from_utf8_lossy(&out.stderr).trim().to_string());
+    }
+
+    let out = Command::new(tmux)
+        .args(["paste-buffer", "-t", pane, "-b", &buf_name, "-p", "-d"])
+        .output()
+        .map_err(|e| format!("failed to run tmux paste-buffer: {e}"))?;
     if !out.status.success() {
         return Err(String::from_utf8_lossy(&out.stderr).trim().to_string());
     }

--- a/skills/agentoast-send/SKILL.md
+++ b/skills/agentoast-send/SKILL.md
@@ -23,17 +23,29 @@ Talk to AI coding agents running in OTHER tmux panes by injecting a message into
    - The user usually provides it — often by pasting agentoast's clipboard string `Please take a look at tmux pane %72.` Take the `%72` from there.
    - If no pane id is present, ask the user which pane to send to.
 2. Run:
+
    ```
    agentoast send-keys --pane %72 "your message"
    ```
-   The text is typed straight into that agent's prompt and submitted. Your own pane is read from `$TMUX_PANE` and appended as a reply address, so the receiver sees a trailing `(reply: agentoast send-keys --pane <you> "<reply>")`. You do not add that hint yourself.
+
+   The text is staged in a tmux paste buffer and delivered to that agent's prompt with bracketed-paste markers, then submitted with Enter. When `--from` is passed or `$TMUX_PANE` is set (the normal case when you are yourself running inside tmux), that pane id is appended as a reply address, so the receiver sees a trailing `(reply: agentoast send-keys --pane <you> "<reply>")`. You do not add that hint yourself. If neither is available (e.g. you are invoked from outside tmux), no reply hint is appended — pass `--from %NN` explicitly when you want one.
+
 3. Tell the user it was sent. The reply arrives later as a new prompt in YOUR pane — there is nothing to poll or watch.
 
 Write the message yourself from the conversation so far. You hold context the other agent lacks, so phrase a self-contained request (summarize the task or question) rather than a bare "see above" — the other pane can't see your screen.
 
 ## Replying to an incoming message
 
-If your prompt contains a line like `(reply: agentoast send-keys --pane %45 "<reply>")`, that is a message from another agent. Do the work it asks for, then run that exact command with your answer in place of `<reply>`.
+If your prompt contains a line like `(reply: agentoast send-keys --pane %45 "<reply>")`, that is a message from another agent. Do the work it asks for, then run `agentoast send-keys --pane %45` with your answer as a single shell-safe argument — do not blindly paste your reply into the literal command template, because reply text often contains `"`, `` ` ``, `$(...)`, or newlines that would break shell quoting or trigger unintended expansion. Pass the answer via a quoted here-doc instead:
+
+```
+agentoast send-keys --pane %45 "$(cat <<'EOF'
+your multi-line answer with "quotes", $vars, and `backticks` is safe here
+EOF
+)"
+```
+
+The `'EOF'` (single-quoted heredoc tag) suppresses shell expansion inside the body, so nothing in the reply gets interpreted.
 
 ## Don't scrape the screen — ask the agent
 


### PR DESCRIPTION
## Summary

- `agentoast send-keys` previously delivered the body via `tmux send-keys -l <body>` and submitted with a separate `tmux send-keys Enter` invocation. On Codex's crossterm-based input loop the trailing Enter raced with the body burst and was intermittently absorbed as paste content — the message landed in the input box without ever submitting (~1/3 of the time in back-to-back probes; not reproducible on Claude Code, but the race window exists for any TUI).
- Stage the body in a uniquely-named tmux paste buffer and dispatch it with `paste-buffer -p`, which wraps the bytes in bracketed-paste markers (`ESC [200~ … ESC [201~`). Receivers that opt into bracketed paste mode (every modern agent TUI does) see an explicit paste-end marker before our subsequent Enter, so the Enter is unambiguously a key press and not part of the paste — eliminating the race at the byte-stream level regardless of how the TUI schedules reads. `-d` deletes the buffer after pasting so we do not leak buffer names.
- Also fix two docs defects in `skills/agentoast-send/SKILL.md` (originally surfaced by Codex while reviewing an earlier iteration of this PR): the reply template was shell-injection-unsafe (now uses a single-quoted heredoc pattern), and the reply-hint behavior was described unconditionally (now made explicit that it only fires when `--from` is passed or `$TMUX_PANE` is set).

## Empirical validation

| Binary | Target | Result |
|---|---|---|
| Old | Codex (%37), 3 back-to-back probes | n=3 stuck in input box, never submitted |
| Old | Claude Code (%39), 3 back-to-back probes | 3/3 submitted |
| New | Codex (%37), 5 back-to-back probes | 5/5 submitted (some queued by Codex as expected when busy) |

## Test plan

- [ ] `cargo make lint` passes locally (rustfmt / clippy / vp fmt / cspell)
- [ ] Send a message to a Codex pane and confirm it submits without sitting in the input box
- [ ] Send N back-to-back messages to a Codex pane and confirm the race never recurs
- [ ] Verify `--no-enter` still leaves the message in the input box without submitting
- [ ] Verify `--raw` still skips the reply hint
- [ ] Verify SKILL.md renders correctly on GitHub
