### PR TITLE
fix: simplify main panel positioning to a single AppKit-coord path

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -20,6 +20,7 @@
     "addon",
     "addons",
     "appdir",
+    "appkit",
     "autolaunch",
     "Backquote",
     "bezeled",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ objc2-foundation = { version = "0.3.2", features = [
 objc2-app-kit = { version = "0.3.2", features = [
   "NSRunningApplication",
   "NSWorkspace",
+  "NSApplication",
   "NSPanel",
   "NSWindow",
   "NSView",
@@ -63,6 +64,12 @@ objc2-app-kit = { version = "0.3.2", features = [
   "NSImage",
   "NSImageView",
   "NSBitmapImageRep",
+  "NSStatusBar",
+  "NSStatusBarButton",
+  "NSStatusItem",
+  "NSControl",
+  "NSButton",
+  "NSResponder",
 ] }
 objc2-core-foundation = "0.3.2"
 objc2-core-graphics = "0.3.2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -414,7 +414,7 @@ fn show_panel(app_handle: tauri::AppHandle) {
         // its last position (e.g. screen center on a fresh launch).
         panel.set_alpha_value(0.0);
         panel.show_and_make_key();
-        panel::position_panel_for_shortcut(&app_handle);
+        panel::position_panel_appkit(&app_handle);
         panel.set_alpha_value(1.0);
     }
 }

--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -4,10 +4,13 @@ use std::sync::OnceLock;
 
 use block2::RcBlock;
 use objc2::msg_send_id;
-use objc2_app_kit::NSEventMask;
+// NB: NSPoint, NSRect, NSEvent, MainThreadMarker, Retained, Bool are pulled in
+// at module scope by `tauri_panel!` below — DON'T re-import them or rustc
+// trips E0252. Use bare names downstream.
+use objc2_app_kit::{NSApplication, NSEventMask, NSScreen};
 use tauri::tray::TrayIconId;
 use tauri::Emitter;
-use tauri::{Manager, PhysicalPosition, PhysicalSize, Position, Size};
+use tauri::Manager;
 use tauri_nspanel::{
     tauri_panel, CollectionBehavior, ManagerExt, PanelLevel, StyleMask, WebviewWindowExt,
 };
@@ -119,583 +122,158 @@ pub fn init(app_handle: &tauri::AppHandle) -> tauri::Result<()> {
     Ok(())
 }
 
-pub fn position_panel_at_tray_icon(
-    app_handle: &tauri::AppHandle,
-    icon_position: Position,
-    icon_size: Size,
-) {
-    let Some(window) = app_handle.get_webview_window("main") else {
-        log::warn!("position_panel_at_tray_icon: main window not found");
+/// Position the main panel on the screen currently containing the cursor (or
+/// the key window's screen, or main screen) such that the panel sits just
+/// below the menu bar, horizontally centered on the tray icon's right-edge
+/// offset.
+///
+/// Both the tray-click and shortcut-trigger paths funnel through this — the
+/// positioning rule is the same in either case: "drop the panel under the
+/// tray icon on the screen the user is currently looking at." On
+/// multi-monitor setups where macOS replicates the menu bar on every screen
+/// (System Settings → Displays → "Show menu bar on all displays"), this puts
+/// the panel exactly under the focused screen's tray icon. On "main display
+/// only" setups, it puts the panel where the icon *would be* on the active
+/// screen (same right-edge offset).
+///
+/// All coordinates are AppKit (bottom-left origin, logical pt). We never
+/// round-trip through Tauri's coordinate API, so no Physical/Logical
+/// normalization or scale-factor math is needed.
+pub fn position_panel_appkit(app_handle: &tauri::AppHandle) {
+    let Some(mtm) = MainThreadMarker::new() else {
+        log::warn!("position_panel_appkit: not on main thread");
         return;
     };
 
-    let (icon_phys_x, icon_phys_y) = match &icon_position {
-        Position::Physical(pos) => (pos.x, pos.y),
-        Position::Logical(pos) => (pos.x as i32, pos.y as i32),
-    };
-
-    log::info!(
-        "[panel-pos] at_tray_icon: icon_pos=({}, {}) icon_size={:?}",
-        icon_phys_x,
-        icon_phys_y,
-        icon_size
-    );
-
-    let monitors = match window.available_monitors() {
-        Ok(m) => m,
-        Err(e) => {
-            log::warn!("position_panel_at_tray_icon: failed to get monitors: {}", e);
-            return;
-        }
-    };
-    // Find the monitor containing the tray icon.
-    // Tray icons live in the macOS menu bar, which sits *above* the usable
-    // rect returned by Tauri, so `icon_phys_y < monitor.position().y` is the
-    // normal case. We first try an exact (X ∧ Y) match for completeness, then
-    // fall back to "X is inside and the monitor's top is closest-above the
-    // tray icon". That tiebreak is critical on setups where two monitors'
-    // X ranges overlap (e.g. a huge secondary display positioned so its X
-    // range covers the primary): the previous `iter().find(X-only)` would
-    // return the first such monitor in the list, sending the panel to the
-    // wrong screen even though the tray icon is visually on the other one.
-    let in_x_range = |m: &tauri::Monitor| {
-        let pos = m.position();
-        let size = m.size();
-        icon_phys_x >= pos.x && icon_phys_x < pos.x + size.width as i32
-    };
-
-    let found_monitor = monitors.iter().find(|m| {
-        let pos = m.position();
-        let size = m.size();
-        let y_in = icon_phys_y >= pos.y && icon_phys_y < pos.y + size.height as i32;
-        in_x_range(m) && y_in
-    });
-    let found_monitor = found_monitor.or_else(|| {
-        monitors.iter().filter(|m| in_x_range(m)).min_by_key(|m| {
-            let dy = m.position().y - icon_phys_y;
-            // Prefer monitors whose top edge sits below the tray icon
-            // (the menu-bar case, dy ≥ 0). Among those, pick the one
-            // closest to the icon. Monitors whose top is above the icon
-            // fall back to distance-only ranking after the preferred set.
-            (if dy < 0 { 1 } else { 0 }, dy.unsigned_abs())
-        })
-    });
-
-    let monitor = match found_monitor.or_else(|| monitors.first()) {
-        Some(m) => m,
-        None => {
-            log::warn!("position_panel_at_tray_icon: no monitors available");
-            return;
-        }
-    };
-    let scale_factor = monitor.scale_factor();
-    let window_size = match window.outer_size() {
-        Ok(s) => s,
-        Err(e) => {
-            log::warn!(
-                "position_panel_at_tray_icon: failed to get window size: {}",
-                e
-            );
-            return;
-        }
-    };
-    let window_width_phys = window_size.width as i32;
-
-    let (icon_phys_x, icon_phys_y, icon_width_phys, icon_height_phys) =
-        match (icon_position, icon_size) {
-            (Position::Physical(pos), Size::Physical(size)) => {
-                (pos.x, pos.y, size.width as i32, size.height as i32)
-            }
-            (Position::Logical(pos), Size::Logical(size)) => (
-                (pos.x * scale_factor) as i32,
-                (pos.y * scale_factor) as i32,
-                (size.width * scale_factor) as i32,
-                (size.height * scale_factor) as i32,
-            ),
-            (Position::Physical(pos), Size::Logical(size)) => (
-                pos.x,
-                pos.y,
-                (size.width * scale_factor) as i32,
-                (size.height * scale_factor) as i32,
-            ),
-            (Position::Logical(pos), Size::Physical(size)) => (
-                (pos.x * scale_factor) as i32,
-                (pos.y * scale_factor) as i32,
-                size.width as i32,
-                size.height as i32,
-            ),
-        };
-
-    let icon_center_x_phys = icon_phys_x + (icon_width_phys / 2);
-    let panel_x_phys = icon_center_x_phys - (window_width_phys / 2);
-    // Was 8.0 — that nudged the panel top *into* the menu bar by 8 logical pt
-    // so the chrome notch could "kiss" the tray icon visually, but it also
-    // made the panel body cover the bottom half of the icon. Sit just below
-    // the menu bar instead.
-    let nudge_up_points: f64 = 0.0;
-    let nudge_up_phys = (nudge_up_points * scale_factor).round() as i32;
-    let panel_y_phys = icon_phys_y + icon_height_phys - nudge_up_phys;
-
-    log::info!(
-        "[panel-pos] at_tray_icon: monitor_pos={:?} scale={} win_phys=({}x{}) icon_phys=({},{} {}x{}) center_x={} pre_clamp=({},{})",
-        monitor.position(),
-        scale_factor,
-        window_size.width,
-        window_size.height,
-        icon_phys_x,
-        icon_phys_y,
-        icon_width_phys,
-        icon_height_phys,
-        icon_center_x_phys,
-        panel_x_phys,
-        panel_y_phys
-    );
-
-    // Clamp panel position within monitor bounds.
-    // Use menu-bar-bottom as the Y minimum so that the panel never sticks to
-    // the very top of the screen (happens when menu bar is auto-hidden or
-    // in fullscreen mode — tray.rect() returns y≈0 in these cases).
-    let monitor_pos = monitor.position();
-    let monitor_size = monitor.size();
-    let window_height_phys = window_size.height as i32;
-    let menu_bar_bottom_phys = monitor_pos.y + (25.0 * scale_factor).round() as i32 - nudge_up_phys;
-    let panel_y_phys = panel_y_phys.max(menu_bar_bottom_phys);
-    let panel_y_phys =
-        panel_y_phys.min(monitor_pos.y + monitor_size.height as i32 - window_height_phys);
-    let panel_x_phys = panel_x_phys.max(monitor_pos.x);
-    let panel_x_phys =
-        panel_x_phys.min(monitor_pos.x + monitor_size.width as i32 - window_width_phys);
-
-    log::info!(
-        "[panel-pos] at_tray_icon: final=({},{})",
-        panel_x_phys,
-        panel_y_phys
-    );
-
-    set_panel_position_sync(app_handle, panel_x_phys, panel_y_phys, monitor);
-}
-
-/// Set panel position directly via NSPanel (synchronous, no Tauri async dispatch).
-/// Converts from Tauri global physical coordinates (top-left origin) to macOS screen
-/// coordinates (bottom-left origin) using the target monitor for correct mixed-DPI
-/// multi-monitor conversion.
-fn set_panel_position_sync(
-    app_handle: &tauri::AppHandle,
-    phys_x: i32,
-    phys_y: i32,
-    monitor: &tauri::Monitor,
-) {
     let panel_handle = match app_handle.get_webview_panel("main") {
         Ok(p) => p,
         Err(_) => {
-            log::warn!("set_panel_position_sync: panel not found");
+            log::warn!("position_panel_appkit: panel not found");
             return;
         }
     };
     let ns_panel = panel_handle.as_panel();
-    let scale = monitor.scale_factor();
-    let mon_pos = monitor.position();
-    let mon_size = monitor.size();
 
-    unsafe {
-        use objc2::msg_send;
+    let panel_frame: NSRect = unsafe { objc2::msg_send![ns_panel, frame] };
+    let panel_width = panel_frame.size.width;
+    let panel_height = panel_frame.size.height;
 
-        // Get the panel's current frame to know window height
-        let frame: tauri_nspanel::NSRect = msg_send![ns_panel, frame];
-        let win_height = frame.size.height;
-
-        // Convert global physical to local physical (relative to target monitor)
-        let local_phys_x = phys_x - mon_pos.x;
-        let local_phys_y = phys_y - mon_pos.y;
-
-        // Convert local physical to local logical using the target monitor's scale
-        let local_logical_x = local_phys_x as f64 / scale;
-        let local_logical_y = local_phys_y as f64 / scale;
-
-        // Find the matching NSScreen by logical dimensions
-        let screens: *const objc2::runtime::AnyObject = msg_send![objc2::class!(NSScreen), screens];
-        if screens.is_null() {
-            return;
-        }
-        let count: usize = msg_send![screens, count];
-        if count == 0 {
-            return;
-        }
-
-        let mon_logical_w = mon_size.width as f64 / scale;
-        let mon_logical_h = mon_size.height as f64 / scale;
-
-        // Approximate expected NSScreen origin.x from Tauri physical position.
-        // Exact for uniform-DPI setups (the only case where duplicate sizes occur
-        // in practice); reasonable heuristic for mixed-DPI.
-        let expected_x = mon_pos.x as f64 / scale;
-
-        let mut screen_frame: Option<tauri_nspanel::NSRect> = None;
-        let mut best_dist = f64::MAX;
-        for i in 0..count {
-            let scr: *const objc2::runtime::AnyObject = msg_send![screens, objectAtIndex: i];
-            if scr.is_null() {
-                continue;
-            }
-            let sf: tauri_nspanel::NSRect = msg_send![scr, frame];
-            // Match by logical dimensions (tolerance for rounding)
-            if (sf.size.width - mon_logical_w).abs() < 2.0
-                && (sf.size.height - mon_logical_h).abs() < 2.0
-            {
-                // Among size-matched screens, pick the one closest to the
-                // expected origin to disambiguate identical monitors.
-                let dist = (sf.origin.x - expected_x).abs();
-                if dist < best_dist {
-                    best_dist = dist;
-                    screen_frame = Some(sf);
-                }
-            }
-        }
-
-        let screen_frame = match screen_frame {
-            Some(f) => f,
-            None => {
-                // Fallback to primary screen
-                let primary: *const objc2::runtime::AnyObject =
-                    msg_send![screens, objectAtIndex: 0usize];
-                if primary.is_null() {
-                    return;
-                }
-                msg_send![primary, frame]
-            }
-        };
-
-        // Convert to macOS coordinates using the matched NSScreen's frame.
-        // NSScreen origin is at bottom-left in macOS global logical coords.
-        // local_logical_y is distance from the TOP of the screen (Tauri convention).
-        let macos_x = screen_frame.origin.x + local_logical_x;
-        let macos_y =
-            screen_frame.origin.y + screen_frame.size.height - local_logical_y - win_height;
-
-        let origin = tauri_nspanel::NSPoint::new(macos_x, macos_y);
-        let _: () = msg_send![ns_panel, setFrameOrigin: origin];
-    }
-}
-
-/// Find the monitor whose bounds contain the given physical point.
-fn find_monitor_containing(
-    monitors: &[tauri::Monitor],
-    phys_x: i32,
-    phys_y: i32,
-) -> Option<&tauri::Monitor> {
-    monitors.iter().find(|m| {
-        let pos = m.position();
-        let size = m.size();
-        phys_x >= pos.x
-            && phys_x < pos.x + size.width as i32
-            && phys_y >= pos.y
-            && phys_y < pos.y + size.height as i32
-    })
-}
-
-/// Position panel at the top-right (menu bar area) of the given monitor.
-fn position_panel_on_monitor(
-    app_handle: &tauri::AppHandle,
-    window: &tauri::WebviewWindow,
-    monitor: &tauri::Monitor,
-) {
-    let scale = monitor.scale_factor();
-    let mon_pos = monitor.position();
-    let mon_size = monitor.size();
-    let win_size = match window.outer_size() {
-        Ok(s) => s,
-        Err(e) => {
-            log::warn!(
-                "position_panel_on_monitor: failed to get window size: {}",
-                e
-            );
-            return;
-        }
-    };
-
-    // Right-aligned with margin
-    let margin_phys = (16.0 * scale).round() as i32;
-    let panel_x = mon_pos.x + mon_size.width as i32 - win_size.width as i32 - margin_phys;
-
-    // Below the menu bar (~25 logical pt) with nudge up (~8 logical pt)
-    let menu_bar_phys = (25.0 * scale).round() as i32;
-    let nudge_phys = (8.0 * scale).round() as i32;
-    let panel_y = mon_pos.y + menu_bar_phys - nudge_phys;
-
-    // Clamp within monitor bounds
-    let panel_x = panel_x.max(mon_pos.x);
-    let panel_x = panel_x.min(mon_pos.x + mon_size.width as i32 - win_size.width as i32);
-    let panel_y = panel_y.max(mon_pos.y);
-    let panel_y = panel_y.min(mon_pos.y + mon_size.height as i32 - win_size.height as i32);
-
-    log::info!(
-        "[panel-pos] on_monitor: monitor_pos={:?} mon_size=({}x{}) scale={} final=({},{})",
-        mon_pos,
-        mon_size.width,
-        mon_size.height,
-        scale,
-        panel_x,
-        panel_y
-    );
-
-    set_panel_position_sync(app_handle, panel_x, panel_y, monitor);
-}
-
-/// Position panel for shortcut-triggered toggle.
-/// Uses cursor position to determine the active monitor. If the cursor and tray icon
-/// are on the same monitor, delegates to `position_panel_at_tray_icon` for precise
-/// alignment. Otherwise, positions at the top-right of the cursor's monitor.
-pub fn position_panel_for_shortcut(app_handle: &tauri::AppHandle) {
-    let Some(window) = app_handle.get_webview_window("main") else {
-        log::warn!("position_panel_for_shortcut: main window not found");
+    let Some(active_screen) = current_active_screen(mtm) else {
+        log::warn!("position_panel_appkit: no usable screen");
         return;
     };
+    let active_frame = active_screen.frame();
+    let active_visible = active_screen.visibleFrame();
 
-    let monitors = match window.available_monitors() {
-        Ok(m) if !m.is_empty() => m,
-        Ok(_) => {
-            log::warn!("position_panel_for_shortcut: no monitors available");
-            return;
-        }
-        Err(e) => {
-            log::warn!("position_panel_for_shortcut: failed to get monitors: {}", e);
-            return;
-        }
+    let tray_frames = get_tray_frames_appkit(app_handle);
+
+    let (panel_x, panel_y) = if let Some((tray_win_frame, tray_screen_frame)) = tray_frames {
+        // Preserve the tray icon's distance from the right edge of its own
+        // screen, then apply that same offset on the active screen. This is
+        // what makes the panel feel like it pops out from "where the tray
+        // would be on this screen" regardless of which monitor the tray
+        // physically lives on.
+        let tray_right_offset = (tray_screen_frame.origin.x + tray_screen_frame.size.width)
+            - (tray_win_frame.origin.x + tray_win_frame.size.width);
+        let tray_width = tray_win_frame.size.width;
+
+        let target_tray_right = active_frame.origin.x + active_frame.size.width - tray_right_offset;
+        let target_tray_center = target_tray_right - tray_width / 2.0;
+        let x = target_tray_center - panel_width / 2.0;
+        // visibleFrame's top edge is the bottom of the menu bar — placing
+        // panel.y so its top sits exactly there lands it just under the
+        // menu bar, no hardcoded height needed.
+        let y = active_visible.origin.y + active_visible.size.height - panel_height;
+        (x, y)
+    } else {
+        // Tray status item unavailable (menu bar hidden / not yet registered).
+        // Fall back to the same top-right convention the toast panel uses.
+        let margin = 16.0;
+        let x = active_frame.origin.x + active_frame.size.width - panel_width - margin;
+        let y = active_visible.origin.y + active_visible.size.height - panel_height;
+        (x, y)
     };
 
-    // Determine cursor's monitor
-    let cursor_pos_raw = window.cursor_position().ok();
-    let cursor_monitor_pos = match &cursor_pos_raw {
-        Some(pos) => {
-            let cx = pos.x as i32;
-            let cy = pos.y as i32;
-            find_monitor_containing(&monitors, cx, cy)
-                .or_else(|| monitors.first())
-                .map(|m| *m.position())
-        }
-        None => None,
-    };
-
-    // Try to get tray icon rect and its monitor.
-    //
-    // Important: `tray.rect()` and `TrayIconEvent::Click`'s `rect` may report
-    // `Position`/`Size` in *different* units — empirically, the click event
-    // delivers `Physical(68, 48)` while `tray.rect()` returns `Logical(34, 43)`
-    // for the same icon. We normalize everything to physical here using a
-    // best-effort scale (the monitor that contains the tray icon's X), so the
-    // mirror math operates on a single coordinate system.
-    let tray_info = app_handle
-        .tray_by_id(&TrayIconId::new("tray"))
-        .and_then(|tray| tray.rect().ok().flatten())
-        .map(|rect| {
-            // Approximate the tray's monitor first using a position-only guess
-            // so we can pick a sensible scale. If the position is already
-            // physical this is exact; if it's logical we'll re-find later.
-            let (raw_x, raw_y) = match &rect.position {
-                Position::Physical(p) => (p.x, p.y),
-                Position::Logical(p) => (p.x as i32, p.y as i32),
-            };
-            let approx_monitor =
-                find_monitor_containing(&monitors, raw_x, raw_y).or_else(|| monitors.first());
-            let scale = approx_monitor.map(|m| m.scale_factor()).unwrap_or(1.0);
-
-            let (px, py, pw, ph) = rect_to_physical(&rect.position, &rect.size, scale);
-            let tray_monitor_pos =
-                find_monitor_containing(&monitors, px, py).map(|m| *m.position());
-
-            (px, py, pw, ph, tray_monitor_pos)
-        });
+    // Clamp inside the active screen so a tray icon near a screen edge
+    // (or a panel wider than expected) can't push the panel off-screen.
+    let min_x = active_frame.origin.x;
+    let max_x = active_frame.origin.x + active_frame.size.width - panel_width;
+    let panel_x = clamp_into(panel_x, min_x, max_x);
+    let min_y = active_visible.origin.y;
+    let max_y = active_visible.origin.y + active_visible.size.height - panel_height;
+    let panel_y = clamp_into(panel_y, min_y, max_y);
 
     log::info!(
-        "[panel-pos] for_shortcut: cursor_raw={:?} cursor_monitor={:?} tray_info_phys={:?}",
-        cursor_pos_raw.as_ref().map(|p| (p.x, p.y)),
-        cursor_monitor_pos,
-        tray_info,
+        "[panel-pos] appkit: tray={} active=({:.0},{:.0} {:.0}x{:.0}) final=({:.0},{:.0}) panel=({:.0}x{:.0})",
+        tray_frames.is_some(),
+        active_frame.origin.x,
+        active_frame.origin.y,
+        active_frame.size.width,
+        active_frame.size.height,
+        panel_x,
+        panel_y,
+        panel_width,
+        panel_height
     );
 
-    match (cursor_monitor_pos, &tray_info) {
-        // Cursor and tray on the same monitor → use tray position directly.
-        (Some(cursor_mp), Some((px, py, pw, ph, Some(tray_mp)))) if cursor_mp == *tray_mp => {
-            log::info!("[panel-pos] for_shortcut: branch=same-monitor → at_tray_icon");
-            position_panel_at_tray_icon(
-                app_handle,
-                Position::Physical(PhysicalPosition { x: *px, y: *py }),
-                Size::Physical(PhysicalSize {
-                    width: *pw as u32,
-                    height: *ph as u32,
-                }),
-            );
-        }
-        // Tray on a different monitor than the cursor → mirror the tray icon
-        // onto the cursor's monitor (preserve its distance from the right edge
-        // and its vertical offset within the monitor) and reuse the tray-icon
-        // positioner. This makes the shortcut feel like "open the panel from
-        // the tray, but on the screen I'm currently looking at" instead of
-        // jumping the panel to the menu bar's actual screen.
-        (Some(cursor_mp), Some((px, py, pw, ph, tray_mp_opt))) => {
-            let cursor_monitor = monitors.iter().find(|m| *m.position() == cursor_mp);
-            // Resolve a "source monitor" for the tray icon. When tray_mp is
-            // None (tray Y outside any monitor — auto-hide menu bar /
-            // fullscreen), fall back to "X-in-range, Y closest from below"
-            // — same heuristic as `position_panel_at_tray_icon`. Plain
-            // `iter().find()` would return the first X-matching monitor in
-            // declaration order, which on overlapping multi-monitor setups
-            // wrongly attributes the tray to the primary even when its true
-            // home is the secondary (and vice-versa).
-            let source_monitor = tray_mp_opt
-                .as_ref()
-                .and_then(|mp| monitors.iter().find(|m| m.position() == mp))
-                .or_else(|| {
-                    monitors
-                        .iter()
-                        .filter(|m| {
-                            let mp = m.position();
-                            let ms = m.size();
-                            *px >= mp.x && *px < mp.x + ms.width as i32
-                        })
-                        .min_by_key(|m| {
-                            let dy = m.position().y - *py;
-                            (if dy < 0 { 1 } else { 0 }, dy.unsigned_abs())
-                        })
-                });
-
-            // If the resolved source monitor turns out to be the cursor's
-            // monitor, this is really a same-monitor case and we should just
-            // use the tray rect directly. Mirroring src==dst would still pick
-            // up the original X — which on tray icons near the right edge
-            // gets clamped to the screen's right side, making the panel
-            // appear to overshoot.
-            let is_same_monitor = match (cursor_monitor, source_monitor) {
-                (Some(c), Some(s)) => c.position() == s.position(),
-                _ => false,
-            };
-
-            if is_same_monitor {
-                log::info!(
-                    "[panel-pos] for_shortcut: branch=mirror-resolved-same-monitor → at_tray_icon"
-                );
-                position_panel_at_tray_icon(
-                    app_handle,
-                    Position::Physical(PhysicalPosition { x: *px, y: *py }),
-                    Size::Physical(PhysicalSize {
-                        width: *pw as u32,
-                        height: *ph as u32,
-                    }),
-                );
-            } else if let (Some(cursor_monitor), Some(source_monitor)) =
-                (cursor_monitor, source_monitor)
-            {
-                let (mx, my, mw, mh) =
-                    mirror_tray_rect_to_monitor(*px, *py, *pw, *ph, source_monitor, cursor_monitor);
-                log::info!(
-                    "[panel-pos] for_shortcut: branch=mirrored src_mon={:?} dst_mon={:?} mirrored_phys=({},{} {}x{})",
-                    source_monitor.position(),
-                    cursor_monitor.position(),
-                    mx,
-                    my,
-                    mw,
-                    mh,
-                );
-                position_panel_at_tray_icon(
-                    app_handle,
-                    Position::Physical(PhysicalPosition { x: mx, y: my }),
-                    Size::Physical(PhysicalSize {
-                        width: mw as u32,
-                        height: mh as u32,
-                    }),
-                );
-            } else if let Some(monitor) = cursor_monitor {
-                log::info!("[panel-pos] for_shortcut: branch=mirror-fallback → on_monitor");
-                position_panel_on_monitor(app_handle, &window, monitor);
-            }
-        }
-        // No tray rect available (tray hidden / not registered yet) → just put
-        // the panel on the cursor's monitor in the conventional top-right slot.
-        (Some(cursor_mp), None) => {
-            if let Some(monitor) = monitors.iter().find(|m| *m.position() == cursor_mp) {
-                log::info!("[panel-pos] for_shortcut: branch=no-tray → on_monitor");
-                position_panel_on_monitor(app_handle, &window, monitor);
-            }
-        }
-        // cursor_position() failed → fallback to tray position if available
-        (None, Some((px, py, pw, ph, _))) => {
-            log::info!("[panel-pos] for_shortcut: branch=no-cursor-fallback → at_tray_icon");
-            position_panel_at_tray_icon(
-                app_handle,
-                Position::Physical(PhysicalPosition { x: *px, y: *py }),
-                Size::Physical(PhysicalSize {
-                    width: *pw as u32,
-                    height: *ph as u32,
-                }),
-            );
-        }
-        // Both failed → fallback to first monitor's top-right
-        (None, None) => {
-            log::info!("[panel-pos] for_shortcut: branch=all-fallback → on_monitor(first)");
-            if let Some(monitor) = monitors.first() {
-                position_panel_on_monitor(app_handle, &window, monitor);
-            }
-        }
+    let origin = NSPoint::new(panel_x, panel_y);
+    unsafe {
+        let _: () = objc2::msg_send![ns_panel, setFrameOrigin: origin];
     }
 }
 
-/// Convert a Tauri `Position`+`Size` pair into physical pixels using the
-/// supplied `scale` factor (only consulted when the value is `Logical`).
-/// `tray.rect()` and the click event report units inconsistently — this
-/// helper lets all downstream math operate in a single coordinate system.
-fn rect_to_physical(position: &Position, size: &Size, scale: f64) -> (i32, i32, i32, i32) {
-    let (x, y) = match position {
-        Position::Physical(p) => (p.x, p.y),
-        Position::Logical(p) => ((p.x * scale).round() as i32, (p.y * scale).round() as i32),
-    };
-    let (w, h) = match size {
-        Size::Physical(s) => (s.width as i32, s.height as i32),
-        Size::Logical(s) => (
-            (s.width * scale).round() as i32,
-            (s.height * scale).round() as i32,
-        ),
-    };
-    (x, y, w, h)
+/// Resolve the "screen the user is currently looking at". Tries the cursor's
+/// screen first, then the key window's screen, then the main screen.
+fn current_active_screen(mtm: MainThreadMarker) -> Option<Retained<NSScreen>> {
+    let mouse_loc = NSEvent::mouseLocation();
+    let screens = NSScreen::screens(mtm);
+    for screen in screens.iter() {
+        let f = screen.frame();
+        if mouse_loc.x >= f.origin.x
+            && mouse_loc.x < f.origin.x + f.size.width
+            && mouse_loc.y >= f.origin.y
+            && mouse_loc.y < f.origin.y + f.size.height
+        {
+            return Some(screen);
+        }
+    }
+
+    let app = NSApplication::sharedApplication(mtm);
+    if let Some(key_window) = app.keyWindow() {
+        if let Some(screen) = key_window.screen() {
+            return Some(screen);
+        }
+    }
+
+    NSScreen::mainScreen(mtm)
 }
 
-/// Mirror a tray icon (already in physical pixels) from `src_monitor` onto
-/// `dst_monitor`, keeping its distance from the monitor's right edge and
-/// placing it at the destination monitor's top-of-screen (menu-bar slot).
+/// Get the tray icon's window frame and its screen's frame, both in AppKit
+/// global coordinates (bottom-left origin, logical pt).
 ///
-/// The reported icon height varies between sources (click event vs
-/// `tray.rect()`), so we override it with a stable 24-logical-pt value scaled
-/// to the destination monitor. That makes the downstream
-/// `panel_y = icon_y + icon_h - nudge` formula in `position_panel_at_tray_icon`
-/// produce the same vertical position the click path produces (panel sits
-/// just under the menu bar).
-fn mirror_tray_rect_to_monitor(
-    icon_phys_x: i32,
-    _icon_phys_y: i32,
-    icon_w_phys: i32,
-    _icon_h_phys: i32,
-    src_monitor: &tauri::Monitor,
-    dst_monitor: &tauri::Monitor,
-) -> (i32, i32, i32, i32) {
-    let src_pos = src_monitor.position();
-    let src_size = src_monitor.size();
-    let dst_pos = dst_monitor.position();
-    let dst_size = dst_monitor.size();
-    let dst_scale = dst_monitor.scale_factor();
+/// Uses `tauri::TrayIcon::with_inner_tray_icon` → `tray_icon::TrayIcon::ns_status_item`
+/// — a documented but internal-ish path. The `tray-icon` crate is pinned by
+/// Tauri minor versions; if Tauri bumps it incompatibly, this will fail to
+/// compile (caught in CI).
+fn get_tray_frames_appkit(app_handle: &tauri::AppHandle) -> Option<(NSRect, NSRect)> {
+    let tray = app_handle.tray_by_id(&TrayIconId::new("tray"))?;
+    tray.with_inner_tray_icon(|inner| {
+        let item = inner.ns_status_item()?;
+        let mtm = MainThreadMarker::new()?;
+        let button = item.button(mtm)?;
+        let window = button.window()?;
+        let screen = window.screen()?;
+        Some((window.frame(), screen.frame()))
+    })
+    .ok()
+    .flatten()
+}
 
-    let src_right = src_pos.x + src_size.width as i32;
-    let dst_right = dst_pos.x + dst_size.width as i32;
-    // Distance from the icon's *right edge* to its monitor's right edge.
-    let right_offset = src_right - (icon_phys_x + icon_w_phys);
-    let new_x = dst_right - right_offset - icon_w_phys;
-
-    // Stable 24-logical-pt icon height in physical pixels at the destination
-    // scale. Matches what `TrayIconEvent::Click` reports for the same tray
-    // icon, so the panel ends up at the same Y the click path produces.
-    let stable_h = (24.0 * dst_scale).round() as i32;
-    // Place the (mirrored) icon at the destination monitor's top — the
-    // downstream Y formula adds icon_h then subtracts the nudge, which lands
-    // the panel just below the menu bar.
-    let new_y = dst_pos.y;
-
-    (new_x, new_y, icon_w_phys, stable_h)
+fn clamp_into(v: f64, lo: f64, hi: f64) -> f64 {
+    // Tolerate inverted ranges (panel wider than screen) by anchoring to
+    // the lower bound rather than producing NaN.
+    if hi < lo {
+        return lo;
+    }
+    v.clamp(lo, hi)
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -5,7 +5,7 @@ use tauri::tray::{MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_nspanel::ManagerExt;
 
-use crate::panel::position_panel_at_tray_icon;
+use crate::panel::position_panel_appkit;
 
 macro_rules! get_or_init_panel {
     ($app_handle:expr) => {
@@ -42,7 +42,7 @@ pub fn toggle_panel(app_handle: &AppHandle) {
         let _ = app_handle.emit("notifications:refresh", ());
         panel.set_alpha_value(0.0);
         panel.show_and_make_key();
-        crate::panel::position_panel_for_shortcut(app_handle);
+        position_panel_appkit(app_handle);
         panel.set_alpha_value(1.0);
     }
 }
@@ -87,12 +87,9 @@ pub fn create(app_handle: &AppHandle) -> tauri::Result<()> {
         .on_tray_icon_event(|tray, event| {
             let app_handle = tray.app_handle();
 
-            if let TrayIconEvent::Click {
-                button_state, rect, ..
-            } = event
-            {
+            if let TrayIconEvent::Click { button_state, .. } = event {
                 if button_state == MouseButtonState::Up {
-                    log::info!("[panel-pos] entry=tray-click rect={:?}", rect);
+                    log::info!("[panel-pos] entry=tray-click");
                     let Some(panel) = get_or_init_panel!(app_handle) else {
                         return;
                     };
@@ -107,7 +104,7 @@ pub fn create(app_handle: &AppHandle) -> tauri::Result<()> {
                     let _ = app_handle.emit("notifications:refresh", ());
                     panel.set_alpha_value(0.0);
                     panel.show_and_make_key();
-                    position_panel_at_tray_icon(app_handle, rect.position, rect.size);
+                    position_panel_appkit(app_handle);
                     panel.set_alpha_value(1.0);
                 }
             }


### PR DESCRIPTION
## Summary

- Collapse main-panel positioning into a single AppKit-coord path. Both the tray-click and shortcut entry points now use the same rule — "drop the panel under the tray icon on the screen the user is currently looking at" — and share one function.
- Read the tray icon's frame straight from `NSStatusItem.button.window`, and resolve the active screen from `NSEvent.mouseLocation` → key window's screen → `NSScreen.mainScreen`. No more Tauri `TrayIconEvent.rect`, no Physical/Logical normalization, no scale-factor math, no hardcoded 25pt menu-bar clamp.
- `panel.rs` shrinks ~700 → ~280 lines.

## Why

The previous implementation split positioning across two code paths:

- **Tray-click** went through `position_panel_at_tray_icon`, normalizing `TrayIconEvent.rect`'s mixed Physical/Logical units, applying scale factors by hand, manually inverting top-left → bottom-left, and two-stage-picking the right monitor when X ranges overlapped.
- **Shortcut** went through `position_panel_for_shortcut` → `mirror_tray_rect_to_monitor`, which took the tray icon's screen position and mirrored its right-edge offset onto the cursor's monitor.

Conceptually it's one rule. Concretely it was ~700 lines of Tauri-to-AppKit translation. By reading `NSStatusItem.button.window.frame` directly (already AppKit screen coords) and resolving the active screen via `NSEvent.mouseLocation`, the whole translation layer disappears.

## What changed

### `src-tauri/src/panel.rs` — collapsed to ~280 lines

- **Added** `position_panel_appkit(app_handle)` — single positioning entry point. Pulls the tray's right-edge offset from `NSStatusItem` and applies it on the active screen.
- **Added** `current_active_screen(mtm)` — cursor screen → key window's screen → main screen fallback chain.
- **Added** `get_tray_frames_appkit(app_handle)` — uses `tauri::TrayIcon::with_inner_tray_icon` → `tray_icon::TrayIcon::ns_status_item` to reach `NSStatusBarButton.window().frame()`.
- **Removed**: `position_panel_at_tray_icon`, `set_panel_position_sync`, `find_monitor_containing`, `position_panel_on_monitor`, `position_panel_for_shortcut`, `rect_to_physical`, `mirror_tray_rect_to_monitor`.

### `src-tauri/src/tray.rs`, `src-tauri/src/lib.rs`

Both call sites (tray-click in `tray.rs`, shortcut in `tray.rs::toggle_panel` + `lib.rs`) now go through `position_panel_appkit`. The `alpha=0 → show → position → alpha=1` flicker-prevention sequence is unchanged.

### `src-tauri/Cargo.toml`

Adds `NSApplication`, `NSStatusBar`, `NSStatusBarButton`, `NSStatusItem`, `NSControl`, `NSButton`, `NSResponder` to the `objc2-app-kit` feature list — required for the new tray-icon access path.

### `cspell.json`

Add `appkit` to the allowlist (used in new function/log names).

## Notes / Tradeoffs

- Depends on `tray_icon::TrayIcon::ns_status_item()` — a documented but internal-ish API on the `tray-icon` crate that Tauri pins by minor version. Incompatible bumps will fail to compile (caught in CI), not silently change behavior.
- Shortcut behavior changes slightly on multi-monitor + "menu bar on main display only" setups: the panel now opens on the cursor's screen at the tray's right-edge offset, even when the cursor is on a screen without a real menu bar. Previously the mirror logic produced essentially the same result. Cursor-on-tray-screen and single-monitor cases are unchanged.


