### PR TITLE
fix: route agentoast-send no-agent path through raw tmux send-keys

### DIFF
--- a/skills/agentoast-send/SKILL.md
+++ b/skills/agentoast-send/SKILL.md
@@ -27,14 +27,14 @@ Trigger conditions in the frontmatter `when_to_use` already filter most non-dele
 
 ## Step 2: Verify an agent is actually at `%NN`
 
-Most panes are shells, editors, build runs, or REPLs. Sending into those just dumps the message into a shell prompt and is annoying. Ask the CLI:
+The right send CLI depends on what's in the pane: `agentoast send-keys` for AI agent panes, plain `tmux send-keys` for shells. Pick the right one:
 
 ```
 agentoast detect-agent --pane %NN
 ```
 
 - **`agent` (exit 0)** → an AI coding agent is running in `%NN`. Proceed to Step 3.
-- **`no-agent` (exit ≠ 0)** → Nothing to send. Answer the user's original prompt normally; if you need to know what's in the pane, run `tmux capture-pane -t %NN -p`.
+- **`no-agent` (exit ≠ 0)** → Don't stall asking for clarification. Carry out the user's instruction with raw `tmux send-keys` (agentoast refuses no-agent panes).
 
 The single source of truth for "what counts as an agent" is `AGENT_PROCESSES` in `crates/agentoast-shared/src/agent_detect.rs`. Both `detect-agent` and `send-keys` share it, so adding a new agent only requires editing that one list — this skill needs no update.
 


### PR DESCRIPTION
## Summary

- Reframe `skills/agentoast-send/SKILL.md` Step 2 so `detect-agent` is a router (agent → `agentoast send-keys`, shell → `tmux send-keys`) instead of a refuser
- Replace the no-agent bullet's "Nothing to send. Answer the original prompt normally." with an imperative "Don't stall asking for clarification. Carry out the user's instruction with raw `tmux send-keys`." — Claude consistently turned the old wording into a 3-way clarify question ("different pane? / send anyway? / new pane?") that left the user stuck
- Removes the contradiction this introduced: the prior Step 2 intro called shell sends "annoying", which clashed with the new tmux fallback

## Background

Failure mode observed:
1. `Please take a look at tmux pane %131.` (agentoast notification) + user instruction to use that pane
2. Skill fires, `agentoast detect-agent --pane %131` returns `no-agent` (the pane was a plain build shell)
3. Per old wording, Claude offered 3 clarify options instead of acting
4. On re-instruction (`コマンド流して`) Claude opened `references/operate.md`, but `agentoast send-keys` hard-refuses no-agent panes at `crates/agentoast-cli/src/lib.rs:341` with exit 1 and no bypass flag — the path dead-ends

## Test plan

- [ ] Re-read `skills/agentoast-send/SKILL.md` Step 2 and confirm: the intro names both CLIs as the routing outcomes, and the no-agent bullet directs `tmux send-keys` without stall language
- [ ] Walk three scenarios mentally against the new text:
  - Notification + `tmuxペインでやってくれ` + pane is no-agent → skill picks `tmux send-keys`, no 3-way clarify
  - Follow-up `コマンド流して` → same path, no retry of `agentoast send-keys`
  - Notification + `あいつに振っといて` + pane is an agent → flow still hits Step 3 / `operate.md` (unchanged path)
- [ ] No code paths in `crates/agentoast-cli/` or `crates/agentoast-shared/` are touched; pre-push lint + clippy passed locally as a side effect of `lefthook`
