### PR TITLE
feat: let users pick which screen corners show toast notifications

### DIFF
--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -83,12 +83,37 @@ pub struct AllowedApp {
     pub display_name: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ToastPosition {
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+}
+
+impl ToastPosition {
+    /// The canonical kebab-case string used in config.toml and IPC payloads.
+    /// Must stay in lockstep with the `rename_all = "kebab-case"` serde attr
+    /// above — keep them together so changes are obvious.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ToastPosition::TopLeft => "top-left",
+            ToastPosition::TopRight => "top-right",
+            ToastPosition::BottomLeft => "bottom-left",
+            ToastPosition::BottomRight => "bottom-right",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct ToastConfig {
     #[serde(default = "default_toast_duration")]
     pub duration_ms: u64,
     #[serde(default)]
     pub persistent: bool,
+    #[serde(default = "default_toast_positions")]
+    pub positions: Vec<ToastPosition>,
 }
 
 impl Default for ToastConfig {
@@ -96,8 +121,13 @@ impl Default for ToastConfig {
         Self {
             duration_ms: default_toast_duration(),
             persistent: false,
+            positions: default_toast_positions(),
         }
     }
+}
+
+fn default_toast_positions() -> Vec<ToastPosition> {
+    vec![ToastPosition::TopRight]
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -354,6 +384,19 @@ pub fn save_toast_persistent(value: bool) -> io::Result<()> {
     std::fs::write(&path, doc.to_string())
 }
 
+/// Update [toast] positions in config.toml, preserving existing comments and formatting.
+pub fn save_toast_positions(values: &[ToastPosition]) -> io::Result<()> {
+    let path = config_path();
+    let content = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut doc: DocumentMut = content.parse().unwrap_or_default();
+    let mut arr = toml_edit::Array::new();
+    for v in values {
+        arr.push(v.as_str());
+    }
+    doc["toast"]["positions"] = toml_edit::value(arr);
+    std::fs::write(&path, doc.to_string())
+}
+
 /// Update [keybinding] toggle_panel in config.toml, preserving existing comments and formatting.
 pub fn save_keybinding_toggle_panel(value: &str) -> io::Result<()> {
     let path = config_path();
@@ -426,6 +469,11 @@ fn default_config_template() -> &'static str {
 
 # Keep toast visible until clicked (default: false)
 # persistent = false
+
+# Where toast notifications appear on the active screen.
+# Multiple positions show the same toast in each corner simultaneously.
+# Valid values: "top-left", "top-right", "bottom-left", "bottom-right"
+# positions = ["top-right"]
 
 # Notification settings
 [notification]
@@ -539,6 +587,35 @@ git = "/opt/homebrew/bin/git"
             config.system.tmux.as_deref(),
             Some("/opt/homebrew/bin/tmux")
         );
+    }
+
+    #[test]
+    fn default_toast_positions_is_top_right() {
+        let config = ToastConfig::default();
+        assert_eq!(config.positions, vec![ToastPosition::TopRight]);
+    }
+
+    #[test]
+    fn parse_toast_positions_kebab_case() {
+        let toml_str = r#"
+[toast]
+positions = ["top-left", "bottom-right"]
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.toast.positions,
+            vec![ToastPosition::TopLeft, ToastPosition::BottomRight]
+        );
+    }
+
+    #[test]
+    fn missing_positions_falls_back_to_default() {
+        let toml_str = r#"
+[toast]
+duration_ms = 2000
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.toast.positions, vec![ToastPosition::TopRight]);
     }
 
     #[test]

--- a/cspell.json
+++ b/cspell.json
@@ -73,6 +73,7 @@
     "subcmd",
     "subview",
     "subviews",
+    "superview",
     "staticlib",
     "symbolichotkeys",
     "sysinfo",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,8 @@ mod macos_hotkeys;
 mod native_toast;
 mod panel;
 #[cfg(target_os = "macos")]
+mod screen;
+#[cfg(target_os = "macos")]
 mod sessions;
 #[cfg(target_os = "macos")]
 mod terminal;
@@ -21,7 +23,7 @@ use std::sync::{Mutex, OnceLock};
 #[cfg(target_os = "macos")]
 use std::time::Duration;
 
-use agentoast_shared::config::{self, AllowedApp, AppConfig};
+use agentoast_shared::config::{self, AllowedApp, AppConfig, ToastPosition};
 use agentoast_shared::db;
 use agentoast_shared::models::{Notification, TmuxPaneGroup};
 use serde::{Deserialize, Serialize};
@@ -657,6 +659,7 @@ fn get_update_enabled(state: tauri::State<'_, Mutex<AppState>>) -> Result<bool, 
 pub struct SettingsPayload {
     pub toast_duration_ms: u64,
     pub toast_persistent: bool,
+    pub toast_positions: Vec<ToastPosition>,
     pub toggle_panel_shortcut: String,
     pub editor: String,
     pub autostart_enabled: bool,
@@ -675,6 +678,7 @@ fn get_settings(state: tauri::State<'_, Mutex<AppState>>) -> Result<SettingsPayl
     Ok(SettingsPayload {
         toast_duration_ms: state.config.toast.duration_ms,
         toast_persistent: state.config.toast.persistent,
+        toast_positions: state.config.toast.positions.clone(),
         toggle_panel_shortcut: state.config.keybinding.toggle_panel.clone(),
         editor: state.config.editor.clone().unwrap_or_default(),
         autostart_enabled,
@@ -714,11 +718,18 @@ fn save_settings(
         (
             guard.config.toast.duration_ms,
             guard.config.toast.persistent,
+            guard.config.toast.positions.clone(),
             guard.config.keybinding.toggle_panel.clone(),
             guard.config.editor.clone().unwrap_or_default(),
         )
     };
-    let (old_toast_duration_ms, old_toast_persistent, old_shortcut_str, old_editor) = snapshot;
+    let (
+        old_toast_duration_ms,
+        old_toast_persistent,
+        old_toast_positions,
+        old_shortcut_str,
+        old_editor,
+    ) = snapshot;
 
     let shortcut_changed = old_shortcut_str != payload.toggle_panel_shortcut;
 
@@ -740,6 +751,9 @@ fn save_settings(
         }
         if old_toast_persistent != payload.toast_persistent {
             config::save_toast_persistent(payload.toast_persistent).map_err(|e| e.to_string())?;
+        }
+        if old_toast_positions != payload.toast_positions {
+            config::save_toast_positions(&payload.toast_positions).map_err(|e| e.to_string())?;
         }
         if shortcut_changed {
             config::save_keybinding_toggle_panel(&payload.toggle_panel_shortcut)
@@ -764,6 +778,13 @@ fn save_settings(
             log::error!(
                 "Rollback: failed to restore toast.persistent={}: {}",
                 old_toast_persistent,
+                e
+            );
+        }
+        if let Err(e) = config::save_toast_positions(&old_toast_positions) {
+            log::error!(
+                "Rollback: failed to restore toast.positions={:?}: {}",
+                old_toast_positions,
                 e
             );
         }
@@ -794,6 +815,7 @@ fn save_settings(
         let mut guard = state.lock().map_err(|e| e.to_string())?;
         guard.config.toast.duration_ms = payload.toast_duration_ms;
         guard.config.toast.persistent = payload.toast_persistent;
+        guard.config.toast.positions = payload.toast_positions.clone();
         guard.config.keybinding.toggle_panel = payload.toggle_panel_shortcut.clone();
         guard.config.editor = if payload.editor.is_empty() {
             None
@@ -804,7 +826,11 @@ fn save_settings(
 
     // --- Phase 4: runtime-push for settings that have live consumers. ---
     #[cfg(target_os = "macos")]
-    native_toast::update_settings(payload.toast_duration_ms, payload.toast_persistent);
+    native_toast::update_settings(
+        payload.toast_duration_ms,
+        payload.toast_persistent,
+        payload.toast_positions.clone(),
+    );
 
     // --- Phase 5: autostart (System Events login item). Not mirrored in
     // config.toml, so a failure here is surfaced but does not need a toml

--- a/src-tauri/src/native_toast.rs
+++ b/src-tauri/src/native_toast.rs
@@ -3,6 +3,7 @@
 use std::sync::{Mutex, OnceLock};
 
 use agentoast_shared::config;
+use agentoast_shared::config::ToastPosition;
 use agentoast_shared::models::Notification;
 use block2::RcBlock;
 use objc2::rc::Retained;
@@ -18,6 +19,7 @@ use objc2_core_foundation::{CGPoint, CGRect, CGSize};
 use objc2_foundation::{MainThreadMarker, NSData, NSString, NSTimer};
 use tauri::Emitter;
 
+use crate::screen::current_active_screen;
 use crate::terminal;
 
 // SAFETY: NSPanel and NSTimer are only ever accessed from the main thread.
@@ -26,7 +28,20 @@ struct SendSyncWrapper<T>(T);
 unsafe impl<T> Send for SendSyncWrapper<T> {}
 unsafe impl<T> Sync for SendSyncWrapper<T> {}
 
-static TOAST_PANEL: OnceLock<SendSyncWrapper<Retained<NSPanel>>> = OnceLock::new();
+/// Four NSPanels — one per ToastPosition, kept alive for the app's lifetime.
+/// Lookup via `panel_index(position)`. We allocate all 4 upfront (cheap)
+/// rather than reactively creating/destroying them when the user's selection
+/// changes — simpler, and the cost of an unused, hidden NSPanel is negligible.
+static TOAST_PANELS: OnceLock<[SendSyncWrapper<Retained<NSPanel>>; 4]> = OnceLock::new();
+
+fn panel_index(p: ToastPosition) -> usize {
+    match p {
+        ToastPosition::TopLeft => 0,
+        ToastPosition::TopRight => 1,
+        ToastPosition::BottomLeft => 2,
+        ToastPosition::BottomRight => 3,
+    }
+}
 static TOAST_STATE: OnceLock<Mutex<ToastState>> = OnceLock::new();
 static APP_HANDLE: OnceLock<tauri::AppHandle> = OnceLock::new();
 static TOAST_TIMER: Mutex<Option<SendSyncWrapper<Retained<NSTimer>>>> = Mutex::new(None);
@@ -80,6 +95,9 @@ struct ToastState {
     is_visible: bool,
     duration_ms: u64,
     persistent: bool,
+    /// Corners currently selected by the user. Each entry causes one of the
+    /// 4 preallocated panels to be shown for every notification.
+    positions: Vec<ToastPosition>,
 }
 
 // --- Color definitions ---
@@ -193,15 +211,21 @@ pub fn init(app_handle: &tauri::AppHandle) -> Result<(), String> {
             is_visible: false,
             duration_ms: cfg.toast.duration_ms,
             persistent: cfg.toast.persistent,
+            positions: cfg.toast.positions.clone(),
         }
     }));
 
     let mtm = MainThreadMarker::new().ok_or_else(|| "Must be called on main thread".to_string())?;
 
-    let panel = create_panel(mtm);
-    TOAST_PANEL
-        .set(SendSyncWrapper(panel))
-        .map_err(|_| "Toast panel already initialized".to_string())?;
+    let panels = [
+        SendSyncWrapper(create_panel(mtm)),
+        SendSyncWrapper(create_panel(mtm)),
+        SendSyncWrapper(create_panel(mtm)),
+        SendSyncWrapper(create_panel(mtm)),
+    ];
+    TOAST_PANELS
+        .set(panels)
+        .map_err(|_| "Toast panels already initialized".to_string())?;
 
     install_event_monitor();
 
@@ -303,7 +327,7 @@ pub fn show_notifications(notifications: Vec<Notification>) {
 
 /// Push runtime settings updates into the live toast state so new settings
 /// take effect on the next displayed toast without requiring an app restart.
-pub fn update_settings(duration_ms: u64, persistent: bool) {
+pub fn update_settings(duration_ms: u64, persistent: bool, positions: Vec<ToastPosition>) {
     let Some(state) = TOAST_STATE.get() else {
         return;
     };
@@ -312,17 +336,19 @@ pub fn update_settings(duration_ms: u64, persistent: bool) {
     };
     guard.duration_ms = duration_ms;
     guard.persistent = persistent;
+    guard.positions = positions;
 }
 
 pub fn hide() {
-    let Some(wrapper) = TOAST_PANEL.get() else {
+    let Some(panels) = TOAST_PANELS.get() else {
         return;
     };
-    let panel = &wrapper.0;
     cancel_timer();
     cancel_fade_timer();
 
-    panel.orderOut(None);
+    for wrapper in panels.iter() {
+        wrapper.0.orderOut(None);
+    }
 
     if let Some(state_mutex) = TOAST_STATE.get() {
         if let Ok(mut state) = state_mutex.lock() {
@@ -336,10 +362,9 @@ pub fn hide() {
 // --- Internal ---
 
 fn update_and_show() {
-    let Some(wrapper) = TOAST_PANEL.get() else {
+    let Some(panels) = TOAST_PANELS.get() else {
         return;
     };
-    let panel = &wrapper.0;
     let Some(state_mutex) = TOAST_STATE.get() else {
         return;
     };
@@ -362,6 +387,7 @@ fn update_and_show() {
     let current_index = state.current_index;
     let duration_ms = state.duration_ms;
     let persistent = state.persistent;
+    let positions = state.positions.clone();
     drop(state);
 
     let mtm = match MainThreadMarker::new() {
@@ -375,27 +401,47 @@ fn update_and_show() {
     let has_body = !current.body.is_empty();
     let panel_height = compute_panel_height(has_meta, has_body);
 
-    // Resize panel BEFORE setting content view to prevent layout distortion in release builds.
-    // Setting content view on a panel with stale size causes AppKit to resize subviews incorrectly.
-    position_at_top_right(mtm, panel, panel_height);
+    // Resolve the active screen once and reuse it for every panel — otherwise
+    // a cursor move mid-fan-out could place two panels on different screens.
+    let active_screen = current_active_screen(mtm);
 
-    let content_view = build_toast_view(mtm, &current, current_index, queue_len, panel_height);
-    panel.setContentView(Some(&content_view));
+    // Hide every panel first so deselected corners don't keep a stale toast
+    // on screen across a settings change. When `positions` is empty this is
+    // the only thing that runs, and `start_timer` below drains the queue.
+    for wrapper in panels.iter() {
+        wrapper.0.orderOut(None);
+    }
 
-    // Show with fade-in animation
-    panel.setAlphaValue(0.0);
-    panel.orderFrontRegardless();
+    for &position in &positions {
+        let wrapper = &panels[panel_index(position)];
+        let panel = &wrapper.0;
 
-    let panel_ptr = Retained::as_ptr(panel) as usize;
-    NSAnimationContext::runAnimationGroup(&RcBlock::new(
-        move |context: std::ptr::NonNull<NSAnimationContext>| {
-            let ctx = unsafe { context.as_ref() };
-            ctx.setDuration(FADE_DURATION);
-            let panel_ref: &NSPanel = unsafe { &*(panel_ptr as *const NSPanel) };
-            let animator: Retained<NSPanel> = unsafe { msg_send_id![panel_ref, animator] };
-            animator.setAlphaValue(1.0);
-        },
-    ));
+        // Resize panel BEFORE setting content view to prevent layout distortion in release builds.
+        // Setting content view on a panel with stale size causes AppKit to resize subviews incorrectly.
+        if let Some(ref screen) = active_screen {
+            position_at_corner(panel, panel_height, position, screen);
+        }
+
+        // Build a fresh content view per panel — NSView can only belong to
+        // one superview at a time, so we can't reuse a single view.
+        let content_view = build_toast_view(mtm, &current, current_index, queue_len, panel_height);
+        panel.setContentView(Some(&content_view));
+
+        // Show with fade-in animation
+        panel.setAlphaValue(0.0);
+        panel.orderFrontRegardless();
+
+        let panel_ptr = Retained::as_ptr(panel) as usize;
+        NSAnimationContext::runAnimationGroup(&RcBlock::new(
+            move |context: std::ptr::NonNull<NSAnimationContext>| {
+                let ctx = unsafe { context.as_ref() };
+                ctx.setDuration(FADE_DURATION);
+                let panel_ref: &NSPanel = unsafe { &*(panel_ptr as *const NSPanel) };
+                let animator: Retained<NSPanel> = unsafe { msg_send_id![panel_ref, animator] };
+                animator.setAlphaValue(1.0);
+            },
+        ));
+    }
 
     // Start auto-advance timer
     if !persistent {
@@ -934,15 +980,18 @@ fn install_event_monitor() {
         unsafe {
             let block = RcBlock::new(|event: std::ptr::NonNull<NSEvent>| -> *mut NSEvent {
                 let event_ref = event.as_ref();
-                let Some(wrapper) = TOAST_PANEL.get() else {
+                let Some(panels) = TOAST_PANELS.get() else {
                     return event.as_ptr();
                 };
-                let panel = &wrapper.0;
 
-                // Check if click is within our panel
+                // Click must be inside one of our 4 panels — otherwise let it
+                // pass through to the underlying window.
                 let event_window_num: i64 = msg_send![event_ref, windowNumber];
-                let panel_window_num: i64 = msg_send![panel, windowNumber];
-                if event_window_num != panel_window_num {
+                let matched = panels.iter().any(|wrapper| {
+                    let n: i64 = msg_send![&wrapper.0, windowNumber];
+                    n == event_window_num
+                });
+                if !matched {
                     return event.as_ptr();
                 }
 
@@ -1112,41 +1161,57 @@ fn advance() {
 }
 
 fn fade_out_and_hide() {
-    let Some(wrapper) = TOAST_PANEL.get() else {
+    let Some(panels) = TOAST_PANELS.get() else {
         return;
     };
-    let panel = &wrapper.0;
     cancel_timer();
 
-    let panel_ptr = Retained::as_ptr(panel) as usize;
-    NSAnimationContext::runAnimationGroup(&RcBlock::new(
-        move |context: std::ptr::NonNull<NSAnimationContext>| {
-            let ctx = unsafe { context.as_ref() };
-            ctx.setDuration(FADE_DURATION);
-            let panel_ref: &NSPanel = unsafe { &*(panel_ptr as *const NSPanel) };
-            let animator: Retained<NSPanel> = unsafe { msg_send_id![panel_ref, animator] };
-            animator.setAlphaValue(0.0);
-        },
-    ));
+    for wrapper in panels.iter() {
+        let panel_ptr = Retained::as_ptr(&wrapper.0) as usize;
+        NSAnimationContext::runAnimationGroup(&RcBlock::new(
+            move |context: std::ptr::NonNull<NSAnimationContext>| {
+                let ctx = unsafe { context.as_ref() };
+                ctx.setDuration(FADE_DURATION);
+                let panel_ref: &NSPanel = unsafe { &*(panel_ptr as *const NSPanel) };
+                let animator: Retained<NSPanel> = unsafe { msg_send_id![panel_ref, animator] };
+                animator.setAlphaValue(0.0);
+            },
+        ));
+    }
 
     start_fade_timer();
 }
 
-fn position_at_top_right(mtm: MainThreadMarker, panel: &NSPanel, panel_height: f64) {
-    let screen = match NSScreen::mainScreen(mtm) {
-        Some(s) => s,
-        None => return,
-    };
+/// Position `panel` at the given corner of `screen`. AppKit coords
+/// (bottom-left origin, logical pt) throughout. `visibleFrame` already
+/// subtracts the menu bar and dock, so we don't compute either by hand.
+fn position_at_corner(
+    panel: &NSPanel,
+    panel_height: f64,
+    corner: ToastPosition,
+    screen: &NSScreen,
+) {
     let screen_frame = screen.frame();
     let visible_frame = screen.visibleFrame();
-
-    let menu_bar_height = (screen_frame.origin.y + screen_frame.size.height)
-        - (visible_frame.origin.y + visible_frame.size.height);
-
     let margin = 16.0;
-    let x = screen_frame.origin.x + screen_frame.size.width - PANEL_WIDTH - margin;
-    let y =
-        screen_frame.origin.y + screen_frame.size.height - menu_bar_height - panel_height - margin;
+
+    let x = match corner {
+        ToastPosition::TopLeft | ToastPosition::BottomLeft => screen_frame.origin.x + margin,
+        ToastPosition::TopRight | ToastPosition::BottomRight => {
+            screen_frame.origin.x + screen_frame.size.width - PANEL_WIDTH - margin
+        }
+    };
+
+    let y = match corner {
+        ToastPosition::TopLeft | ToastPosition::TopRight => {
+            // visibleFrame.maxY sits exactly at the bottom of the menu bar.
+            visible_frame.origin.y + visible_frame.size.height - panel_height - margin
+        }
+        ToastPosition::BottomLeft | ToastPosition::BottomRight => {
+            // visibleFrame.origin.y sits just above the dock (or 0 if dock is hidden / on the side).
+            visible_frame.origin.y + margin
+        }
+    };
 
     panel.setFrame_display(
         CGRect::new(CGPoint::new(x, y), CGSize::new(PANEL_WIDTH, panel_height)),

--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -7,7 +7,9 @@ use objc2::msg_send_id;
 // NB: NSPoint, NSRect, NSEvent, MainThreadMarker, Retained, Bool are pulled in
 // at module scope by `tauri_panel!` below — DON'T re-import them or rustc
 // trips E0252. Use bare names downstream.
-use objc2_app_kit::{NSApplication, NSEventMask, NSScreen};
+use objc2_app_kit::NSEventMask;
+
+use crate::screen::current_active_screen;
 use tauri::tray::TrayIconId;
 use tauri::Emitter;
 use tauri::Manager;
@@ -220,32 +222,6 @@ pub fn position_panel_appkit(app_handle: &tauri::AppHandle) {
     unsafe {
         let _: () = objc2::msg_send![ns_panel, setFrameOrigin: origin];
     }
-}
-
-/// Resolve the "screen the user is currently looking at". Tries the cursor's
-/// screen first, then the key window's screen, then the main screen.
-fn current_active_screen(mtm: MainThreadMarker) -> Option<Retained<NSScreen>> {
-    let mouse_loc = NSEvent::mouseLocation();
-    let screens = NSScreen::screens(mtm);
-    for screen in screens.iter() {
-        let f = screen.frame();
-        if mouse_loc.x >= f.origin.x
-            && mouse_loc.x < f.origin.x + f.size.width
-            && mouse_loc.y >= f.origin.y
-            && mouse_loc.y < f.origin.y + f.size.height
-        {
-            return Some(screen);
-        }
-    }
-
-    let app = NSApplication::sharedApplication(mtm);
-    if let Some(key_window) = app.keyWindow() {
-        if let Some(screen) = key_window.screen() {
-            return Some(screen);
-        }
-    }
-
-    NSScreen::mainScreen(mtm)
 }
 
 /// Get the tray icon's window frame and its screen's frame, both in AppKit

--- a/src-tauri/src/screen.rs
+++ b/src-tauri/src/screen.rs
@@ -1,0 +1,35 @@
+//! Active-screen resolution shared by every NSPanel positioner (main panel,
+//! toast). Centralizing this means a single fallback chain — and a single
+//! place to fix whatever the next "which monitor?" edge case turns out to be.
+
+use objc2::rc::Retained;
+use objc2_app_kit::{NSApplication, NSEvent, NSScreen};
+use objc2_foundation::MainThreadMarker;
+
+/// Resolve "the screen the user is currently looking at". Falls back through
+/// the cursor's screen, then the key window's screen, then the main screen,
+/// so callers always get *something* usable as long as macOS has any screen
+/// attached.
+pub fn current_active_screen(mtm: MainThreadMarker) -> Option<Retained<NSScreen>> {
+    let mouse_loc = NSEvent::mouseLocation();
+    let screens = NSScreen::screens(mtm);
+    for screen in screens.iter() {
+        let f = screen.frame();
+        if mouse_loc.x >= f.origin.x
+            && mouse_loc.x < f.origin.x + f.size.width
+            && mouse_loc.y >= f.origin.y
+            && mouse_loc.y < f.origin.y + f.size.height
+        {
+            return Some(screen);
+        }
+    }
+
+    let app = NSApplication::sharedApplication(mtm);
+    if let Some(key_window) = app.keyWindow() {
+        if let Some(screen) = key_window.screen() {
+            return Some(screen);
+        }
+    }
+
+    NSScreen::mainScreen(mtm)
+}

--- a/src/SettingsApp.tsx
+++ b/src/SettingsApp.tsx
@@ -8,6 +8,7 @@ import { NumberStepper } from "@/components/number-stepper";
 import { RestartBanner } from "@/components/restart-banner";
 import { SettingsRow, SettingsSection } from "@/components/settings-section";
 import { ShortcutRecorder } from "@/components/shortcut-recorder";
+import { ToastPositionPicker } from "@/components/toast-position-picker";
 import { Toggle } from "@/components/toggle";
 import type { AllowedApp } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -200,7 +201,7 @@ export function SettingsApp() {
 
         <SettingsSection
           title="Toast"
-          description="Transient popup at the top-right when a new notification arrives."
+          description="Transient popup shown when a new notification arrives. Toasts follow the cursor's screen."
         >
           <SettingsRow
             label="Display duration"
@@ -227,6 +228,16 @@ export function SettingsApp() {
               ariaLabel="Keep toast until clicked"
             />
           </SettingsRow>
+        </SettingsSection>
+
+        <SettingsSection
+          title="Toast position"
+          description="Choose where notifications appear. Multiple positions can be selected."
+        >
+          <ToastPositionPicker
+            value={draft.toastPositions}
+            onChange={(v) => updateField("toastPositions", v)}
+          />
         </SettingsSection>
 
         <SettingsSection title="Startup" description="Control how agentoast launches on this Mac.">

--- a/src/components/toast-position-picker.tsx
+++ b/src/components/toast-position-picker.tsx
@@ -1,0 +1,123 @@
+import { Check } from "lucide-react";
+import type { ToastPosition } from "@/lib/settings-types";
+import { cn } from "@/lib/utils";
+
+interface ToastPositionPickerProps {
+  value: ToastPosition[];
+  onChange: (next: ToastPosition[]) => void;
+}
+
+const OPTIONS: { id: ToastPosition; label: string }[] = [
+  { id: "top-left", label: "Top Left" },
+  { id: "top-right", label: "Top Right" },
+  { id: "bottom-left", label: "Bottom Left" },
+  { id: "bottom-right", label: "Bottom Right" },
+];
+
+export function ToastPositionPicker({ value, onChange }: ToastPositionPickerProps) {
+  const toggle = (pos: ToastPosition) => {
+    if (value.includes(pos)) {
+      onChange(value.filter((p) => p !== pos));
+      return;
+    }
+    // Preserve a canonical display order so the saved array doesn't shift
+    // based on click sequence — purely cosmetic for config.toml diffs.
+    const next = OPTIONS.map((o) => o.id).filter((id) => value.includes(id) || id === pos);
+    onChange(next);
+  };
+
+  return (
+    <div className="px-3.5 py-2.5">
+      <div className="grid grid-cols-4 gap-2">
+        {OPTIONS.map((opt) => {
+          const checked = value.includes(opt.id);
+          return (
+            <button
+              key={opt.id}
+              type="button"
+              role="checkbox"
+              aria-checked={checked}
+              aria-label={opt.label}
+              onClick={() => toggle(opt.id)}
+              className="flex flex-col items-stretch gap-1.5 rounded-md p-1 text-left transition-colors hover:bg-[var(--row-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            >
+              <PreviewTile position={opt.id} selected={checked} />
+              <div className="flex items-center gap-1.5">
+                <CheckboxBox checked={checked} />
+                <span className="text-[11px] font-medium text-[var(--text-primary)]">
+                  {opt.label}
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface PreviewTileProps {
+  position: ToastPosition;
+  selected: boolean;
+}
+
+function PreviewTile({ position, selected }: PreviewTileProps) {
+  const corner = cornerStyles(position);
+  return (
+    <div
+      className={cn(
+        "relative w-full overflow-hidden rounded border",
+        // 16:9 aspect; Tailwind's aspect-video does exactly this without
+        // pulling in extra layout math.
+        "aspect-video",
+        selected
+          ? "border-[var(--accent)] ring-1 ring-[var(--accent)]"
+          : "border-[var(--border-subtle)]",
+      )}
+      style={{ backgroundColor: "#ffffff" }}
+    >
+      <span
+        className="absolute rounded-[2px]"
+        style={{
+          backgroundColor: "var(--accent)",
+          width: "30%",
+          height: "16%",
+          ...corner,
+        }}
+      />
+    </div>
+  );
+}
+
+function cornerStyles(position: ToastPosition): React.CSSProperties {
+  switch (position) {
+    case "top-left":
+      return { top: "10%", left: "8%" };
+    case "top-right":
+      return { top: "10%", right: "8%" };
+    case "bottom-left":
+      return { bottom: "10%", left: "8%" };
+    case "bottom-right":
+      return { bottom: "10%", right: "8%" };
+  }
+}
+
+interface CheckboxBoxProps {
+  checked: boolean;
+}
+
+function CheckboxBox({ checked }: CheckboxBoxProps) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "flex h-3 w-3 shrink-0 items-center justify-center rounded-[3px] border transition-colors",
+        checked
+          ? "border-[var(--accent)] bg-[var(--accent)] text-white"
+          : "border-[var(--text-tertiary)] bg-transparent",
+      )}
+    >
+      {checked && <Check size={9} strokeWidth={3} />}
+    </span>
+  );
+}

--- a/src/lib/settings-types.ts
+++ b/src/lib/settings-types.ts
@@ -1,6 +1,9 @@
+export type ToastPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
+
 export interface SettingsPayload {
   toastDurationMs: number;
   toastPersistent: boolean;
+  toastPositions: ToastPosition[];
   togglePanelShortcut: string;
   editor: string;
   autostartEnabled: boolean;


### PR DESCRIPTION
## Summary

- Multi-select Toast Position setting (top-left / top-right / bottom-left / bottom-right) in Settings → Toast section. Default unchanged (top-right). When multiple corners are selected, the same notification fans out to every selected corner simultaneously.
- Toasts now follow the cursor's screen — same rule the main panel adopted in #333 — instead of being pinned to `NSScreen::mainScreen`. The two surfaces now share a `current_active_screen` helper in a new `src-tauri/src/screen.rs`.

## Why

Multi-monitor users working on a secondary display had to glance back at the menu-bar display or miss notifications entirely. Picking corners gives explicit control of where the toast goes, and following the cursor matches the mental model the main panel already established.

## What changed

### `crates/agentoast-shared/src/config.rs`
- `ToastPosition` enum (`TopLeft` / `TopRight` / `BottomLeft` / `BottomRight`) with serde `rename_all = "kebab-case"`
- `[toast] positions = ["top-right"]` field on `ToastConfig`, default applied via `#[serde(default)]` so existing configs keep working
- `save_toast_positions` helper preserving comments via `toml_edit`
- `ToastPosition::as_str` as the single source of truth for the kebab-case mapping
- Tests: default value, kebab-case parsing, fallback when field absent

### `src-tauri/src/native_toast.rs`
- One static `NSPanel` → `[NSPanel; 4]`, one slot per corner, all created upfront in `init`. `panel_index` is the only place that knows the array layout
- `update_and_show` iterates the user's selected positions, builds a fresh content view per panel (NSView can't be shared across superviews), resolves the active screen once per show so a cursor move mid-fan-out doesn't split panels across screens
- `position_at_top_right` → generic `position_at_corner(corner, screen)`. `NSScreen.visibleFrame` handles menu-bar and dock offsets implicitly — no hardcoded heights
- `hide` / `fade_out_and_hide` iterate all 4 panels; the local event monitor matches click events against any of the 4 window numbers
- `current_active_screen` (was duplicated from `panel.rs`) moved out

### `src-tauri/src/screen.rs` (new)
- Hosts `current_active_screen(mtm)` — cursor's screen → key window's screen → main screen fallback chain. Used by both `panel.rs` and `native_toast.rs`

### `src-tauri/src/panel.rs`
- Drops its local `current_active_screen` and the now-unused `NSApplication` / `NSScreen` imports; uses `crate::screen::current_active_screen`

### `src-tauri/src/lib.rs`
- `SettingsPayload.toast_positions: Vec<ToastPosition>` threaded through `get_settings` / `save_settings` with rollback handling in the same chain as the other fields
- `native_toast::update_settings(...)` extended with the positions list so it can be pushed to the live `ToastState` without an app restart

### `src/components/toast-position-picker.tsx` (new)
- 4 tiles in a row; each tile renders a 16:9 mini-screen preview with an orange corner marker, a checkbox, and a label
- Selected tiles get an accent ring + filled checkbox. Toggling preserves the canonical display order so config.toml diffs stay clean

### `src/SettingsApp.tsx` / `src/lib/settings-types.ts`
- `ToastPosition` TS union + `toastPositions` field on `SettingsPayload`
- New "Toast position" section under the existing "Toast" group

### `cspell.json`
- Add `appkit` and `superview` to the dictionary
