### PR TITLE
feat: keep streaming Claude panes Running via body-hash hysteresis

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,14 @@ pub struct SessionsCache {
     pub groups: Option<Vec<TmuxPaneGroup>>,
 }
 
+/// Per-pane "did this body just change?" tracker consumed by the agent
+/// status detector. Owns nothing else; lives in its own Tauri-managed state
+/// so the hot path (`list_tmux_panes_grouped`) can lock it independently of
+/// `SessionsCache`, whose lock is taken later to publish the rendered
+/// groups.
+#[cfg(target_os = "macos")]
+pub type PaneHysteresisState = Mutex<sessions::hysteresis::PaneHysteresis>;
+
 #[derive(Default)]
 pub struct MuteState {
     pub global_muted: bool,
@@ -99,7 +107,9 @@ fn refresh_and_emit(app_handle: &tauri::AppHandle) {
 #[cfg(target_os = "macos")]
 fn refresh_and_emit_with_conn(app_handle: &tauri::AppHandle, db_conn: &Option<db::Connection>) {
     let show_non_agent = read_show_non_agent_panes(app_handle);
-    match sessions::list_tmux_panes_grouped(show_non_agent, db_conn) {
+    let hysteresis_state = app_handle.try_state::<PaneHysteresisState>();
+    let hysteresis = hysteresis_state.as_ref().map(|s| s.inner());
+    match sessions::list_tmux_panes_grouped(show_non_agent, db_conn, hysteresis) {
         Ok(groups) => {
             // Reaching here means the tmux server is alive and responsive —
             // the right moment to attempt one-shot hook registration (retries
@@ -455,9 +465,12 @@ async fn get_sessions(app_handle: tauri::AppHandle) -> Result<Vec<TmuxPaneGroup>
     #[cfg(target_os = "macos")]
     {
         let show_non_agent = read_show_non_agent_panes(&app_handle);
+        let hysteresis_handle = app_handle.clone();
         let result = tauri::async_runtime::spawn_blocking(move || {
             let db_conn = db::open_reader(&config::db_path()).ok();
-            sessions::list_tmux_panes_grouped(show_non_agent, &db_conn)
+            let hysteresis_state = hysteresis_handle.try_state::<PaneHysteresisState>();
+            let hysteresis = hysteresis_state.as_ref().map(|s| s.inner());
+            sessions::list_tmux_panes_grouped(show_non_agent, &db_conn, hysteresis)
         })
         .await
         .map_err(|e| e.to_string())?;
@@ -1235,6 +1248,10 @@ pub fn run() {
             }));
 
             app.manage(Mutex::new(SessionsCache { groups: None }));
+            #[cfg(target_os = "macos")]
+            app.manage::<PaneHysteresisState>(Mutex::new(
+                sessions::hysteresis::PaneHysteresis::default(),
+            ));
 
             app.manage(Mutex::new(MuteState {
                 global_muted: initial_muted,

--- a/src-tauri/src/sessions/agents/claude.rs
+++ b/src-tauri/src/sessions/agents/claude.rs
@@ -953,7 +953,7 @@ another history line
 
     #[test]
     fn hash_assist_none_preserves_legacy_idle() {
-        // No hash assist available (first-seen pane / unlocatable input) —
+        // No hash assist available (first-seen pane / input not found) —
         // judgement must match the pre-change behavior exactly.
         let result = detect_claude_status(&None, "%9", Some(AT_PROMPT_NO_SPINNER), None);
         assert_eq!(result.status, AgentStatus::Idle);
@@ -969,8 +969,8 @@ some history line
 ⏺ Claude is streaming a response and the input box is hidden while text
   pours into the conversation history. Once the spinner glyph briefly
   drops out of view, none of the status-bar markers help either.
-1234567890 lorem ipsum dolor sit amet consectetur adipiscing elit
-1234567890 sed do eiusmod tempor incididunt ut labore et dolore magna
+1234567890 streaming token output line continues here
+1234567890 another generated line filling the bottom of the screen
 ";
 
     #[test]

--- a/src-tauri/src/sessions/agents/claude.rs
+++ b/src-tauri/src/sessions/agents/claude.rs
@@ -1,6 +1,14 @@
+use std::time::Instant;
+
 use agentoast_shared::{db, models::AgentStatus};
 
 use super::{is_numbered_option, AgentDetectionResult};
+use crate::sessions::hysteresis::InputRegion;
+
+/// How long after the body-hash last changed the pane is still treated as
+/// Running while sitting `at_prompt`. Sized for a 2 s polling cadence so a
+/// single missed spinner frame doesn't blink the status to Idle.
+pub(crate) const CHANGE_TTL: std::time::Duration = std::time::Duration::from_millis(3000);
 
 struct ClaudePaneContentInfo {
     has_spinner: bool, // Spinner chars + "…" / "esc to interrupt" (real-time, reliable)
@@ -21,17 +29,20 @@ pub(super) fn detect_claude_status(
     db_conn: &Option<db::Connection>,
     pane_id: &str,
     content: Option<&str>,
+    last_changed_at: Option<Instant>,
 ) -> AgentDetectionResult {
     let info = check_claude_pane_content(pane_id, content);
 
+    let hash_age_ms = last_changed_at.map(|t| t.elapsed().as_millis());
     log::debug!(
-        "detect_claude_status({}): spinner={} status_running={} question_dialog={} plan_approval={} prompt={}",
+        "detect_claude_status({}): spinner={} status_running={} question_dialog={} plan_approval={} prompt={} hash_age_ms={:?}",
         pane_id,
         info.has_spinner,
         info.has_status_running,
         info.has_question_dialog,
         info.has_plan_approval,
-        info.at_prompt
+        info.at_prompt,
+        hash_age_ms,
     );
 
     // Background work indicators that should override at_prompt Idle.
@@ -63,13 +74,24 @@ pub(super) fn detect_claude_status(
     } else if has_background_work {
         // Background work in progress — Running regardless of prompt state.
         (AgentStatus::Running, None)
+    } else if hash_assist_says_running(last_changed_at) {
+        // Body content is still mutating off-screen — almost always means
+        // the agent is mid-stream and the spinner was simply absent from
+        // this capture. Sits above at_prompt because pure text streaming
+        // hides the input box (is_prompt_line returns false), which would
+        // otherwise drop us straight to the Idle fallback below. Sits
+        // BELOW the question / plan-approval checks so explicit Waiting
+        // dialogs still win during a recent hash change.
+        (AgentStatus::Running, None)
     } else if info.at_prompt {
-        if let Some(conn) = db_conn {
-            if let Ok(Some(_)) = db::get_latest_notification_by_pane(conn, pane_id) {
-                (AgentStatus::Waiting, None)
-            } else {
-                (AgentStatus::Idle, None)
-            }
+        let has_recent_notif = db_conn.as_ref().is_some_and(|conn| {
+            matches!(
+                db::get_latest_notification_by_pane(conn, pane_id),
+                Ok(Some(_))
+            )
+        });
+        if has_recent_notif {
+            (AgentStatus::Waiting, None)
         } else {
             (AgentStatus::Idle, None)
         }
@@ -91,6 +113,149 @@ pub(super) fn detect_claude_status(
         team_role: info.team_role,
         team_name: info.team_name,
     }
+}
+
+fn hash_assist_says_running(last_changed_at: Option<Instant>) -> bool {
+    last_changed_at.is_some_and(|t| t.elapsed() < CHANGE_TTL)
+}
+
+/// Locate the input box region in a Claude Code pane capture.
+///
+/// Real Claude layouts place the `│ ... │` input box ABOVE the mode line,
+/// usage stats footer, and shortcut hints — i.e., the box is not the
+/// bottom-most non-empty content. Walk up from the bottom skipping empty,
+/// separator, and footer-noise lines, then expect a `│`-prefixed block and
+/// return its contiguous span. `None` means we did not find a box (startup
+/// splash, modal dialog covering the box, plain shell after agent exit,
+/// etc.) — the hysteresis layer disables hash assist for that cycle rather
+/// than risk hashing the user's keystrokes.
+pub(super) fn locate_input_region(lines: &[&str]) -> Option<InputRegion> {
+    let mut end = lines.len();
+    loop {
+        if end == 0 {
+            return None;
+        }
+        let idx = end - 1;
+        let line = lines[idx];
+        let trimmed = line.trim();
+        if trimmed.is_empty() || is_separator_line(trimmed) || is_footer_noise(line) {
+            end -= 1;
+            continue;
+        }
+        if is_box_border_line(line) {
+            break;
+        }
+        // A non-box, non-footer line below where the input box should be —
+        // not a Claude TUI we recognize. Bail.
+        return None;
+    }
+    let last_box = end - 1;
+    let mut start = last_box;
+    while start > 0 && is_box_border_line(lines[start - 1]) {
+        start -= 1;
+    }
+    Some(InputRegion {
+        start_line: start,
+        end_line: last_box,
+    })
+}
+
+fn is_box_border_line(line: &str) -> bool {
+    line.trim_start().starts_with('\u{2502}')
+}
+
+/// Lines immediately above the input region eligible for footer normalization.
+/// Anything further up is conversation body and is hashed verbatim — that way
+/// a code block in the chat that mentions e.g. "ctrl+c" never gets stripped.
+const FOOTER_SCAN_LINES: usize = 10;
+
+/// Collect the lines that should feed Claude's body hash. The cutoff is the
+/// start of the input region when we can locate the `│ ... │` box; when we
+/// cannot — and pure text streaming is the canonical case, because the
+/// response scrolls the input box off-screen — we hash the entire capture.
+/// Returns `None` only when there's nothing to hash (zero non-blank lines)
+/// or when the input region is reported as starting at line 0, which means
+/// the box ate the whole screen and there is no body left.
+///
+/// **Safety of the full-content fallback:** Claude Code holds the keyboard
+/// while streaming (the TUI does not accept input characters until the
+/// response completes), so the user can never be typing into the input box
+/// when the box is off-screen. That means hashing the full capture in the
+/// streaming case cannot accidentally fold user keystrokes into the body
+/// hash — the only thing that can change is generated output, which is
+/// exactly the signal hash assist is looking for.
+pub(super) fn collect_hashable_body(content: &str) -> Option<Vec<&str>> {
+    let lines: Vec<&str> = content.lines().collect();
+    let cutoff = match locate_input_region(&lines) {
+        Some(region) if region.start_line == 0 => return None,
+        Some(region) => region.start_line,
+        None => lines.len(),
+    };
+    if cutoff == 0 {
+        return None;
+    }
+    let scan_start = cutoff.saturating_sub(FOOTER_SCAN_LINES);
+    let mut out: Vec<&str> = Vec::with_capacity(cutoff);
+    for (idx, line) in lines.iter().enumerate().take(cutoff) {
+        if idx >= scan_start && is_footer_noise(line) {
+            continue;
+        }
+        out.push(line);
+    }
+    Some(out)
+}
+
+/// Claude Code mode-line run / pause markers. Used in three places
+/// (`is_claude_tui_footer_line`, the team-role detector, `is_prompt_line`)
+/// so the literal escapes don't drift across sites.
+const MODE_PLAY: char = '\u{23F5}'; // ⏵
+const MODE_PAUSE: char = '\u{23F8}'; // ⏸
+
+/// Recognize a line as a built-in Claude Code TUI footer fragment shared
+/// between two callers: `is_prompt_line` (which walks past these to look
+/// for the real prompt) and `is_footer_noise` (which strips them from the
+/// hashable body). Keeping the shared facts in one helper prevents the two
+/// callers from silently diverging when Claude's footer changes.
+fn is_claude_tui_footer_line(trimmed: &str) -> bool {
+    if trimmed.starts_with(MODE_PLAY) || trimmed.starts_with(MODE_PAUSE) {
+        return true;
+    }
+    if trimmed.contains("Context left until auto-compact") {
+        return true;
+    }
+    if trimmed.contains("for shortcuts") {
+        return true;
+    }
+    false
+}
+
+/// Recognize a line as periodic-update footer noise from Claude Code's
+/// built-in TUI. Intentionally narrow — anything that could be a custom
+/// statusline (user-configured model badges, rate-limit clusters, time
+/// indicators, etc.) is NOT matched here, so this code stays portable
+/// across statusline customizations. The cost of a false negative is a
+/// brief false Running blip; the cost of a false positive is missing a
+/// real diff and reverting to Idle while the agent is streaming, which is
+/// the bug we're fixing.
+fn is_footer_noise(line: &str) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if is_claude_tui_footer_line(trimmed) {
+        return true;
+    }
+    // Claude's ctrl-hint footer rows have the shape "ctrl+X (...) to <verb>"
+    // (or "ctrl-X to <verb>"). Requiring both the modifier and the trailing
+    // " to " keeps a bare "ctrl+c" inside a conversation code block from
+    // being stripped, even when it ends up inside the footer scan window.
+    // (is_prompt_line uses the broader, unguarded ctrl+ check below — safe
+    // there because that detector only sees the absolute bottom of the
+    // screen, where conversation text never lands.)
+    if (trimmed.contains("ctrl+") || trimmed.contains("ctrl-")) && trimmed.contains(" to ") {
+        return true;
+    }
+    false
 }
 
 /// Claude Code spinner characters that appear at the start of running lines.
@@ -264,7 +429,7 @@ fn check_claude_pane_content(pane_id: &str, content: Option<&str>) -> ClaudePane
         // Lead: mode line (⏵/⏸) containing "teammate"
         //   e.g., "⏸ plan mode on · 3 teammates"
         if team_role.is_none() {
-            let is_mode_line = trimmed.starts_with('⏵') || trimmed.starts_with('⏸');
+            let is_mode_line = trimmed.starts_with(MODE_PLAY) || trimmed.starts_with(MODE_PAUSE);
             if is_mode_line && trimmed.contains("teammate") {
                 log::debug!(
                     "check_claude_pane_content({}): agent team lead detected (mode line): {:?}",
@@ -546,24 +711,20 @@ fn is_prompt_line(lines: &[&str]) -> bool {
         if is_separator_line(trimmed) {
             continue;
         }
-        // Mode indicator: ⏵⏵ bypass permissions, ⏸ plan mode
-        if trimmed.starts_with('⏵') || trimmed.starts_with('⏸') {
+        // Built-in Claude TUI footer (mode line, auto-compact warning, "for
+        // shortcuts" hint). Single shared predicate so this detector and
+        // is_footer_noise can't drift.
+        if is_claude_tui_footer_line(trimmed) {
             continue;
         }
         // ctrl shortcut hints (e.g., "ctrl+b ctrl+b (twice) to run in background",
-        // "ctrl-g to edit in Nvim")
+        // "ctrl-g to edit in Nvim"). Unguarded match is safe here because the
+        // detector only inspects the absolute bottom of the screen.
         if trimmed.contains("ctrl+") || trimmed.contains("ctrl-") {
             continue;
         }
-        // Context auto-compact warning (e.g., "Context left until auto-compact: 8%")
-        if trimmed.contains("Context left until auto-compact") {
-            continue;
-        }
-        // Skip Claude Code TUI footer lines
-        if trimmed.contains("for shortcuts")
-            || trimmed.contains("shift+tab to cycle")
-            || is_file_changes_line(trimmed)
-        {
+        // Remaining footer odds and ends not in the shared predicate.
+        if trimmed.contains("shift+tab to cycle") || is_file_changes_line(trimmed) {
             continue;
         }
         // Claude Code elicitation numbered options (e.g., "  2. Yes, and bypass permissions")
@@ -670,7 +831,7 @@ mod tests {
 
     #[test]
     fn detects_running_when_fork_is_active_without_parent_spinner() {
-        let result = detect_claude_status(&None, "%4", Some(FORK_RUNNING_NO_PARENT_SPINNER));
+        let result = detect_claude_status(&None, "%4", Some(FORK_RUNNING_NO_PARENT_SPINNER), None);
         assert_eq!(
             result.status,
             AgentStatus::Running,
@@ -681,7 +842,7 @@ mod tests {
 
     #[test]
     fn fork_count_added_to_agent_modes() {
-        let result = detect_claude_status(&None, "%4", Some(FORK_RUNNING_NO_PARENT_SPINNER));
+        let result = detect_claude_status(&None, "%4", Some(FORK_RUNNING_NO_PARENT_SPINNER), None);
         assert!(
             result.agent_modes.iter().any(|m| m.ends_with("fork")),
             "expected fork count badge in agent_modes, got: {:?}",
@@ -747,5 +908,216 @@ mod tests {
             ),
             Some(1)
         );
+    }
+
+    /// Pane sitting at an empty prompt with no spinner and no notification —
+    /// matches the real Claude TUI layout where the built-in mode line
+    /// renders BELOW the input box. Uses only built-in TUI patterns so the
+    /// tests don't pin behavior to a specific statusline customization.
+    const AT_PROMPT_NO_SPINNER: &str = "\
+some history line
+another history line
+────────────────────────────────────────────────────────────────────────────────
+│ ❯                                                                            │
+────────────────────────────────────────────────────────────────────────────────
+  ⏸ plan mode on (shift+tab to cycle)
+";
+
+    #[test]
+    fn hash_assist_recent_change_promotes_to_running() {
+        let result = detect_claude_status(
+            &None,
+            "%9",
+            Some(AT_PROMPT_NO_SPINNER),
+            Some(Instant::now()),
+        );
+        assert_eq!(
+            result.status,
+            AgentStatus::Running,
+            "recent body change should keep pane Running, got {:?}",
+            result.status
+        );
+    }
+
+    #[test]
+    fn hash_assist_stale_falls_through_to_idle() {
+        let stale = Instant::now() - CHANGE_TTL - std::time::Duration::from_millis(500);
+        let result = detect_claude_status(&None, "%9", Some(AT_PROMPT_NO_SPINNER), Some(stale));
+        assert_eq!(
+            result.status,
+            AgentStatus::Idle,
+            "stale body change should let Idle win, got {:?}",
+            result.status
+        );
+    }
+
+    #[test]
+    fn hash_assist_none_preserves_legacy_idle() {
+        // No hash assist available (first-seen pane / unlocatable input) —
+        // judgement must match the pre-change behavior exactly.
+        let result = detect_claude_status(&None, "%9", Some(AT_PROMPT_NO_SPINNER), None);
+        assert_eq!(result.status, AgentStatus::Idle);
+    }
+
+    /// Pure text streaming: spinner happens to be missing from this capture,
+    /// and the bottom of the screen is mid-response text (no input box
+    /// drawn), so `is_prompt_line` returns false. Without hash assist this
+    /// falls through every status check and lands on the Idle fallback,
+    /// which is exactly the user-visible bug fixed here.
+    const STREAMING_NO_INPUT_BOX: &str = "\
+some history line
+⏺ Claude is streaming a response and the input box is hidden while text
+  pours into the conversation history. Once the spinner glyph briefly
+  drops out of view, none of the status-bar markers help either.
+1234567890 lorem ipsum dolor sit amet consectetur adipiscing elit
+1234567890 sed do eiusmod tempor incididunt ut labore et dolore magna
+";
+
+    #[test]
+    fn hash_assist_runs_even_when_at_prompt_is_false() {
+        let result = detect_claude_status(
+            &None,
+            "%9",
+            Some(STREAMING_NO_INPUT_BOX),
+            Some(Instant::now()),
+        );
+        assert_eq!(
+            result.status,
+            AgentStatus::Running,
+            "streaming content with recent body change must be Running, got {:?}",
+            result.status
+        );
+    }
+
+    #[test]
+    fn hash_assist_stale_during_streaming_falls_to_idle_fallback() {
+        // After CHANGE_TTL has elapsed and no spinner / prompt is visible,
+        // the existing fallback (Idle) takes over. This is the natural
+        // recovery path after interrupt with no further activity.
+        let stale = Instant::now() - CHANGE_TTL - std::time::Duration::from_millis(500);
+        let result = detect_claude_status(&None, "%9", Some(STREAMING_NO_INPUT_BOX), Some(stale));
+        assert_eq!(result.status, AgentStatus::Idle);
+    }
+
+    #[test]
+    fn locate_input_region_finds_box_border_block() {
+        let content = "history\n────\n│ first  │\n│ second │";
+        let lines: Vec<&str> = content.lines().collect();
+        let region = locate_input_region(&lines).expect("box border expected");
+        assert_eq!(region.start_line, 2);
+        assert_eq!(region.end_line, 3);
+    }
+
+    #[test]
+    fn locate_input_region_returns_none_without_box_border() {
+        let content = "history\nmore history\nplain shell prompt $";
+        let lines: Vec<&str> = content.lines().collect();
+        assert!(locate_input_region(&lines).is_none());
+    }
+
+    #[test]
+    fn collect_hashable_body_drops_input_and_footer_inside_scan_window() {
+        let content = "history line A\nhistory line B\nhistory line C\nContext left until auto-compact: 8%\n⏵⏵ bypass permissions on · 1 shell\n│ user typed │\n│ second row │\n│             │";
+        let body = collect_hashable_body(content).expect("box border present");
+        let joined = body.join("\n");
+        assert!(joined.contains("history line A"));
+        assert!(joined.contains("history line C"));
+        assert!(!joined.contains("Context left until auto-compact"));
+        assert!(!joined.contains("bypass permissions"));
+        assert!(!joined.contains("user typed"));
+    }
+
+    #[test]
+    fn collect_hashable_body_keeps_footer_lookalikes_outside_scan_window() {
+        // "ctrl+" mention at line 0 must survive — input box starts at line
+        // 20, so the 10-line footer scan window only covers lines 10..20.
+        // This guarantees a code block in the conversation that mentions
+        // "ctrl+c" still moves the body hash and counts as activity.
+        let mut lines: Vec<String> = vec!["Press ctrl+c to abort".into()];
+        for _ in 0..19 {
+            lines.push("history filler".into());
+        }
+        lines.push("│ input │".into());
+        lines.push("│ input │".into());
+        lines.push("│ input │".into());
+        let content = lines.join("\n");
+        let body = collect_hashable_body(&content).expect("box border present");
+        assert!(
+            body.iter().any(|l| l.contains("ctrl+c to abort")),
+            "expected conversation body to survive footer scan: {:?}",
+            body
+        );
+    }
+
+    #[test]
+    fn collect_hashable_body_keeps_bare_ctrl_mention_inside_scan_window() {
+        // The footer-noise predicate requires both "ctrl+" AND " to " — a
+        // bare mention without the trailing " to <verb>" hint must NOT be
+        // stripped, even when it lands inside the 10-line scan window.
+        let lines = [
+            "history",
+            "use ctrl+c",
+            "history",
+            "history",
+            "history",
+            "│ input │",
+            "│ input │",
+            "│ input │",
+        ];
+        let content = lines.join("\n");
+        let body = collect_hashable_body(&content).expect("box border present");
+        assert!(
+            body.iter().any(|l| l.contains("use ctrl+c")),
+            "bare ctrl+c mention must survive shape-gated footer scan: {:?}",
+            body
+        );
+    }
+
+    #[test]
+    fn collect_hashable_body_falls_back_to_full_content_when_box_missing() {
+        // Pure text streaming pushes the input box off-screen — there's no
+        // `│ ... │` block to find. The detector must still hash whatever
+        // text it can see, otherwise hash assist never fires during
+        // long-form generation and the pane blinks back to Idle.
+        let content = "history A\nhistory B\n⏺ streaming response text appears here\nmore streaming text on this line\nyet more streaming text";
+        let body = collect_hashable_body(content).expect("streaming content must hash");
+        assert!(body.iter().any(|l| l.contains("streaming response text")));
+        assert!(body.iter().any(|l| l.contains("yet more streaming text")));
+    }
+
+    #[test]
+    fn collect_hashable_body_strips_real_claude_ctrl_hint() {
+        // Real Claude footer hint lines have the shape "ctrl+X (...) to <verb>";
+        // those MUST still be stripped.
+        let lines = [
+            "history",
+            "history",
+            "history",
+            "history",
+            "ctrl+b to bookmark",
+            "│ input │",
+            "│ input │",
+            "│ input │",
+        ];
+        let content = lines.join("\n");
+        let body = collect_hashable_body(&content).expect("box border present");
+        assert!(
+            !body.iter().any(|l| l.contains("ctrl+b to bookmark")),
+            "shape-matching ctrl hint must be stripped: {:?}",
+            body
+        );
+    }
+
+    #[test]
+    fn locate_input_region_finds_box_with_footer_below() {
+        // Real Claude layout: built-in mode line and shortcut hints render
+        // BELOW the input box. The detector must walk past them before
+        // landing on the box border. Uses ONLY Claude built-in TUI patterns
+        // (⏸ mode line, ctrl+X to ... hint) — no custom statusline.
+        let content = "history A\nhistory B\n────────\n│ ❯ first  │\n│ second    │\n────────\n  ⏸ plan mode on (shift+tab to cycle)\n  ctrl+b to bookmark\n";
+        let lines: Vec<&str> = content.lines().collect();
+        let region = locate_input_region(&lines).expect("input region expected");
+        assert_eq!(region.start_line, 3);
+        assert_eq!(region.end_line, 4);
     }
 }

--- a/src-tauri/src/sessions/agents/mod.rs
+++ b/src-tauri/src/sessions/agents/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 use agentoast_shared::{db, models::AgentStatus};
 
@@ -182,14 +183,20 @@ pub(super) fn is_numbered_option(line: &str) -> bool {
 /// Detect agent status using pre-captured pane content.
 /// This avoids redundant capture-pane calls when content is already available
 /// (e.g., captured in parallel by the caller).
+///
+/// `last_changed_at` is supplied by `crate::sessions::hysteresis` and is
+/// used as a short-term Running assist on Claude's `at_prompt` path. Only
+/// the Claude detector takes it today — adding it to the other detectors
+/// would just produce three dead args.
 pub(super) fn detect_agent_status_with_content(
     db_conn: &Option<db::Connection>,
     pane_id: &str,
     agent_type: &str,
     content: Option<&str>,
+    last_changed_at: Option<Instant>,
 ) -> AgentDetectionResult {
     match agent_type {
-        "claude-code" => claude::detect_claude_status(db_conn, pane_id, content),
+        "claude-code" => claude::detect_claude_status(db_conn, pane_id, content, last_changed_at),
         "codex" => codex::detect_codex_status(db_conn, pane_id, content),
         "copilot-cli" => copilot::detect_copilot_status(db_conn, pane_id, content),
         "opencode" => opencode::detect_opencode_status(db_conn, pane_id, content),
@@ -207,6 +214,21 @@ pub(super) fn detect_agent_status_with_content(
                 team_name: None,
             }
         }
+    }
+}
+
+/// Extract the lines an agent's body hash should cover. The hashing,
+/// tracking, and timestamp logic live in `sessions::hysteresis`; only the
+/// agent-specific knowledge of which lines are conversation body (vs. input
+/// box, vs. periodically-redrawn footer) lives here. Returning `None`
+/// signals the hysteresis layer to skip this pane for this cycle.
+pub(crate) fn collect_hashable_body<'a>(
+    agent_type: &str,
+    content: &'a str,
+) -> Option<Vec<&'a str>> {
+    match agent_type {
+        "claude-code" => claude::collect_hashable_body(content),
+        _ => None,
     }
 }
 

--- a/src-tauri/src/sessions/hysteresis.rs
+++ b/src-tauri/src/sessions/hysteresis.rs
@@ -1,0 +1,236 @@
+use std::collections::{HashMap, HashSet};
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::time::Instant;
+
+use super::agents;
+
+/// Inclusive line range marking the on-screen input box for an agent pane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InputRegion {
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
+/// Tracks the most-recent hash of each pane's "body" (= content minus input
+/// region and minus periodic footer noise) so the state detector can tell
+/// whether anything new was drawn between polling cycles.
+///
+/// Used only as a SHORT-TERM ASSIST for the `at_prompt → Idle` path: if the
+/// body just changed it almost certainly means the agent is still streaming
+/// output, even though the spinner glyph happened to be missed by this
+/// capture. See `detect_claude_status` priority #5b.
+///
+/// The tracker is intentionally per-pane in-memory state with no persistence
+/// — restart-time recovery is unnecessary because the tracker's only job is
+/// to bridge a few seconds of polling gaps.
+#[derive(Default)]
+pub struct PaneHysteresis {
+    /// pane_id → (last_body_hash, last observed change time).
+    /// `last_changed` is `None` until a real change is observed — the seed
+    /// observation must NOT count as a change, otherwise the second cycle
+    /// (~2 s later) would report `Some(seed_time)` whose elapsed time is
+    /// still within CHANGE_TTL and the at_prompt path would flash Running
+    /// for one cycle on every newly-seen pane.
+    entries: HashMap<String, (u64, Option<Instant>)>,
+}
+
+impl PaneHysteresis {
+    /// Observe all panes in one shot. The held lock spans only the in-memory
+    /// hash computation across `panes` (no DB I/O, no tmux I/O).
+    ///
+    /// Returned map contains an entry only for panes whose body is
+    /// hash-eligible AND have produced at least one observed hash change
+    /// since startup. First-seen panes seed the tracker but are omitted
+    /// from the result, so a fresh app start or a pane switch does not
+    /// flash 3 s of false Running for every agent pane. Panes whose
+    /// hashable body could not be extracted (input region unlocatable,
+    /// unknown agent) are also omitted.
+    pub fn observe_batch<'a>(
+        &mut self,
+        panes: impl IntoIterator<Item = (&'a str, &'a str, &'a str)>,
+    ) -> HashMap<String, Instant> {
+        let now = Instant::now();
+        let mut out = HashMap::new();
+        for (pane_id, agent_type, content) in panes {
+            let Some(h) = hash_body_region(agent_type, content) else {
+                continue;
+            };
+            match self.entries.get_mut(pane_id) {
+                Some((prev_hash, last_changed)) => {
+                    if *prev_hash != h {
+                        *prev_hash = h;
+                        *last_changed = Some(now);
+                    }
+                    if let Some(t) = *last_changed {
+                        out.insert(pane_id.to_string(), t);
+                    }
+                }
+                None => {
+                    self.entries.insert(pane_id.to_string(), (h, None));
+                }
+            }
+        }
+        out
+    }
+
+    /// Drop tracker entries for panes that no longer exist. Accepting borrowed
+    /// ids avoids cloning every pane id every cycle just to feed the call.
+    /// Bails before allocating the live-id set when the tracker is empty —
+    /// the common case at startup and whenever there are no Claude panes.
+    pub fn retain<'a>(&mut self, live: impl IntoIterator<Item = &'a str>) {
+        if self.entries.is_empty() {
+            return;
+        }
+        let live: HashSet<&str> = live.into_iter().collect();
+        self.entries.retain(|k, _| live.contains(k.as_str()));
+    }
+
+    #[cfg(test)]
+    pub fn entry(&self, pane_id: &str) -> Option<(u64, Option<Instant>)> {
+        self.entries.get(pane_id).copied()
+    }
+}
+
+/// Hash the body region of a pane's captured content, returning `None` when
+/// the agent-specific extractor cannot isolate the conversation body (and
+/// therefore hash assist must be disabled). Lines are hashed individually
+/// with an explicit separator so a `join("\n")` allocation is avoided and
+/// `["ab", "c"]` doesn't collide with `["a", "bc"]`.
+pub fn hash_body_region(agent_type: &str, content: &str) -> Option<u64> {
+    let lines = agents::collect_hashable_body(agent_type, content)?;
+    let mut hasher = DefaultHasher::new();
+    for line in &lines {
+        line.hash(&mut hasher);
+        hasher.write_u8(b'\n');
+    }
+    Some(hasher.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_body_region_returns_none_for_unknown_agent() {
+        assert!(hash_body_region("mystery-agent", "anything").is_none());
+    }
+
+    #[test]
+    fn observe_batch_first_seen_omitted_from_result() {
+        let mut h = PaneHysteresis::default();
+        let content = sample_claude_content();
+        let out = h.observe_batch([("%1", "claude-code", content.as_str())]);
+        assert!(
+            out.is_empty(),
+            "first observation must not yet report a change"
+        );
+        assert!(h.entry("%1").is_some(), "but tracker should remember it");
+    }
+
+    #[test]
+    fn observe_batch_second_cycle_unchanged_still_omitted() {
+        // Regression: a previous version stored last_changed=seed_time on
+        // the first observation, so the second-cycle unchanged observation
+        // returned Some(seed_time). Elapsed time of 2 s (the polling
+        // cadence) was still within CHANGE_TTL=3 s, so every newly-seen
+        // pane flashed Running for one cycle. Verify that doesn't happen.
+        let mut h = PaneHysteresis::default();
+        let content = sample_claude_content();
+        h.observe_batch([("%1", "claude-code", content.as_str())]);
+        let out = h.observe_batch([("%1", "claude-code", content.as_str())]);
+        assert!(
+            out.is_empty(),
+            "unchanged second cycle must not report a change time"
+        );
+        let (_hash, last_changed) = h.entry("%1").expect("still tracked");
+        assert_eq!(
+            last_changed, None,
+            "last_changed stays None until a real diff is observed"
+        );
+    }
+
+    #[test]
+    fn observe_batch_changed_after_seed_reports_change_time() {
+        let mut h = PaneHysteresis::default();
+        let v1 = sample_claude_content();
+        h.observe_batch([("%1", "claude-code", v1.as_str())]); // seed
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let v2 = sample_claude_content().replace("history B", "history B+");
+        let before = Instant::now();
+        let out = h.observe_batch([("%1", "claude-code", v2.as_str())]);
+        let observed = *out.get("%1").expect("change reported");
+        assert!(observed >= before, "change time must be from this cycle");
+    }
+
+    #[test]
+    fn observe_batch_unchanged_after_real_change_preserves_change_time() {
+        let mut h = PaneHysteresis::default();
+        let v1 = sample_claude_content();
+        h.observe_batch([("%1", "claude-code", v1.as_str())]); // seed
+        let v2 = sample_claude_content().replace("history B", "history B+");
+        let out = h.observe_batch([("%1", "claude-code", v2.as_str())]);
+        let t_change = *out.get("%1").unwrap();
+        // Now a static cycle: same content as v2. Should still report
+        // t_change (so the at_prompt branch keeps Running for CHANGE_TTL).
+        let out2 = h.observe_batch([("%1", "claude-code", v2.as_str())]);
+        assert_eq!(out2.get("%1"), Some(&t_change));
+    }
+
+    #[test]
+    fn observe_batch_footer_change_does_not_advance_timestamp() {
+        let mut h = PaneHysteresis::default();
+        let v1 = sample_claude_content();
+        h.observe_batch([("%1", "claude-code", v1.as_str())]);
+        let v2 = v1.replace(
+            "Context left until auto-compact: 8%",
+            "Context left until auto-compact: 9%",
+        );
+        assert_ne!(v1, v2, "fixture must actually change");
+        let out = h.observe_batch([("%1", "claude-code", v2.as_str())]);
+        assert!(
+            out.is_empty(),
+            "footer-only change must not surface a change time"
+        );
+    }
+
+    #[test]
+    fn observe_batch_unknown_agent_skips_pane() {
+        let mut h = PaneHysteresis::default();
+        let out = h.observe_batch([("%1", "mystery-agent", "any content")]);
+        assert!(out.is_empty());
+        assert!(
+            h.entry("%1").is_none(),
+            "unknown agents must not seed the tracker"
+        );
+    }
+
+    #[test]
+    fn retain_drops_missing_entries() {
+        let mut h = PaneHysteresis::default();
+        let c = sample_claude_content();
+        h.observe_batch([("%1", "claude-code", c.as_str())]);
+        h.observe_batch([("%1", "claude-code", c.as_str())]); // promote past first-seen
+        assert!(h.entry("%1").is_some());
+        h.retain(["%2"]);
+        assert!(h.entry("%1").is_none());
+    }
+
+    fn sample_claude_content() -> String {
+        // Minimal Claude-shape capture using ONLY built-in TUI patterns —
+        // no custom statusline content, so the tests don't accidentally
+        // pin behavior to a specific statusline format.
+        [
+            "history A",
+            "history B",
+            "history C",
+            "history D",
+            "history E",
+            "Context left until auto-compact: 8%",
+            "⏸ plan mode on (shift+tab to cycle)",
+            "│ ❯                 │",
+            "│                   │",
+            "│                   │",
+        ]
+        .join("\n")
+    }
+}

--- a/src-tauri/src/sessions/hysteresis.rs
+++ b/src-tauri/src/sessions/hysteresis.rs
@@ -43,7 +43,7 @@ impl PaneHysteresis {
     /// since startup. First-seen panes seed the tracker but are omitted
     /// from the result, so a fresh app start or a pane switch does not
     /// flash 3 s of false Running for every agent pane. Panes whose
-    /// hashable body could not be extracted (input region unlocatable,
+    /// hashable body could not be extracted (input region not found,
     /// unknown agent) are also omitted.
     pub fn observe_batch<'a>(
         &mut self,

--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -8,10 +8,14 @@ use agentoast_shared::models::{TmuxPane, TmuxPaneGroup};
 use crate::terminal::find_tmux;
 
 pub(crate) mod agents;
+pub mod hysteresis;
 mod process_tree;
 use agents::detect_agent_status_with_content;
 
 use agentoast_shared::agent_detect::detect_agent;
+use hysteresis::PaneHysteresis;
+use std::sync::Mutex;
+use std::time::Instant;
 
 /// Debug-build spawn accounting so the per-cycle external-process count can
 /// be verified from the logs (the whole point of the constant-spawn work).
@@ -34,6 +38,7 @@ fn log_cycle_spawns() {
 pub fn list_tmux_panes_grouped(
     show_non_agent: bool,
     db_conn: &Option<db::Connection>,
+    hysteresis: Option<&Mutex<PaneHysteresis>>,
 ) -> Result<Vec<TmuxPaneGroup>, String> {
     log::info!(
         "sessions: get_sessions called (show_non_agent={})",
@@ -171,6 +176,24 @@ pub fn list_tmux_panes_grouped(
         })
         .collect();
 
+    // Single-shot hysteresis observation. The write lock spans only the
+    // in-memory hash computation (no tmux / DB / git I/O), so contention
+    // with `emit_cached_sessions` and the get_sessions command stays
+    // bounded even with hundreds of panes.
+    let last_changed_map: HashMap<String, Instant> = if let Some(h) = hysteresis {
+        let mut guard = h.lock().unwrap_or_else(|e| e.into_inner());
+        let observed = guard.observe_batch(agent_pane_indices.iter().filter_map(|&idx| {
+            let rp = &raw_panes[idx];
+            let agent_type = rp.agent_type.as_deref()?;
+            let content = captured_contents.get(&idx).and_then(|c| c.as_deref())?;
+            Some((rp.pane_id.as_str(), agent_type, content))
+        }));
+        guard.retain(raw_panes.iter().map(|p| p.pane_id.as_str()));
+        observed
+    } else {
+        HashMap::new()
+    };
+
     // Build TmuxPane with git info and agent status (DB lookups on main thread)
     let panes: Vec<TmuxPane> = raw_panes
         .into_iter()
@@ -180,7 +203,17 @@ pub fn list_tmux_panes_grouped(
             let (agent_status, waiting_reason, agent_modes, team_role, team_name) =
                 if let Some(ref at) = rp.agent_type {
                     let content = captured_contents.get(&idx).and_then(|c| c.as_deref());
-                    let r = detect_agent_status_with_content(db_conn, &rp.pane_id, at, content);
+                    // Map entry absent ⇒ first observation, input region
+                    // unlocatable, or non-Claude agent — all collapse to
+                    // "no hash assist for this pane this cycle".
+                    let last_changed = last_changed_map.get(&rp.pane_id).copied();
+                    let r = detect_agent_status_with_content(
+                        db_conn,
+                        &rp.pane_id,
+                        at,
+                        content,
+                        last_changed,
+                    );
                     (
                         Some(r.status),
                         r.waiting_reason,

--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -204,7 +204,7 @@ pub fn list_tmux_panes_grouped(
                 if let Some(ref at) = rp.agent_type {
                     let content = captured_contents.get(&idx).and_then(|c| c.as_deref());
                     // Map entry absent ⇒ first observation, input region
-                    // unlocatable, or non-Claude agent — all collapse to
+                    // not found, or non-Claude agent — all collapse to
                     // "no hash assist for this pane this cycle".
                     let last_changed = last_changed_map.get(&rp.pane_id).copied();
                     let r = detect_agent_status_with_content(


### PR DESCRIPTION
## Summary

- Fix the long-standing UX bug where claude-code panes blinked to **Idle** the moment a polling cycle missed the spinner glyph during a long streaming response.
- Track each pane's body hash in memory and treat the pane as **Running** for up to `CHANGE_TTL = 3 s` after a real hash change, so single-frame spinner misses can't flip the menu-bar status.
- Stay portable across statusline customizations: only built-in Claude TUI patterns are recognized as footer noise — custom rate-limit clusters, model badges, etc. are intentionally left alone.

## Why a hash, not more hooks

Earlier iterations of this work explored requiring `UserPromptSubmit` / `PreToolUse` / `PostToolUse` hooks to be registered with each agent. That meant per-agent settings.json wiring just to get accurate status, which directly contradicts the project's "hook-config-free out of the box" appeal. Hashing the captured pane content is agent-agnostic and turns on automatically.

## What this changes

| File | Change |
|---|---|
| `src-tauri/src/sessions/hysteresis.rs` (NEW) | `PaneHysteresis` tracker — `observe_batch` + `retain` driven once per polling cycle inside a single `Mutex` lock. Returns `HashMap<String, Instant>` keyed by pane id; first-seen panes are seeded but omitted from the result so app startup does not flash 3 s of false Running. |
| `src-tauri/src/sessions/agents/claude.rs` | `locate_input_region` walks bottom-up skipping empty / separator / footer-noise lines and returns the `│ ... │` block. `collect_hashable_body` extracts hashable lines (input region stripped, footer scan window normalized). `is_footer_noise` shares the `is_claude_tui_footer_line` predicate with the existing `is_prompt_line`. New priority slot in `detect_claude_status` between `has_background_work` and `at_prompt`. |
| `src-tauri/src/sessions/agents/mod.rs` | `collect_hashable_body` dispatch (Claude-only today); `detect_agent_status_with_content` accepts `last_changed_at: Option<Instant>` and forwards only to Claude. |
| `src-tauri/src/sessions/mod.rs` | Wires the tracker through `list_tmux_panes_grouped` — single lock, no DB/tmux I/O held. `retain` short-circuits when the tracker is empty. |
| `src-tauri/src/lib.rs` | Tauri state plumbing for `PaneHysteresisState`. |

## Design notes

- **Footer noise normalization is conservative.** Only built-in patterns are matched: `Context left until auto-compact`, `⏵/⏸` mode markers, `for shortcuts`, and `ctrl+X to <verb>` shortcut hints. Custom statusline content (model badges, rate-limit clusters, anything else) is left in the hash, so a tick in someone's custom statusline merely produces a brief false Running blip rather than missing a real diff.
- **Full-content fallback during streaming is safe.** When the input box scrolls off-screen, `collect_hashable_body` hashes everything. Claude blocks keyboard input while streaming, so user keystrokes can never appear in that capture — the only thing that can change is generated output, which is the signal we want.
- **Trade-off the design accepts.** A brief generation triggers up to `CHANGE_TTL` (3 s) of Running after the response actually completes, because the hash genuinely just changed. This is the same window that protects long streaming from frame-skip flicker.


