### PR TITLE
fix: drop AGENT_PROCESSES internals note from agentoast-send skill

### DIFF
--- a/skills/agentoast-send/SKILL.md
+++ b/skills/agentoast-send/SKILL.md
@@ -36,8 +36,6 @@ agentoast detect-agent --pane %NN
 - **`agent` (exit 0)** → an AI coding agent is running in `%NN`. Proceed to Step 3.
 - **`no-agent` (exit ≠ 0)** → Don't stall asking for clarification. Carry out the user's instruction with raw `tmux send-keys` (agentoast refuses no-agent panes).
 
-The single source of truth for "what counts as an agent" is `AGENT_PROCESSES` in `crates/agentoast-shared/src/agent_detect.rs`. Both `detect-agent` and `send-keys` share it, so adding a new agent only requires editing that one list — this skill needs no update.
-
 ## Step 3: Send (and reply)
 
 Open and follow [references/operate.md](references/operate.md). It covers the `agentoast send-keys` invocation, the reply pattern for incoming messages, and when the right move is to _not_ send anything (handoffs, acknowledgments, status pings). Reading it before Step 2 passes is wasted context.


### PR DESCRIPTION
## Summary

- Drop the Step 2 paragraph in `skills/agentoast-send/SKILL.md` that pointed skill readers at `AGENT_PROCESSES` in `crates/agentoast-shared/src/agent_detect.rs`.
- The note addressed repository maintainers, not skill users (who may not have the repo checked out at all), and broke the Step 2 → Step 3 flow with implementation trivia.
- The `detect-agent` exit-based branching already tells the user what to do; no replacement sentence is needed.

## Changes

- `skills/agentoast-send/SKILL.md`: remove L38-40 (paragraph + leading blank line). No other edits.

Out of scope (intentionally untouched):
- `skills/agentoast-send/references/operate.md` L57 still mentions `AGENT_PROCESSES`, but there it grounds a behavioral rule ("if a real agent isn't being detected, that's an `AGENT_PROCESSES` gap to fix in Rust, not something this skill bypasses"), not a standalone maintainer aside.
- `skills/agentoast-send.backup/SKILL.md` is a snapshot and is not synced.

## Test plan

- [ ] `skills/agentoast-send/SKILL.md` renders cleanly: Step 2 ends with the `no-agent` bullet and flows straight into the `## Step 3` heading.
- [ ] Frontmatter (`name`, `when_to_use`, `allowed-tools`, `metadata.version`) is unchanged.
- [ ] Skill still triggers under the documented "agentoast notification + explicit send instruction" condition.