### PR TITLE
fix: tighten agentoast-send detection and reply discipline

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,31 +377,25 @@ agentoast send \
 
 ### Cross-Agent Messaging (Experimental)
 
-> **Experimental**: This feature and its skill packaging are still evolving and may change or be removed without notice.
+> **Experimental**: API and skill packaging may change without notice.
 
-`agentoast send-keys` injects a message straight into another agent's prompt running in a different tmux pane, addressed only by its pane id (e.g. `%72`) — no team, login, or registration. Your own pane (`$TMUX_PANE`) is appended as a reply address, so the receiving agent can answer back into your pane.
+`agentoast send-keys` injects a message straight into another agent's prompt running in a different tmux pane, addressed only by its pane id (e.g. `%72`).
 
 ```bash
 agentoast send-keys --pane %72 "Please review the diff on this branch"
 ```
 
-| Option       | Short | Default      | Description                                           |
-| ------------ | ----- | ------------ | ----------------------------------------------------- |
-| `--pane`     | `-t`  | (required)   | Target tmux pane id (e.g. `%72`)                      |
-| `--from`     | —     | `$TMUX_PANE` | Sender pane id embedded as the reply address          |
-| `--raw`      | —     | `false`      | Inject the raw message only, without the reply hint   |
-| `--no-enter` | —     | `false`      | Type the text without submitting (no trailing Enter)  |
-| `--force`    | —     | `false`      | Send even when the target pane runs no detected agent |
+How it works:
 
-By default `send-keys` refuses a target pane that has no detected AI agent (a plain shell), since the message would just be typed into the shell prompt — usually a sign you picked the wrong pane. Pass `--force` when you are sure an agent is running there but the detector doesn't recognize it.
+- **Detection.** The target pane's process tree must contain one of the names in `AGENT_PROCESSES` (`crates/agentoast-shared/src/agent_detect.rs`). Panes that look like a plain shell are refused — sending into a shell would just execute the message as a command. To support a new agent, add its binary name to that list.
+- **Reply address.** `$TMUX_PANE` (or `--from`) is appended as a single-line hint so the receiver can reply with `agentoast send-keys --pane <you> "..."`.
+- **Detection-only probe.** `agentoast detect-agent --pane %NN` reports `agent` / `no-agent` without sending anything. The bundled skill uses it as a precondition.
 
-To let an agent drive this on its own (delegate a task, hand off, or reply to incoming messages), install the bundled [`agentoast-send`](skills/agentoast-send/SKILL.md) skill with [apm](https://github.com/danielmeppiel/apm).
+Run `agentoast send-keys --help` for the full flag list. To let an agent drive this on its own (delegate, hand off, or reply), install the bundled [`agentoast-send`](skills/agentoast-send/SKILL.md) skill with [apm](https://github.com/danielmeppiel/apm).
 
 ```bash
 apm install shuntaka9576/agentoast -t claude
 ```
-
-This deploys the skill to `.claude/skills/`. Once installed, asking your agent to "ask the agent in pane %72 to review this" routes through `send-keys` automatically.
 
 ### Tips
 

--- a/crates/agentoast-cli/src/lib.rs
+++ b/crates/agentoast-cli/src/lib.rs
@@ -112,12 +112,15 @@ enum Commands {
         /// Do not send a trailing Enter (leave the text without submitting)
         #[arg(long)]
         no_enter: bool,
+    },
 
-        /// Send even when the target pane has no detected AI agent (a plain
-        /// shell). By default send-keys refuses such targets to avoid typing
-        /// the message into a shell prompt.
-        #[arg(long)]
-        force: bool,
+    /// Detect whether the given tmux pane is running an AI coding agent.
+    /// Prints `agent` (exit 0) or `no-agent` (exit 1) to stdout. Used by the
+    /// agentoast-send skill as a single source of truth for agent detection.
+    DetectAgent {
+        /// Target tmux pane ID (e.g. %72)
+        #[arg(short = 't', long)]
+        pane: String,
     },
 
     /// Open config file in editor
@@ -157,6 +160,7 @@ pub fn try_run_cli() -> bool {
     let known = [
         "send",
         "send-keys",
+        "detect-agent",
         "hook",
         "list",
         "dismiss",
@@ -174,6 +178,30 @@ pub fn try_run_cli() -> bool {
     let cli = Cli::parse();
     run(cli);
     true
+}
+
+/// Resolve the tmux binary path from config + built-in lookup, or exit 1.
+fn resolve_tmux_or_exit() -> std::path::PathBuf {
+    let tmux_override = config::load_config().system.tmux;
+    match tmux::find_tmux(tmux_override.as_deref()) {
+        Some(p) => p,
+        None => {
+            eprintln!("tmux not found");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Detect which AI coding agent (if any) is running in `pane`. Exits 1 with a
+/// "pane not found" error when the pane id is bogus. Shared between
+/// `send-keys` (uses it as a guard) and `detect-agent` (returns the verdict).
+fn detect_agent_for_pane(tmux_bin: &std::path::Path, pane: &str) -> Option<String> {
+    let Some(pid) = tmux::pane_pid(tmux_bin, pane) else {
+        eprintln!("pane '{}' not found", pane);
+        std::process::exit(1);
+    };
+    let process_tree = agent_detect::build_process_tree();
+    agent_detect::detect_agent(&process_tree, pid)
 }
 
 fn run(cli: Cli) {
@@ -300,37 +328,24 @@ fn run(cli: Cli) {
             from,
             raw,
             no_enter,
-            force,
         } => {
-            let tmux_override = config::load_config().system.tmux;
-            let Some(tmux_bin) = tmux::find_tmux(tmux_override.as_deref()) else {
-                eprintln!("tmux not found");
-                std::process::exit(1);
-            };
-            // Resolve the pane's pid. This doubles as an existence check (a
-            // bogus pane yields no pid) and feeds agent detection below — one
-            // tmux call instead of a separate existence query.
-            let Some(pid) = tmux::pane_pid(&tmux_bin, &pane) else {
-                eprintln!("pane '{}' not found", pane);
-                std::process::exit(1);
-            };
+            let tmux_bin = resolve_tmux_or_exit();
+            let detected_agent = detect_agent_for_pane(&tmux_bin, &pane);
 
             // Guard: send-keys is for agent-to-agent messaging. If the target
-            // pane runs no detected AI agent (e.g. a plain shell), refuse by
-            // default — otherwise the message would be typed into the shell
-            // prompt and executed as commands. --force overrides (for agents
-            // the detector doesn't recognize).
-            let process_tree = agent_detect::build_process_tree();
-            let detected_agent = agent_detect::detect_agent(&process_tree, pid);
-            if detected_agent.is_none() && !force {
-                // One sentence per line, no mid-sentence hard breaks — the
-                // terminal wraps long lines on its own, and an agent reading
-                // this back parses whole sentences more reliably.
+            // pane runs no detected AI agent (e.g. a plain shell), refuse —
+            // otherwise the message would be typed into the shell prompt and
+            // executed as commands. To send to a pane running an agent the
+            // detector doesn't recognize, add its process name to
+            // AGENT_PROCESSES in crates/agentoast-shared/src/agent_detect.rs.
+            if detected_agent.is_none() {
                 eprintln!(
-                    "pane '{}' has no detected AI coding agent (it looks like a plain shell), so send-keys would just type the message into the shell prompt.",
+                    "pane '{}' has no detected AI coding agent (it looks like a plain shell). send-keys refused to type the message into a shell prompt.",
                     pane
                 );
-                eprintln!("If an agent really is running there, re-run with --force.");
+                eprintln!(
+                    "If this pane really runs an agent, add it to AGENT_PROCESSES in crates/agentoast-shared/src/agent_detect.rs."
+                );
                 std::process::exit(1);
             }
 
@@ -362,6 +377,18 @@ fn run(cli: Cli) {
                 ),
                 Err(e) => {
                     eprintln!("send-keys failed: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
+        Commands::DetectAgent { pane } => {
+            let tmux_bin = resolve_tmux_or_exit();
+            match detect_agent_for_pane(&tmux_bin, &pane) {
+                Some(_) => {
+                    println!("agent");
+                }
+                None => {
+                    println!("no-agent");
                     std::process::exit(1);
                 }
             }

--- a/skills/agentoast-send/SKILL.md
+++ b/skills/agentoast-send/SKILL.md
@@ -40,4 +40,4 @@ The single source of truth for "what counts as an agent" is `AGENT_PROCESSES` in
 
 ## Step 3: Send (and reply)
 
-Open and follow [references/operate.md](references/operate.md). That file contains the actual `agentoast send-keys` invocation, the reply-via-heredoc pattern, and a short Notes section on flags. Reading it before Step 2 passes is wasted context.
+Open and follow [references/operate.md](references/operate.md). It covers the `agentoast send-keys` invocation, the reply pattern for incoming messages, and when the right move is to *not* send anything (handoffs, acks, status pings). Reading it before Step 2 passes is wasted context.

--- a/skills/agentoast-send/SKILL.md
+++ b/skills/agentoast-send/SKILL.md
@@ -40,4 +40,4 @@ The single source of truth for "what counts as an agent" is `AGENT_PROCESSES` in
 
 ## Step 3: Send (and reply)
 
-Open and follow [references/operate.md](references/operate.md). It covers the `agentoast send-keys` invocation, the reply pattern for incoming messages, and when the right move is to *not* send anything (handoffs, acks, status pings). Reading it before Step 2 passes is wasted context.
+Open and follow [references/operate.md](references/operate.md). It covers the `agentoast send-keys` invocation, the reply pattern for incoming messages, and when the right move is to _not_ send anything (handoffs, acknowledgments, status pings). Reading it before Step 2 passes is wasted context.

--- a/skills/agentoast-send/SKILL.md
+++ b/skills/agentoast-send/SKILL.md
@@ -27,22 +27,16 @@ Trigger conditions in the frontmatter `when_to_use` already filter most non-dele
 
 ## Step 2: Verify an agent is actually at `%NN`
 
-Most panes are shells, editors, build runs, or REPLs. Sending into those just dumps the message into a shell prompt and is annoying. Always check before you send by listing every process attached to the pane's tty and matching against known agent binary names:
+Most panes are shells, editors, build runs, or REPLs. Sending into those just dumps the message into a shell prompt and is annoying. Ask the CLI:
 
 ```
-ps -t "$(tmux display-message -t %NN -p '#{pane_tty}' | sed 's|^/dev/||')" -o command= 2>/dev/null | grep -qiE '(^|/)(claude|codex|cursor-agent|aider|cody|continue)( |$)' && echo agent || echo no-agent
+agentoast detect-agent --pane %NN
 ```
 
-- **`agent`** → an AI coding agent (Claude Code, Codex, Cursor, Aider, etc.) is genuinely running in `%NN`. Proceed to Step 3.
-- **`no-agent`** → STOP. Tell the user that `%NN` is not running an agent (you can show them the process list above to clarify) and handle the rest of their request as a normal task: if they wanted to see what's in the pane, run `tmux capture-pane -t %NN -p` and discuss it; if they just mentioned the pane in passing, carry on with the original conversation. Do NOT call `agentoast send-keys`.
+- **`agent` (exit 0)** → an AI coding agent is running in `%NN`. Proceed to Step 3.
+- **`no-agent` (exit ≠ 0)** → STOP. The skill is done here. Do NOT open `references/operate.md`, do NOT call `agentoast send-keys`, do NOT run `tmux capture-pane` or any other tmux probe on behalf of this skill. Reply to the user with one short sentence — "`%NN` is not running an AI coding agent, so I won't send anything." — and then handle the rest of their request as a normal conversation (if they later ask to see what's in the pane, use plain `tmux` at that point, outside this skill).
 
-Why this check rather than `pane_current_command` or `tmux capture-pane`:
-
-- `pane_current_command` reports the foreground binary, which is `node` for Codex, a version string like `2.1.177` for Claude Code, `cargo-make` for a build run — too coarse to tell agents apart from build tools.
-- `tmux capture-pane` is unreliable for agents whose TUI is cursor-positioned (Codex via ratatui, others): their scrollback can be empty even while the UI is on screen.
-- The process list attached to the tty always contains the actual agent CLI invocation (`claude --chrome ...`, `.../bin/codex`, etc.), so grepping it is robust regardless of how the UI is drawn.
-
-If Step 2 says STOP, the skill's job is done. Hand control back to the main task.
+The single source of truth for "what counts as an agent" is `AGENT_PROCESSES` in `crates/agentoast-shared/src/agent_detect.rs`. Both `detect-agent` and `send-keys` share it, so adding a new agent only requires editing that one list — this skill needs no update.
 
 ## Step 3: Send (and reply)
 

--- a/skills/agentoast-send/references/operate.md
+++ b/skills/agentoast-send/references/operate.md
@@ -31,7 +31,7 @@ EOF
 
 ## When NOT to reply
 
-`send-keys` is a working channel, not a chat. Every message you send another agent costs them a turn of context. Don't spend it on social glue — bare acknowledgments ("got it", "thanks", "will share progress"), echoing the plan back to confirm understanding, or a standalone "done" ping with no result attached. If you finished, the result *is* the message: send the diff, the path, or the answer in the same call. If the artifact is already visible to them (commit pushed, file saved), send nothing and let it speak.
+`send-keys` is a working channel, not a chat. Every message you send another agent costs them a turn of context. Don't spend it on social glue — bare acknowledgments ("got it", "thanks", "will share progress"), echoing the plan back to confirm understanding, or a standalone "done" ping with no result attached. If you finished, the result _is_ the message: send the diff, the path, or the answer in the same call. If the artifact is already visible to them (commit pushed, file saved), send nothing and let it speak.
 
 A reply is the right call only when (a) you have a substantive answer to a question they asked, (b) you hit a blocker only they can resolve, or (c) you finished and the result isn't otherwise visible. Otherwise, finish the work and stay silent.
 
@@ -39,7 +39,7 @@ A reply is the right call only when (a) you have a substantive answer to a quest
 
 When the incoming message hands the task to you — "take it from here", "you own this now", "hand it over to you" — that is a transfer of responsibility, not a question. The sender has stepped out. Don't ack before starting, and don't send mid-task status pings; the handoff already said they're not waiting. Report back only when you finish (with the result in the same message) or when you genuinely cannot proceed without their input.
 
-If you finish a handed-off task, the audience for the result is usually the human in *your* pane, not the original agent. Surface the result in your normal output — don't ping the previous agent over `send-keys` just to close the loop.
+If you finish a handed-off task, the audience for the result is usually the human in _your_ pane, not the original agent. Surface the result in your normal output — don't ping the previous agent over `send-keys` just to close the loop.
 
 ## Don't scrape the screen — ask the agent
 

--- a/skills/agentoast-send/references/operate.md
+++ b/skills/agentoast-send/references/operate.md
@@ -12,7 +12,7 @@ agentoast send-keys --pane %72 "your message"
 
 The text is typed into that agent's prompt and submitted. If you are running inside tmux (`$TMUX_PANE` set) or you pass `--from %NN`, your pane id is appended as a reply address so the receiver sees `(reply: agentoast send-keys --pane <you> "<reply>")` — you do not add that hint yourself.
 
-If the command exits non-zero with `pane '%NN' has no detected AI coding agent`, your Step 2 verification was wrong (it can happen if a `node`/`python` process happened not to be an agent). Do NOT retry with `--force` unless the user explicitly insists. Tell them, stop sending, and handle the rest of the request without messaging.
+Step 2 (`agentoast detect-agent`) already confirmed an agent is at the target, so `send-keys` should not refuse. In the rare case it does (a one-off race in detection), report the refusal to the user and stop. Do not retry.
 
 After a successful send, tell the user it was sent. The reply arrives later as a new prompt in YOUR pane — there is nothing to poll or watch.
 
@@ -42,6 +42,6 @@ The agent knows its own context and will summarize it far better than a screen g
 ## Notes
 
 - Address = tmux pane id; ids stay stable for the life of the pane.
-- `send-keys` refuses a pane with no detected AI coding agent (a plain shell), since the message would just be typed into the shell prompt — a sign you picked the wrong pane. Pass `--force` only when you are sure an agent is there but the detector doesn't recognize it.
+- `send-keys` refuses a pane with no detected AI coding agent (a plain shell), since the message would just be typed into the shell prompt — a sign you picked the wrong pane. If a real agent isn't being detected, that's an `AGENT_PROCESSES` gap to fix in Rust, not something this skill bypasses.
 - If the target looks busy mid-generation, injected keystrokes can interleave — prefer sending when it is idle or waiting for input.
 - `--raw` sends without the reply hint; `--no-enter` types without submitting.

--- a/skills/agentoast-send/references/operate.md
+++ b/skills/agentoast-send/references/operate.md
@@ -29,6 +29,18 @@ EOF
 )"
 ```
 
+## When NOT to reply
+
+`send-keys` is a working channel, not a chat. Every message you send another agent costs them a turn of context. Don't spend it on social glue — bare acknowledgments ("got it", "thanks", "will share progress"), echoing the plan back to confirm understanding, or a standalone "done" ping with no result attached. If you finished, the result *is* the message: send the diff, the path, or the answer in the same call. If the artifact is already visible to them (commit pushed, file saved), send nothing and let it speak.
+
+A reply is the right call only when (a) you have a substantive answer to a question they asked, (b) you hit a blocker only they can resolve, or (c) you finished and the result isn't otherwise visible. Otherwise, finish the work and stay silent.
+
+## Handoffs: act, don't ack
+
+When the incoming message hands the task to you — "take it from here", "you own this now", "hand it over to you" — that is a transfer of responsibility, not a question. The sender has stepped out. Don't ack before starting, and don't send mid-task status pings; the handoff already said they're not waiting. Report back only when you finish (with the result in the same message) or when you genuinely cannot proceed without their input.
+
+If you finish a handed-off task, the audience for the result is usually the human in *your* pane, not the original agent. Surface the result in your normal output — don't ping the previous agent over `send-keys` just to close the loop.
+
 ## Don't scrape the screen — ask the agent
 
 To learn what another agent is doing or what its task is, do NOT run `tmux capture-pane`. In a conversation TUI the captured text is clipped to the pane width and truncated, and scrollback can't hold the whole conversation — you get a broken, partial view. Instead, ask the agent and let it answer in clean, authored prose:


### PR DESCRIPTION
## Summary

- Drop `--force` from `agentoast send-keys` and route both the CLI and the `agentoast-send` skill through a single `agentoast detect-agent` source of truth, so the skill never reaches `send-keys` for shell-only panes.
- Teach the skill to stay silent when nothing useful needs to be sent — no bare acks, plan echoes, "done" pings, or handoff-receipt messages — to stop agent-to-agent chatter loops.
- Trim the README's Cross-Agent Messaging section; the flag table now lives behind `--help`, the README keeps just the mechanism.

## Changes

- **`crates/agentoast-cli/src/lib.rs`** — Remove the `--force` flag from `send-keys`, rewrite the refusal message to point at `AGENT_PROCESSES` instead of advertising a bypass. Add a new `agentoast detect-agent --pane %NN` subcommand that prints `agent` / `no-agent` (exit 0 / 1) using the same `agent_detect::detect_agent` walk. Both subcommands share `detect_agent_for_pane()` so detection logic stays in one place.
- **`skills/agentoast-send/SKILL.md`** — Replace the bespoke Step 2 `ps … grep` (which used a different agent list than the CLI and would mis-classify e.g. `cursor-agent` / `aider` / `continue` panes) with a single `agentoast detect-agent` call. On `no-agent`, the skill bails out cleanly — does not open `operate.md`, does not call `send-keys`, does not probe with `tmux` on the skill's behalf — and just tells the user the pane has no agent. Notes that `AGENT_PROCESSES` (Rust side) is the sole place to add a new agent.
- **`skills/agentoast-send/references/operate.md`** — Drop every mention of `--force`. Add two new sections: *When NOT to reply* (no bare acks / plan echoes / done-only pings; reply only when there's a substantive answer, an unblockable blocker, or an otherwise-invisible result) and *Handoffs: act, don't ack* (treat handoffs as transfers of responsibility, skip the ack, skip mid-task status pings).
- **`README.md`** — Compress the Cross-Agent Messaging section: drop the per-flag table (now `--help` territory), keep the mechanism (pane-id addressing, `AGENT_PROCESSES`-based detection, `$TMUX_PANE` reply hint, `detect-agent` probe).


