### PR TITLE
feat: add optional multi-monitor toast display

### DIFF
--- a/crates/agentoast-shared/src/config.rs
+++ b/crates/agentoast-shared/src/config.rs
@@ -106,6 +106,28 @@ impl ToastPosition {
     }
 }
 
+/// Which screens a toast appears on. `Active` follows the cursor's screen
+/// (historical behavior); `All` mirrors the toast onto every attached screen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ToastDisplay {
+    #[default]
+    Active,
+    All,
+}
+
+impl ToastDisplay {
+    /// The canonical kebab-case string used in config.toml and IPC payloads.
+    /// Must stay in lockstep with the `rename_all = "kebab-case"` serde attr
+    /// above — keep them together so changes are obvious.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ToastDisplay::Active => "active",
+            ToastDisplay::All => "all",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct ToastConfig {
     #[serde(default = "default_toast_duration")]
@@ -114,6 +136,8 @@ pub struct ToastConfig {
     pub persistent: bool,
     #[serde(default = "default_toast_positions")]
     pub positions: Vec<ToastPosition>,
+    #[serde(default)]
+    pub display: ToastDisplay,
 }
 
 impl Default for ToastConfig {
@@ -122,6 +146,7 @@ impl Default for ToastConfig {
             duration_ms: default_toast_duration(),
             persistent: false,
             positions: default_toast_positions(),
+            display: ToastDisplay::default(),
         }
     }
 }
@@ -397,6 +422,15 @@ pub fn save_toast_positions(values: &[ToastPosition]) -> io::Result<()> {
     std::fs::write(&path, doc.to_string())
 }
 
+/// Update [toast] display in config.toml, preserving existing comments and formatting.
+pub fn save_toast_display(value: ToastDisplay) -> io::Result<()> {
+    let path = config_path();
+    let content = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut doc: DocumentMut = content.parse().unwrap_or_default();
+    doc["toast"]["display"] = toml_edit::value(value.as_str());
+    std::fs::write(&path, doc.to_string())
+}
+
 /// Update [keybinding] toggle_panel in config.toml, preserving existing comments and formatting.
 pub fn save_keybinding_toggle_panel(value: &str) -> io::Result<()> {
     let path = config_path();
@@ -474,6 +508,10 @@ fn default_config_template() -> &'static str {
 # Multiple positions show the same toast in each corner simultaneously.
 # Valid values: "top-left", "top-right", "bottom-left", "bottom-right"
 # positions = ["top-right"]
+
+# Which screens show toasts (default: "active")
+# "active" = only the screen the cursor is on, "all" = every attached screen
+# display = "active"
 
 # Notification settings
 [notification]
@@ -616,6 +654,32 @@ duration_ms = 2000
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.toast.positions, vec![ToastPosition::TopRight]);
+    }
+
+    #[test]
+    fn default_toast_display_is_active() {
+        let config = ToastConfig::default();
+        assert_eq!(config.display, ToastDisplay::Active);
+    }
+
+    #[test]
+    fn parse_toast_display_all() {
+        let toml_str = r#"
+[toast]
+display = "all"
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.toast.display, ToastDisplay::All);
+    }
+
+    #[test]
+    fn missing_toast_display_falls_back_to_active() {
+        let toml_str = r#"
+[toast]
+duration_ms = 2000
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.toast.display, ToastDisplay::Active);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,7 +23,7 @@ use std::sync::{Mutex, OnceLock};
 #[cfg(target_os = "macos")]
 use std::time::Duration;
 
-use agentoast_shared::config::{self, AllowedApp, AppConfig, ToastPosition};
+use agentoast_shared::config::{self, AllowedApp, AppConfig, ToastDisplay, ToastPosition};
 use agentoast_shared::db;
 use agentoast_shared::models::{Notification, TmuxPaneGroup};
 use serde::{Deserialize, Serialize};
@@ -660,6 +660,7 @@ pub struct SettingsPayload {
     pub toast_duration_ms: u64,
     pub toast_persistent: bool,
     pub toast_positions: Vec<ToastPosition>,
+    pub toast_display: ToastDisplay,
     pub toggle_panel_shortcut: String,
     pub editor: String,
     pub autostart_enabled: bool,
@@ -679,6 +680,7 @@ fn get_settings(state: tauri::State<'_, Mutex<AppState>>) -> Result<SettingsPayl
         toast_duration_ms: state.config.toast.duration_ms,
         toast_persistent: state.config.toast.persistent,
         toast_positions: state.config.toast.positions.clone(),
+        toast_display: state.config.toast.display,
         toggle_panel_shortcut: state.config.keybinding.toggle_panel.clone(),
         editor: state.config.editor.clone().unwrap_or_default(),
         autostart_enabled,
@@ -719,6 +721,7 @@ fn save_settings(
             guard.config.toast.duration_ms,
             guard.config.toast.persistent,
             guard.config.toast.positions.clone(),
+            guard.config.toast.display,
             guard.config.keybinding.toggle_panel.clone(),
             guard.config.editor.clone().unwrap_or_default(),
         )
@@ -727,6 +730,7 @@ fn save_settings(
         old_toast_duration_ms,
         old_toast_persistent,
         old_toast_positions,
+        old_toast_display,
         old_shortcut_str,
         old_editor,
     ) = snapshot;
@@ -754,6 +758,9 @@ fn save_settings(
         }
         if old_toast_positions != payload.toast_positions {
             config::save_toast_positions(&payload.toast_positions).map_err(|e| e.to_string())?;
+        }
+        if old_toast_display != payload.toast_display {
+            config::save_toast_display(payload.toast_display).map_err(|e| e.to_string())?;
         }
         if shortcut_changed {
             config::save_keybinding_toggle_panel(&payload.toggle_panel_shortcut)
@@ -788,6 +795,13 @@ fn save_settings(
                 e
             );
         }
+        if let Err(e) = config::save_toast_display(old_toast_display) {
+            log::error!(
+                "Rollback: failed to restore toast.display={:?}: {}",
+                old_toast_display,
+                e
+            );
+        }
         if shortcut_changed {
             if let Err(e) = config::save_keybinding_toggle_panel(&old_shortcut_str) {
                 log::error!(
@@ -816,6 +830,7 @@ fn save_settings(
         guard.config.toast.duration_ms = payload.toast_duration_ms;
         guard.config.toast.persistent = payload.toast_persistent;
         guard.config.toast.positions = payload.toast_positions.clone();
+        guard.config.toast.display = payload.toast_display;
         guard.config.keybinding.toggle_panel = payload.toggle_panel_shortcut.clone();
         guard.config.editor = if payload.editor.is_empty() {
             None
@@ -830,6 +845,7 @@ fn save_settings(
         payload.toast_duration_ms,
         payload.toast_persistent,
         payload.toast_positions.clone(),
+        payload.toast_display,
     );
 
     // --- Phase 5: autostart (System Events login item). Not mirrored in

--- a/src-tauri/src/native_toast.rs
+++ b/src-tauri/src/native_toast.rs
@@ -3,7 +3,7 @@
 use std::sync::{Mutex, OnceLock};
 
 use agentoast_shared::config;
-use agentoast_shared::config::ToastPosition;
+use agentoast_shared::config::{ToastDisplay, ToastPosition};
 use agentoast_shared::models::Notification;
 use block2::RcBlock;
 use objc2::rc::Retained;
@@ -28,20 +28,13 @@ struct SendSyncWrapper<T>(T);
 unsafe impl<T> Send for SendSyncWrapper<T> {}
 unsafe impl<T> Sync for SendSyncWrapper<T> {}
 
-/// Four NSPanels — one per ToastPosition, kept alive for the app's lifetime.
-/// Lookup via `panel_index(position)`. We allocate all 4 upfront (cheap)
-/// rather than reactively creating/destroying them when the user's selection
-/// changes — simpler, and the cost of an unused, hidden NSPanel is negligible.
-static TOAST_PANELS: OnceLock<[SendSyncWrapper<Retained<NSPanel>>; 4]> = OnceLock::new();
-
-fn panel_index(p: ToastPosition) -> usize {
-    match p {
-        ToastPosition::TopLeft => 0,
-        ToastPosition::TopRight => 1,
-        ToastPosition::BottomLeft => 2,
-        ToastPosition::BottomRight => 3,
-    }
-}
+/// Pool of NSPanels, kept alive for the app's lifetime. One panel is needed
+/// per (screen × selected corner) — with `display = "all"` that count depends
+/// on how many screens are attached, which can change at runtime, so the pool
+/// grows on demand in `update_and_show` and never shrinks: the cost of an
+/// unused, hidden NSPanel is negligible, and reuse avoids churning windows on
+/// every toast.
+static TOAST_PANELS: Mutex<Vec<SendSyncWrapper<Retained<NSPanel>>>> = Mutex::new(Vec::new());
 static TOAST_STATE: OnceLock<Mutex<ToastState>> = OnceLock::new();
 static APP_HANDLE: OnceLock<tauri::AppHandle> = OnceLock::new();
 static TOAST_TIMER: Mutex<Option<SendSyncWrapper<Retained<NSTimer>>>> = Mutex::new(None);
@@ -95,9 +88,11 @@ struct ToastState {
     is_visible: bool,
     duration_ms: u64,
     persistent: bool,
-    /// Corners currently selected by the user. Each entry causes one of the
-    /// 4 preallocated panels to be shown for every notification.
+    /// Corners currently selected by the user. Each entry causes one panel
+    /// per targeted screen to be shown for every notification.
     positions: Vec<ToastPosition>,
+    /// Which screens to target: the cursor's screen only, or all of them.
+    display: ToastDisplay,
 }
 
 // --- Color definitions ---
@@ -212,21 +207,14 @@ pub fn init(app_handle: &tauri::AppHandle) -> Result<(), String> {
             duration_ms: cfg.toast.duration_ms,
             persistent: cfg.toast.persistent,
             positions: cfg.toast.positions.clone(),
+            display: cfg.toast.display,
         }
     }));
 
-    let mtm = MainThreadMarker::new().ok_or_else(|| "Must be called on main thread".to_string())?;
+    MainThreadMarker::new().ok_or_else(|| "Must be called on main thread".to_string())?;
 
-    let panels = [
-        SendSyncWrapper(create_panel(mtm)),
-        SendSyncWrapper(create_panel(mtm)),
-        SendSyncWrapper(create_panel(mtm)),
-        SendSyncWrapper(create_panel(mtm)),
-    ];
-    TOAST_PANELS
-        .set(panels)
-        .map_err(|_| "Toast panels already initialized".to_string())?;
-
+    // Panels are created lazily in update_and_show — the count depends on the
+    // screen configuration at display time, so nothing to preallocate here.
     install_event_monitor();
 
     log::info!("[native_toast] init complete");
@@ -327,7 +315,12 @@ pub fn show_notifications(notifications: Vec<Notification>) {
 
 /// Push runtime settings updates into the live toast state so new settings
 /// take effect on the next displayed toast without requiring an app restart.
-pub fn update_settings(duration_ms: u64, persistent: bool, positions: Vec<ToastPosition>) {
+pub fn update_settings(
+    duration_ms: u64,
+    persistent: bool,
+    positions: Vec<ToastPosition>,
+    display: ToastDisplay,
+) {
     let Some(state) = TOAST_STATE.get() else {
         return;
     };
@@ -337,17 +330,17 @@ pub fn update_settings(duration_ms: u64, persistent: bool, positions: Vec<ToastP
     guard.duration_ms = duration_ms;
     guard.persistent = persistent;
     guard.positions = positions;
+    guard.display = display;
 }
 
 pub fn hide() {
-    let Some(panels) = TOAST_PANELS.get() else {
-        return;
-    };
     cancel_timer();
     cancel_fade_timer();
 
-    for wrapper in panels.iter() {
-        wrapper.0.orderOut(None);
+    if let Ok(panels) = TOAST_PANELS.lock() {
+        for wrapper in panels.iter() {
+            wrapper.0.orderOut(None);
+        }
     }
 
     if let Some(state_mutex) = TOAST_STATE.get() {
@@ -362,9 +355,6 @@ pub fn hide() {
 // --- Internal ---
 
 fn update_and_show() {
-    let Some(panels) = TOAST_PANELS.get() else {
-        return;
-    };
     let Some(state_mutex) = TOAST_STATE.get() else {
         return;
     };
@@ -388,6 +378,7 @@ fn update_and_show() {
     let duration_ms = state.duration_ms;
     let persistent = state.persistent;
     let positions = state.positions.clone();
+    let display = state.display;
     drop(state);
 
     let mtm = match MainThreadMarker::new() {
@@ -401,47 +392,66 @@ fn update_and_show() {
     let has_body = !current.body.is_empty();
     let panel_height = compute_panel_height(has_meta, has_body);
 
-    // Resolve the active screen once and reuse it for every panel — otherwise
-    // a cursor move mid-fan-out could place two panels on different screens.
-    let active_screen = current_active_screen(mtm);
+    // Resolve the target screens once and reuse them for every panel —
+    // otherwise a cursor move (or a display change) mid-fan-out could place
+    // panels inconsistently.
+    let screens: Vec<Retained<NSScreen>> = match display {
+        ToastDisplay::All => NSScreen::screens(mtm).iter().collect(),
+        ToastDisplay::Active => current_active_screen(mtm).into_iter().collect(),
+    };
 
-    // Hide every panel first so deselected corners don't keep a stale toast
-    // on screen across a settings change. When `positions` is empty this is
-    // the only thing that runs, and `start_timer` below drains the queue.
+    let Ok(mut panels) = TOAST_PANELS.lock() else {
+        return;
+    };
+
+    // Grow the pool to one panel per (screen × corner). Never shrinks; extra
+    // panels just stay hidden.
+    let needed = screens.len() * positions.len();
+    while panels.len() < needed {
+        panels.push(SendSyncWrapper(create_panel(mtm)));
+    }
+
+    // Hide every panel first so deselected corners / detached screens don't
+    // keep a stale toast on screen across a settings or display change. When
+    // `needed` is 0 this is the only thing that runs, and `start_timer` below
+    // drains the queue.
     for wrapper in panels.iter() {
         wrapper.0.orderOut(None);
     }
 
-    for &position in &positions {
-        let wrapper = &panels[panel_index(position)];
-        let panel = &wrapper.0;
+    let mut pool_index = 0;
+    for screen in &screens {
+        for &position in &positions {
+            let panel = &panels[pool_index].0;
+            pool_index += 1;
 
-        // Resize panel BEFORE setting content view to prevent layout distortion in release builds.
-        // Setting content view on a panel with stale size causes AppKit to resize subviews incorrectly.
-        if let Some(ref screen) = active_screen {
+            // Resize panel BEFORE setting content view to prevent layout distortion in release builds.
+            // Setting content view on a panel with stale size causes AppKit to resize subviews incorrectly.
             position_at_corner(panel, panel_height, position, screen);
+
+            // Build a fresh content view per panel — NSView can only belong to
+            // one superview at a time, so we can't reuse a single view.
+            let content_view =
+                build_toast_view(mtm, &current, current_index, queue_len, panel_height);
+            panel.setContentView(Some(&content_view));
+
+            // Show with fade-in animation
+            panel.setAlphaValue(0.0);
+            panel.orderFrontRegardless();
+
+            let panel_ptr = Retained::as_ptr(panel) as usize;
+            NSAnimationContext::runAnimationGroup(&RcBlock::new(
+                move |context: std::ptr::NonNull<NSAnimationContext>| {
+                    let ctx = unsafe { context.as_ref() };
+                    ctx.setDuration(FADE_DURATION);
+                    let panel_ref: &NSPanel = unsafe { &*(panel_ptr as *const NSPanel) };
+                    let animator: Retained<NSPanel> = unsafe { msg_send_id![panel_ref, animator] };
+                    animator.setAlphaValue(1.0);
+                },
+            ));
         }
-
-        // Build a fresh content view per panel — NSView can only belong to
-        // one superview at a time, so we can't reuse a single view.
-        let content_view = build_toast_view(mtm, &current, current_index, queue_len, panel_height);
-        panel.setContentView(Some(&content_view));
-
-        // Show with fade-in animation
-        panel.setAlphaValue(0.0);
-        panel.orderFrontRegardless();
-
-        let panel_ptr = Retained::as_ptr(panel) as usize;
-        NSAnimationContext::runAnimationGroup(&RcBlock::new(
-            move |context: std::ptr::NonNull<NSAnimationContext>| {
-                let ctx = unsafe { context.as_ref() };
-                ctx.setDuration(FADE_DURATION);
-                let panel_ref: &NSPanel = unsafe { &*(panel_ptr as *const NSPanel) };
-                let animator: Retained<NSPanel> = unsafe { msg_send_id![panel_ref, animator] };
-                animator.setAlphaValue(1.0);
-            },
-        ));
     }
+    drop(panels);
 
     // Start auto-advance timer
     if !persistent {
@@ -980,17 +990,21 @@ fn install_event_monitor() {
         unsafe {
             let block = RcBlock::new(|event: std::ptr::NonNull<NSEvent>| -> *mut NSEvent {
                 let event_ref = event.as_ref();
-                let Some(panels) = TOAST_PANELS.get() else {
-                    return event.as_ptr();
-                };
 
-                // Click must be inside one of our 4 panels — otherwise let it
-                // pass through to the underlying window.
+                // Click must be inside one of our panels — otherwise let it
+                // pass through to the underlying window. Scope the pool lock
+                // so it's released before the handlers below re-enter
+                // update_and_show (which locks the pool again).
                 let event_window_num: i64 = msg_send![event_ref, windowNumber];
-                let matched = panels.iter().any(|wrapper| {
-                    let n: i64 = msg_send![&wrapper.0, windowNumber];
-                    n == event_window_num
-                });
+                let matched = {
+                    let Ok(panels) = TOAST_PANELS.lock() else {
+                        return event.as_ptr();
+                    };
+                    panels.iter().any(|wrapper| {
+                        let n: i64 = msg_send![&wrapper.0, windowNumber];
+                        n == event_window_num
+                    })
+                };
                 if !matched {
                     return event.as_ptr();
                 }
@@ -1161,22 +1175,23 @@ fn advance() {
 }
 
 fn fade_out_and_hide() {
-    let Some(panels) = TOAST_PANELS.get() else {
-        return;
-    };
     cancel_timer();
 
-    for wrapper in panels.iter() {
-        let panel_ptr = Retained::as_ptr(&wrapper.0) as usize;
-        NSAnimationContext::runAnimationGroup(&RcBlock::new(
-            move |context: std::ptr::NonNull<NSAnimationContext>| {
-                let ctx = unsafe { context.as_ref() };
-                ctx.setDuration(FADE_DURATION);
-                let panel_ref: &NSPanel = unsafe { &*(panel_ptr as *const NSPanel) };
-                let animator: Retained<NSPanel> = unsafe { msg_send_id![panel_ref, animator] };
-                animator.setAlphaValue(0.0);
-            },
-        ));
+    if let Ok(panels) = TOAST_PANELS.lock() {
+        // Fading hidden pool panels too is harmless — animating alpha on an
+        // ordered-out window is a no-op visually.
+        for wrapper in panels.iter() {
+            let panel_ptr = Retained::as_ptr(&wrapper.0) as usize;
+            NSAnimationContext::runAnimationGroup(&RcBlock::new(
+                move |context: std::ptr::NonNull<NSAnimationContext>| {
+                    let ctx = unsafe { context.as_ref() };
+                    ctx.setDuration(FADE_DURATION);
+                    let panel_ref: &NSPanel = unsafe { &*(panel_ptr as *const NSPanel) };
+                    let animator: Retained<NSPanel> = unsafe { msg_send_id![panel_ref, animator] };
+                    animator.setAlphaValue(0.0);
+                },
+            ));
+        }
     }
 
     start_fade_timer();

--- a/src/SettingsApp.tsx
+++ b/src/SettingsApp.tsx
@@ -201,7 +201,7 @@ export function SettingsApp() {
 
         <SettingsSection
           title="Toast"
-          description="Transient popup shown when a new notification arrives. Toasts follow the cursor's screen."
+          description="Transient popup shown when a new notification arrives. Toasts follow the cursor's screen by default."
         >
           <SettingsRow
             label="Display duration"
@@ -238,6 +238,18 @@ export function SettingsApp() {
             value={draft.toastPositions}
             onChange={(v) => updateField("toastPositions", v)}
           />
+          <SettingsRow
+            label="Show on all displays"
+            hint="Mirror toasts onto every attached display instead of only the cursor's display."
+            htmlFor="toast-display-all"
+          >
+            <Toggle
+              id="toast-display-all"
+              checked={draft.toastDisplay === "all"}
+              onChange={(v) => updateField("toastDisplay", v ? "all" : "active")}
+              ariaLabel="Show toasts on all displays"
+            />
+          </SettingsRow>
         </SettingsSection>
 
         <SettingsSection title="Startup" description="Control how agentoast launches on this Mac.">

--- a/src/lib/settings-types.ts
+++ b/src/lib/settings-types.ts
@@ -1,9 +1,12 @@
 export type ToastPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
 
+export type ToastDisplay = "active" | "all";
+
 export interface SettingsPayload {
   toastDurationMs: number;
   toastPersistent: boolean;
   toastPositions: ToastPosition[];
+  toastDisplay: ToastDisplay;
   togglePanelShortcut: string;
   editor: string;
   autostartEnabled: boolean;


### PR DESCRIPTION
## Summary

- Add an option to mirror toasts onto every attached monitor: `[toast] display = "active" | "all"` (default `"active"` = current behavior, cursor's screen only)
- Add a **Show on all displays** toggle to the Toast position section in Settings. Applied live on save — no restart required
- Refactor toast panels from a fixed 4-corner array into a dynamic pool sized per (screen × selected corner), so monitor attach/detach is picked up on every display

## Changes

### `crates/agentoast-shared/src/config.rs`
- Add `ToastDisplay` enum (`"active"` / `"all"`, kebab-case serde, defaults to `Active`)
- Add `display` field to `ToastConfig` (`#[serde(default)]`, so existing configs keep the current behavior)
- Add `save_toast_display()` (toml_edit, preserves comments) and document the key in the default config template
- Add 3 parsing tests (default value / parsing `"all"` / fallback when the key is missing)

### `src-tauri/src/native_toast.rs`
- Replace the fixed `TOAST_PANELS: [NSPanel; 4]` with a dynamic `Mutex<Vec<NSPanel>>` pool. Grown lazily at display time, never shrinks (the cost of a hidden NSPanel is negligible)
- `update_and_show()`: `"all"` iterates `NSScreen::screens()` and places a panel at each selected corner of every screen; `"active"` keeps the single `current_active_screen()`. Screens are resolved once per display
- Update the click event monitor, `hide()`, and fade-out to match against the pool (lock released before handlers re-enter)
- Add `display` to `update_settings()` for live application

### `src-tauri/src/lib.rs`
- Add `toast_display` to `SettingsPayload` and wire it through `get_settings` / `save_settings` (snapshot, write, rollback, in-memory commit, runtime push)

### Frontend
- `src/lib/settings-types.ts`: add the `ToastDisplay` type and `SettingsPayload.toastDisplay`
- `src/SettingsApp.tsx`: add the Show on all displays toggle to the Toast position section, and soften the Toast section description to "by default"

## Test plan

- [x] `cargo check --workspace` / `cargo clippy --workspace -- -D warnings` / `cargo fmt --all -- --check`
- [x] `cargo test -p agentoast-shared` (35 passed, including the 3 new tests)
- [x] `tsc --noEmit` / `vp lint --deny-warnings` / `vp fmt --check`
- [ ] Manual: with multiple monitors and `display = "all"`, toasts appear on every monitor; with the default, only on the cursor's monitor
- [ ] Manual: toggling the setting in Settings takes effect without restarting the app
