### PR TITLE
chore: track agentoast-send skill version via tagpr

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -1,6 +1,6 @@
 [tagpr]
 	vPrefix = true
 	releaseBranch = main
-	versionFile = Cargo.toml,src-tauri/tauri.conf.json,package.json
+	versionFile = Cargo.toml,src-tauri/tauri.conf.json,package.json,skills/agentoast-send/SKILL.md
 	release = draft
 	postVersionCommand = cargo update --workspace && bun x vp fmt

--- a/skills/agentoast-send/SKILL.md
+++ b/skills/agentoast-send/SKILL.md
@@ -11,6 +11,12 @@ when_to_use: |
   - The user only wants to inspect, read, check, or look at what is displayed in a pane ("what's in %23", "check pane %15", "show me %4", "look at the output in %9"). Handle those normally without messaging.
   - A pane id (%NN) is mentioned without any send/ask/delegate intent.
   - The intent is ambiguous — defer to the user.
+license: MIT
+compatibility: Requires agentoast CLI and tmux
+allowed-tools: Bash(agentoast:*) Read
+metadata:
+  author: shuntaka9576
+  version: "0.49.2"
 ---
 
 # agentoast-send: triage before you send


### PR DESCRIPTION
## Summary

- Add Agent Skills spec frontmatter fields (`license`, `compatibility`, `allowed-tools`, `metadata.author`, `metadata.version`) to `skills/agentoast-send/SKILL.md`.
- Include `skills/agentoast-send/SKILL.md` in `.tagpr`'s `versionFile` so the skill's `metadata.version` is bumped alongside `Cargo.toml`, `src-tauri/tauri.conf.json`, and `package.json` on each release.


